### PR TITLE
addresses issue in gama-platform/gama#3102

### DIFF
--- a/msi.gama.core/src/msi/gama/util/file/GamaOsmFile.java
+++ b/msi.gama.core/src/msi/gama/util/file/GamaOsmFile.java
@@ -439,7 +439,7 @@ public class GamaOsmFile extends GamaGisFile {
 			final Map<String, String> atts = new HashMap<>();
 			if (pt != null) {
 				for (final Tag tg : node.getTags()) {
-					final String key = tg.getKey().split(":")[0];
+					final String key = tg.getKey();
 					final Object val = tg.getValue();
 					if (val != null) {
 						addAttribute(atts, key, val);
@@ -495,7 +495,7 @@ public class GamaOsmFile extends GamaGisFile {
 			final Map<String, String> atts = GamaMapFactory.createUnordered();
 
 			for (final Tag tg : way.getTags()) {
-				final String key = tg.getKey().split(":")[0];
+				final String key = tg.getKey();
 				final Object val = tg.getValue();
 				if (val != null) {
 					addAttribute(atts, key, val);
@@ -591,7 +591,7 @@ public class GamaOsmFile extends GamaGisFile {
 		for (final Relation relation : relations) {
 			final Map<String, Object> values = GamaMapFactory.create();
 			for (final Tag tg : relation.getTags()) {
-				final String key = tg.getKey().split(":")[0];
+				final String key = tg.getKey();
 				values.put(key, tg.getValue());
 			}
 
@@ -659,7 +659,7 @@ public class GamaOsmFile extends GamaGisFile {
 				final Map<String, String> atts = GamaMapFactory.createUnordered();
 
 				for (final Tag tg : relation.getTags()) {
-					final String key = tg.getKey().split(":")[0];
+					final String key = tg.getKey();
 					final Object val = tg.getValue();
 					if (val != null) {
 						addAttribute(atts, key, val);


### PR DESCRIPTION
…/gama/util/file/GamaOsmFile.java uses keys from OSM verbatim rather than parsing them on colons (:)