### PR TITLE
Update component version

### DIFF
--- a/msi.gama.ext/pom2.xml
+++ b/msi.gama.ext/pom2.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>msi.gama</groupId>
     <artifactId>msi.gama.parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.1-SNAPSHOT</version>
     <relativePath>../msi.gama.parent/</relativePath>
   </parent>
   <artifactId>msi.gama.ext</artifactId>

--- a/msi.gama.p2updatesite/category.xml
+++ b/msi.gama.p2updatesite/category.xml
@@ -12,34 +12,34 @@
    <feature url="features/simtools.graphlayout.feature_0.0.0.jar" id="simtools.graphlayout.feature" version="0.0.0">
       <category name="gama.optional"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.core.extensions_1.7.0.qualifier.jar" id="ummisco.gama.feature.core.extensions" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.core.extensions_1.8.1.qualifier.jar" id="ummisco.gama.feature.core.extensions" version="0.0.0">
       <category name="gama.core"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.experiment.ui_1.7.0.qualifier.jar" id="ummisco.gama.feature.experiment.ui" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.experiment.ui_1.8.1.qualifier.jar" id="ummisco.gama.feature.experiment.ui" version="0.0.0">
       <category name="gama.ui"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.modeling.ui_1.7.0.qualifier.jar" id="ummisco.gama.feature.modeling.ui" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.modeling.ui_1.8.1.qualifier.jar" id="ummisco.gama.feature.modeling.ui" version="0.0.0">
       <category name="gama.ui"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.core.ui_1.7.0.qualifier.jar" id="ummisco.gama.feature.core.ui" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.core.ui_1.8.1.qualifier.jar" id="ummisco.gama.feature.core.ui" version="0.0.0">
       <category name="gama.ui"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.core_1.7.0.qualifier.jar" id="ummisco.gama.feature.core" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.core_1.8.1.qualifier.jar" id="ummisco.gama.feature.core" version="0.0.0">
       <category name="gama.core"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.network_1.7.0.qualifier.jar" id="ummisco.gama.feature.network" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.network_1.8.1.qualifier.jar" id="ummisco.gama.feature.network" version="0.0.0">
       <category name="gama.optional"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.serialize_1.7.0.qualifier.jar" id="ummisco.gama.feature.serialize" version="0.0.0">
+   <feature url="features/ummisco.gama.feature.serialize_1.8.1.qualifier.jar" id="ummisco.gama.feature.serialize" version="0.0.0">
       <category name="gama.optional"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.core.extensions_1.7.0.qualifier.jar" id="ummisco.gama.feature.core.extensions" version="1.7.0.qualifier">
+   <feature url="features/ummisco.gama.feature.core.extensions_1.8.1.qualifier.jar" id="ummisco.gama.feature.core.extensions" version="1.8.1.qualifier">
       <category name="gama.optional"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.models_1.7.0.qualifier.jar" id="ummisco.gama.feature.models" version="1.7.0.qualifier">
+   <feature url="features/ummisco.gama.feature.models_1.8.1.qualifier.jar" id="ummisco.gama.feature.models" version="1.8.1.qualifier">
       <category name="gama.models"/>
    </feature>
-   <feature url="features/ummisco.gama.feature.dependencies_1.7.0.qualifier.jar" id="ummisco.gama.feature.dependencies" version="1.7.0.qualifier">
+   <feature url="features/ummisco.gama.feature.dependencies_1.8.1.qualifier.jar" id="ummisco.gama.feature.dependencies" version="1.8.1.qualifier">
       <category name="gama.core"/>
    </feature>
    <category-def name="gama.ui" label="UI components of GAMA"/>

--- a/msi.gama.parent/tiny_pom.xml
+++ b/msi.gama.parent/tiny_pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>msi.gama</groupId>
 	<artifactId>msi.gama.parent</artifactId>
-	<version>1.7.0-SNAPSHOT</version>
+	<version>1.8.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<distributionManagement>
@@ -249,7 +249,7 @@
 		<p2-maven.version>1.2.0-SNAPSHOT</p2-maven.version>
 		<jetty-maven.version>8.1.5.v20120716</jetty-maven.version>
 		<tycho.version>0.25.0</tycho.version>
-		<project.version>1.7.0-SNAPSHOT</project.version>
+		<project.version>1.8.1-SNAPSHOT</project.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<geotools.version>14.5</geotools.version>
 		<math3.version>3.1.1</math3.version>
@@ -375,7 +375,7 @@
 				<version>${tycho.version}</version>
 				<configuration>
 					<!-- <target> <artifact> <groupId>msi.gama</groupId> <artifactId>gama.target.platform</artifactId> 
-						<version>1.7.0-SNAPSHOT</version> </artifact> </target> -->
+						<version>1.8.1-SNAPSHOT</version> </artifact> </target> -->
 
 					<dependency-resolution>
 						<optionalDependencies>ignore</optionalDependencies>

--- a/msi.gama.processor/META-INF/MANIFEST.MF
+++ b/msi.gama.processor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GAMA Processor
 Bundle-SymbolicName: msi.gama.processor;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.8.1.qualifier
 Bundle-Vendor: MSI
 Export-Package: msi.gama.precompiler;
   uses:="org.w3c.dom,

--- a/msi.gama.processor/pom.xml
+++ b/msi.gama.processor/pom.xml
@@ -8,7 +8,7 @@
 		</parent> -->
 	<groupId>msi.gama</groupId>
 	<artifactId>msi.gama.processor</artifactId>
-	<version>1.4.0-SNAPSHOT</version>
+	<version>1.8.1-SNAPSHOT</version>
 	<distributionManagement>
 		<repository>
 			<uniqueVersion>false</uniqueVersion>

--- a/msi.gama.release/pom.xml
+++ b/msi.gama.release/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>msi.gama</groupId>
 		<artifactId>msi.gama.parent</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.8.1-SNAPSHOT</version>
 		<relativePath>../msi.gama.parent/</relativePath>
 	</parent>
 	<artifactId>msi.gama.release</artifactId>

--- a/simtools.graphlayout.feature/feature.xml
+++ b/simtools.graphlayout.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="simtools.graphlayout.feature"
       label="Graph Layouts"
-      version="1.7.0.qualifier">
+      version="1.8.1.qualifier">
 
    <description url="http://www.example.com/description">
       Graph Layout Operators

--- a/simtools.graphlayout.feature/pom.xml
+++ b/simtools.graphlayout.feature/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.audio/feature.xml
+++ b/ummisco.gama.feature.audio/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.audio"
       label="Audio"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://www.example.com/description">

--- a/ummisco.gama.feature.audio/pom.xml
+++ b/ummisco.gama.feature.audio/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.core.extensions/feature.xml
+++ b/ummisco.gama.feature.core.extensions/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.core.extensions"
       label="Core extensions of GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO, IRIT &amp; IDEES">
 
    <description url="http://gama-platform.org">
@@ -22,7 +22,7 @@
    </url>
 
    <requires>
-      <import feature="ummisco.gama.feature.core" version="1.7.0.qualifier"/>
+      <import feature="ummisco.gama.feature.core" version="1.8.1.qualifier"/>
    </requires>
 
    <plugin

--- a/ummisco.gama.feature.core.extensions/pom.xml
+++ b/ummisco.gama.feature.core.extensions/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.core.ui/feature.xml
+++ b/ummisco.gama.feature.core.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.core.ui"
       label="Common UI Components of GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://gama-platform.org">

--- a/ummisco.gama.feature.core.ui/pom.xml
+++ b/ummisco.gama.feature.core.ui/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.core/feature.xml
+++ b/ummisco.gama.feature.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.core"
       label="Core plugins of GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://gama-platform.org">

--- a/ummisco.gama.feature.core/pom.xml
+++ b/ummisco.gama.feature.core/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.dependencies/feature.xml
+++ b/ummisco.gama.feature.dependencies/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.dependencies"
       label="Dependencies of GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://www.example.com/description">

--- a/ummisco.gama.feature.dependencies/pom.xml
+++ b/ummisco.gama.feature.dependencies/pom.xml
@@ -6,7 +6,7 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
 </project>

--- a/ummisco.gama.feature.experiment.ui/feature.xml
+++ b/ummisco.gama.feature.experiment.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.experiment.ui"
       label="UI Components for running experiments in  GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://gama-platform.org">
@@ -22,7 +22,7 @@
    </url>
 
    <requires>
-      <import feature="ummisco.gama.feature.core.ui" version="1.7.0.qualifier"/>
+      <import feature="ummisco.gama.feature.core.ui" version="1.8.1.qualifier"/>
    </requires>
 
    <plugin

--- a/ummisco.gama.feature.experiment.ui/pom.xml
+++ b/ummisco.gama.feature.experiment.ui/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.modeling.ui/feature.xml
+++ b/ummisco.gama.feature.modeling.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.modeling.ui"
       label="UI Components for designing models in  GAMA"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO">
 
    <description url="http://gama-platform.org">
@@ -22,7 +22,7 @@
    </url>
 
    <requires>
-      <import feature="ummisco.gama.feature.core.ui" version="1.7.0.qualifier"/>
+      <import feature="ummisco.gama.feature.core.ui" version="1.8.1.qualifier"/>
    </requires>
 
    <plugin

--- a/ummisco.gama.feature.modeling.ui/pom.xml
+++ b/ummisco.gama.feature.modeling.ui/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.models/feature.xml
+++ b/ummisco.gama.feature.models/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.models"
       label="Models"
-      version="1.7.0.qualifier"
+      version="1.8.1.qualifier"
       provider-name="UMMISCO"
       colocation-affinity="ummisco.gama.feature.core">
 

--- a/ummisco.gama.feature.models/pom.xml
+++ b/ummisco.gama.feature.models/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.network/feature.xml
+++ b/ummisco.gama.feature.network/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.network"
       label="Network"
-      version="1.7.0.qualifier">
+      version="1.8.1.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/ummisco.gama.feature.network/pom.xml
+++ b/ummisco.gama.feature.network/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.serialize/feature.xml
+++ b/ummisco.gama.feature.serialize/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.serialize"
       label="Serialize"
-      version="1.7.0.qualifier">
+      version="1.8.1.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/ummisco.gama.feature.serialize/pom.xml
+++ b/ummisco.gama.feature.serialize/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.feature.stats/feature.xml
+++ b/ummisco.gama.feature.stats/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ummisco.gama.feature.stats"
       label="Stats"
-      version="1.7.0.qualifier">
+      version="1.8.1.qualifier">
 
    <description url="http://www.example.com/description">
       This plug-in contains additional statistical operators.

--- a/ummisco.gama.feature.stats/pom.xml
+++ b/ummisco.gama.feature.stats/pom.xml
@@ -6,8 +6,8 @@
   <parent>
   	<groupId>msi.gama</groupId>
   	<artifactId>msi.gama.parent</artifactId>
-  	<version>1.7.0-SNAPSHOT</version>
+  	<version>1.8.1-SNAPSHOT</version>
   	<relativePath>../msi.gama.parent/</relativePath>
   </parent>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.1-SNAPSHOT</version>
 </project>

--- a/ummisco.gama.product/gama.product
+++ b/ummisco.gama.product/gama.product
@@ -271,14 +271,14 @@
       <feature id="org.eclipse.equinox.p2.extras.feature"/>
       <feature id="org.eclipse.equinox.p2.rcp.feature"/>
       <feature id="org.eclipse.equinox.p2.user.ui"/>
-      <feature id="ummisco.gama.feature.core.ui" version="1.7.0.qualifier" installMode="root"/>
-      <feature id="ummisco.gama.feature.core.extensions" version="1.7.0.qualifier" installMode="root"/>
-      <feature id="ummisco.gama.feature.core" version="1.7.0.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.core.ui" version="1.8.1.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.core.extensions" version="1.8.1.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.core" version="1.8.1.qualifier" installMode="root"/>
       <feature id="ummisco.gama.feature.dependencies" installMode="root"/>
-      <feature id="ummisco.gama.feature.models" version="1.7.0.qualifier" installMode="root"/>
-      <feature id="ummisco.gama.feature.core.ui" version="1.7.0.qualifier" installMode="root"/>
-      <feature id="ummisco.gama.feature.experiment.ui" version="1.7.0.qualifier" installMode="root"/>
-      <feature id="ummisco.gama.feature.modeling.ui" version="1.7.0.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.models" version="1.8.1.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.core.ui" version="1.8.1.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.experiment.ui" version="1.8.1.qualifier" installMode="root"/>
+      <feature id="ummisco.gama.feature.modeling.ui" version="1.8.1.qualifier" installMode="root"/>
    </features>
 
    <configurations>

--- a/ummisco.gama.product/gama.runtime.product
+++ b/ummisco.gama.product/gama.runtime.product
@@ -266,13 +266,13 @@
       <feature id="org.eclipse.equinox.p2.extras.feature"/>
       <feature id="org.eclipse.equinox.p2.rcp.feature"/>
       <feature id="org.eclipse.equinox.p2.user.ui"/>
-      <feature id="ummisco.gama.feature.core.extensions" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.core.ui" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.core" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.models" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.core.ui" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.experiment.ui" version="1.7.0.qualifier"/>
-      <feature id="ummisco.gama.feature.modeling.ui" version="1.7.0.qualifier"/>
+      <feature id="ummisco.gama.feature.core.extensions" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.core.ui" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.core" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.models" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.core.ui" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.experiment.ui" version="1.8.1.qualifier"/>
+      <feature id="ummisco.gama.feature.modeling.ui" version="1.8.1.qualifier"/>
    </features>
 
    <configurations>

--- a/ummisco.gama.product/pom.xml
+++ b/ummisco.gama.product/pom.xml
@@ -133,7 +133,7 @@
 					<products>
 						<product>
 							<id>ummisco.gama.application.product</id>
-							<archiveFileName>Gama1.7</archiveFileName>
+							<archiveFileName>Gama1.8.1</archiveFileName>
 							<rootFolders>
 								<macosx>Gama.app</macosx>
 							</rootFolders>


### PR DESCRIPTION
Update all the component versions to 1.8.1

I don't know if this is the correct way of versioning the component, but the previous version doesn't work. Basically, some of the subprojects needed version 1.7.0 dependencies but it doesn't exist for a freshly cloned and compiled project. I guess updating all version to 1.8.1 make sense?

