### PR TITLE
replace neighbours_at (deprecated) with neighbors_at

### DIFF
--- a/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Charts examples).gaml
+++ b/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Charts examples).gaml
@@ -24,7 +24,7 @@ global {
 
 
 grid ant_grid width: gridsize height: gridsize neighbours: 8 use_regular_agents: false {
-	list<ant_grid> neighbours <- self neighbours_at 1;
+	list<ant_grid> neighbours <- self neighbors_at 1;
 	bool multiagent <- true ;
 	int type <- int(types at {grid_x,grid_y}) ;
 	bool isNestLocation <- (self distance_to center) < 4 ; 

--- a/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Classic).gaml
+++ b/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Classic).gaml
@@ -24,7 +24,7 @@ global {
 
 
 grid ant_grid width: gridsize height: gridsize neighbours: 8 use_regular_agents: false {
-	list<ant_grid> neighbours <- self neighbours_at 1;
+	list<ant_grid> neighbours <- self neighbors_at 1;
 	bool multiagent <- true ;
 	int type <- int(types at {grid_x,grid_y}) ;
 	bool isNestLocation <- (self distance_to center) < 4 ;

--- a/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Complex).gaml
+++ b/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Complex).gaml
@@ -37,7 +37,7 @@ global {
 
 
 grid ant_grid width: gridsize height: gridsize neighbours: 8 frequency: grid_frequency use_regular_agents: false use_individual_shapes: false{
-	const neighbours type: list of: ant_grid <- self neighbours_at 1;
+	const neighbours type: list of: ant_grid <- self neighbors_at 1;
 	const is_nest type: bool <- (topology(ant_grid) distance_between [self, center]) < 4;
 	rgb color <- is_nest ? nest_color : ((food > 0) ? food_color : ((road < 0.001) ? background : rgb(#009900) + int(road * 5))) update: is_nest ? nest_color : ((food > 0) ?
 	food_color : ((road < 0.001) ? background : rgb(#009900) + int(road * 5)));

--- a/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Simple).gaml
+++ b/msi.gama.models/models/Toy Models/Ants/models/Ant Foraging (Simple).gaml
@@ -38,7 +38,7 @@ global {
 grid ant_grid width: gridsize height: gridsize neighbours: 8 {
 	bool isNestLocation  <- ( self distance_to center ) < 4;
 	bool isFoodLocation <-  types[grid_x , grid_y] = 2;       
-	list<ant_grid> neighbours <- self neighbours_at 1;  
+	list<ant_grid> neighbours <- self neighbors_at 1;  
 	rgb color <- rgb([ self.road > 15 ? 255 : ( isNestLocation ? 125 : 0 ) , self.road * 30 , self.road > 15 ? 255 : food * 50 ]) update: rgb([ self.road > 15 ? 255 : ( isNestLocation ? 125 : 0 ) ,self.road * 30 , self.road > 15 ? 255 : food * 50 ]); 
 	int food <- isFoodLocation ? 5 : 0; 
 	const nest type: int <- int(300 - ( self distance_to center ));

--- a/msi.gama.models/models/Toy Models/Ants/models/Ant Sorting.gaml
+++ b/msi.gama.models/models/Toy Models/Ants/models/Ant Sorting.gaml
@@ -54,7 +54,7 @@ species ant skills: [ moving ] control: fsm {
 
 grid ant_grid width: width_and_height_of_grid height: width_and_height_of_grid neighbours: 8 use_regular_agents: false frequency: 0{
 	rgb color <- (rnd(100)) < density_percent ? (colors at rnd(number_of_different_colors - 1)) as rgb : world.black ;
-	list<ant_grid> neighbours <- self neighbours_at 1;    
+	list<ant_grid> neighbours <- self neighbors_at 1;    
 }
 
 

--- a/msi.gama.models/models/Toy Models/Circle/Circle.gaml
+++ b/msi.gama.models/models/Toy Models/Circle/Circle.gaml
@@ -29,7 +29,7 @@ species cell skills: [moving] {
 	}
 	
 	reflex flee_others {
-		cell close <- one_of ( ( (self neighbours_at range) of_species cell) sort_by (self distance_to each) );
+		cell close <- one_of ( ( (self neighbors_at range) of_species cell) sort_by (self distance_to each) );
 		if close != nil {
 			heading <- (self towards close) - 180;
 			float dist <- self distance_to close;

--- a/msi.gama.models/models/Toy Models/Evacuation/models/grid_move.gaml
+++ b/msi.gama.models/models/Toy Models/Evacuation/models/grid_move.gaml
@@ -51,7 +51,7 @@ species people {
 		do die;
 	}
 	reflex move {
-		list<cell> possible_cells <- current_cell neighbours_at 1 where (not (each.is_obstacle) and each.is_free and not (each in memory));
+		list<cell> possible_cells <- current_cell neighbors_at 1 where (not (each.is_obstacle) and each.is_free and not (each in memory));
 		if not empty(possible_cells) {
 			current_cell.is_free <- true;
 			current_cell <- shuffle(possible_cells) with_min_of (each.location distance_to target_cell.location);

--- a/msi.gama.models/models/Toy Models/Flood Simulation/models/Hydrological Model.gaml
+++ b/msi.gama.models/models/Toy Models/Flood Simulation/models/Hydrological Model.gaml
@@ -39,7 +39,7 @@ global {
    action init_cells {
       ask cell {
          altitude <- grid_value;
-         neighbour_cells <- (self neighbours_at 1) ;
+         neighbour_cells <- (self neighbors_at 1) ;
       }
    }
    action init_water {

--- a/msi.gama.models/models/Toy Models/Infection/Susceptible Infected (SI).gaml
+++ b/msi.gama.models/models/Toy Models/Infection/Susceptible Infected (SI).gaml
@@ -39,7 +39,7 @@ global {
 
 grid si_grid width: 50 height: 50 use_individual_shapes: false use_regular_agents: false frequency: 0{
 	rgb color <- #black;
-	list<si_grid> neighbours <- (self neighbours_at neighbours_size) ;       
+	list<si_grid> neighbours <- (self neighbors_at neighbours_size) ;       
 }
 species Host  {
 	bool is_susceptible <- true;

--- a/msi.gama.models/models/Toy Models/Infection/Susceptible Infected Recovered (SIR).gaml
+++ b/msi.gama.models/models/Toy Models/Infection/Susceptible Infected Recovered (SIR).gaml
@@ -46,7 +46,7 @@ global {
 
 grid sir_grid width: 50 height: 50 use_individual_shapes: false use_regular_agents: false frequency: 0{
 	rgb color <- #black;
-	list<sir_grid> neighbours <- (self neighbours_at neighbours_size) ;       
+	list<sir_grid> neighbours <- (self neighbors_at neighbours_size) ;       
 }
 species Host  {
 	bool is_susceptible <- true;

--- a/msi.gama.models/models/Toy Models/Life/Life (No Colors).gaml
+++ b/msi.gama.models/models/Toy Models/Life/Life (No Colors).gaml
@@ -24,7 +24,7 @@ grid life_cell width: environment_width height: environment_height neighbours: 8
 	bool new_state;
 	bool state <- (rnd(100)) < density ;
 	rgb color <- state ? black : white ;
-	list<life_cell> neighbours <- self neighbours_at 1;
+	list<life_cell> neighbours <- self neighbors_at 1;
 	
 	action evolve {
 		int living  <- neighbours count each.state ;

--- a/msi.gama.models/models/Toy Models/Life/Life.gaml
+++ b/msi.gama.models/models/Toy Models/Life/Life.gaml
@@ -38,7 +38,7 @@ global torus: torus_environment {
 grid life_cell width: environment_width height: environment_height neighbours: 8  use_individual_shapes: false use_regular_agents: false frequency: 0
 use_neighbours_cache: false {
 	bool new_state;
-	list<life_cell> neighbours <- self neighbours_at 1;
+	list<life_cell> neighbours <- self neighbors_at 1;
 	bool state <- (rnd(100)) < density;
 	rgb color <- state ? livingcolor : deadcolor;
 	action evolve {

--- a/msi.gama.models/models/Toy Models/Segregation/models/Segregation (Cellular Automata).gaml
+++ b/msi.gama.models/models/Toy Models/Segregation/models/Segregation (Cellular Automata).gaml
@@ -33,7 +33,7 @@ global torus: true{
 
 grid space parent: base width: dimensions height: dimensions neighbours: 8  {
 	rgb color <- black;
-	list<space> my_neighbours <- self neighbours_at neighbours_distance;
+	list<space> my_neighbours <- self neighbors_at neighbours_distance;
 	action migrate {
 		if !is_happy {
 			space pp <- any(my_neighbours where (each.color = black));

--- a/msi.gama.models/models/Toy Models/Segregation/models/Segregation (Google Map).gaml
+++ b/msi.gama.models/models/Toy Models/Segregation/models/Segregation (Google Map).gaml
@@ -34,7 +34,7 @@ grid space width: dimensions height: dimensions neighbours: 8 use_individual_sha
 
 species people parent: base  {
 	const color type: rgb <- colors at (rnd (number_of_groups - 1));
-	list<people> my_neighbours -> {(self neighbours_at neighbours_distance) of_species people};
+	list<people> my_neighbours -> {(self neighbors_at neighbours_distance) of_species people};
 	init {
 		location <- (one_of(free_places)).location; 
 		remove location as space from: free_places;

--- a/msi.gama.models/models/Toy Models/Sugarscape/models/Sugarscape.gaml
+++ b/msi.gama.models/models/Toy Models/Sugarscape/models/Sugarscape.gaml
@@ -45,7 +45,7 @@ global {
 		map<int,list<sugar_cell>> neighbours;
 		init {
 			loop i from: 1 to: maxRange {
-				neighbours[i] <- self neighbours_at i; 
+				neighbours[i] <- self neighbors_at i; 
 			}
 		}
 	}	

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 03.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 03.gaml
@@ -49,7 +49,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2);
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2);
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 04.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 04.gaml
@@ -49,7 +49,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2);
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2);
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 05.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 05.gaml
@@ -79,7 +79,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 06.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 06.gaml
@@ -105,7 +105,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 07.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 07.gaml
@@ -115,7 +115,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 08.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 08.gaml
@@ -132,7 +132,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 09.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 09.gaml
@@ -136,7 +136,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 10.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 10.gaml
@@ -136,7 +136,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 11.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 11.gaml
@@ -146,7 +146,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 12.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 12.gaml
@@ -152,7 +152,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Predator Prey/models/Model 13.gaml
+++ b/msi.gama.models/models/Tutorials/Predator Prey/models/Model 13.gaml
@@ -153,7 +153,7 @@ grid vegetation_cell width: 50 height: 50 neighbours: 4 {
 	float foodProd <- (rnd(1000) / 1000) * 0.01 ;
 	float food <- (rnd(1000) / 1000) max: maxFood update: food + foodProd ;
 	rgb color <- rgb(int(255 * (1 - food)), 255, int(255 * (1 - food))) update: rgb(int(255 * (1 - food)), 255, int(255 *(1 - food))) ;
-	list<vegetation_cell> neighbours  <- (self neighbours_at 2); 
+	list<vegetation_cell> neighbours  <- (self neighbors_at 2); 
 }
 
 experiment prey_predator type: gui {

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 01.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 01.gaml
@@ -10,7 +10,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 }
 
 species bug {

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 02.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 02.gaml
@@ -10,7 +10,7 @@ global torus: true{
 }
  
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 }
 
 species bug {

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 03.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 03.gaml
@@ -10,7 +10,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- 0.01;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 04.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 04.gaml
@@ -9,7 +9,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- 0.01;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 05.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 05.gaml
@@ -14,7 +14,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 06.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 06.gaml
@@ -14,7 +14,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 07.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 07.gaml
@@ -17,7 +17,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 08.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 08.gaml
@@ -19,7 +19,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 09.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 09.gaml
@@ -19,7 +19,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 10.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 10.gaml
@@ -19,7 +19,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 11.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 11.gaml
@@ -21,7 +21,7 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
+	list<cell> neighbours4 <- self neighbors_at 4;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 12.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 12.gaml
@@ -21,8 +21,8 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
-	list<cell> neighbours3 <- self neighbours_at 3;
+	list<cell> neighbours4 <- self neighbors_at 4;
+	list<cell> neighbours3 <- self neighbors_at 3;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd ;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 13.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 13.gaml
@@ -21,8 +21,8 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
-	list<cell> neighbours3 <- self neighbours_at 3;
+	list<cell> neighbours4 <- self neighbors_at 4;
+	list<cell> neighbours3 <- self neighbors_at 3;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 14.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 14.gaml
@@ -22,8 +22,8 @@ global torus: true{
 }
 
 grid cell width: 100 height: 100 neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
-	list<cell> neighbours3 <- self neighbours_at 3;
+	list<cell> neighbours4 <- self neighbors_at 4;
+	list<cell> neighbours3 <- self neighbors_at 3;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 15.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 15.gaml
@@ -33,8 +33,8 @@ global {
 }
 
 grid cell width: width height: height neighbours: 4 {
-	list<cell> neighbours4 <- self neighbours_at 4;
-	list<cell> neighbours3 <- self neighbours_at 3;
+	list<cell> neighbours4 <- self neighbors_at 4;
+	list<cell> neighbours3 <- self neighbors_at 3;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;

--- a/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 16.gaml
+++ b/msi.gama.models/models/Tutorials/Stupid Model/models/Stupid Model 16.gaml
@@ -38,8 +38,8 @@ global {
 species scheduler schedules: cell + (bug sort_by ( - each.size)) + shuffle(predator);
 
 grid cell width: width height: height neighbours: 4 schedules:[]{
-	list<cell> neighbours4 <- self neighbours_at 4;
-	list<cell> neighbours3 <- self neighbours_at 3;
+	list<cell> neighbours4 <- self neighbors_at 4;
+	list<cell> neighbours3 <- self neighbors_at 3;
 	float maxFoodProdRate <- globalMaxFoodProdRate;
 	float foodProd <- (rnd(1000) / 1000) * maxFoodProdRate;
 	float food <- 0.0 update: food + foodProd;
@@ -90,7 +90,7 @@ species bug schedules:[]{
 species predator schedules:[]{
 	cell my_place;             
     reflex hunt {
-    	list<cell> neighbour_cells <- my_place neighbours_at 1;
+    	list<cell> neighbour_cells <- my_place neighbors_at 1;
         bug chosen_prey <- one_of((neighbour_cells + my_place) accumulate (each.agents of_species bug));
        	if chosen_prey != nil {
             cell new_place <- chosen_prey.my_place;    


### PR DESCRIPTION
After the issue #1244 , the commit @48d51377f74538a391abce17a966a407bfaab8d5 made `neighbours_at` deprecated in profit of `neighbors_at`, but it hasn't been changed in the example models.