### PR TITLE
Do not use spatial indices for species who have subspecies

### DIFF
--- a/msi.gama.core/src/msi/gama/metamodel/topology/CompoundSpatialIndex.java
+++ b/msi.gama.core/src/msi/gama/metamodel/topology/CompoundSpatialIndex.java
@@ -205,7 +205,11 @@ public class CompoundSpatialIndex extends Object implements ISpatialIndex.Compou
 	private ISpatialIndex add(final IScope scope, final IAgentFilter filter) {
 		if (filter == null) return null;
 		IPopulation<? extends IAgent> pop = filter.getPopulation(scope);
-		if (pop == null) return null;
+		if (pop == null ||
+				// spatial indices only work for species with no subspecies
+				!filter.getSpecies().getSubSpecies(scope).isEmpty()) {  
+			return null;
+		}
 		return add(pop, true);
 	}
 


### PR DESCRIPTION
What happened in #3254 is that the spatial index was only filled with agents from the parent species, since the input filter was considered as a `list<parent_species>`. If we want to find the closest agent, we would compute the intersection between the spatial index and the input list, but then agents belong to child species would be left out because they were not present in the index.

By returning `null` here, we would use the same logic to find the closest agent as if the input filter was a `MetaPopulation`: https://github.com/gama-platform/gama/blob/4ddc5b1ca7ca50be56804ba7e96b68a6ae2623b3/msi.gama.core/src/msi/gama/metamodel/topology/CompoundSpatialIndex.java#L74-L98

Close #3254