### PR TITLE
Fix for #225

### DIFF
--- a/gama.core/src/gama/core/runtime/GAMA.java
+++ b/gama.core/src/gama/core/runtime/GAMA.java
@@ -127,6 +127,10 @@ public class GAMA {
 	public static void flushWritePerAgent(final AbstractAgent owner) {
 		bufferingController.flushWriteOfOwner(owner);
 	}
+	public static void flushAllBufferings() {
+		bufferingController.flushAllBufferings();
+	}
+	
 
 	
 	/**

--- a/gama.core/src/gama/core/runtime/concurrent/BufferingController.java
+++ b/gama.core/src/gama/core/runtime/concurrent/BufferingController.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.NotImplementedException;
@@ -360,4 +361,28 @@ public class BufferingController {
 		flushAllWriteOfOwner(owner, consoleBufferListPerAgent);		
 	}
 	
+	public void flushAllBufferings() {
+		// flushes the console per cycle first
+		for (var agent : consoleBufferListPerAgentForCycles.keySet()) {
+			flushWriteInCycle(agent);
+		}
+		// flushes the others for the console
+		for (var agent : consoleBufferListPerAgent.keySet()) {
+			flushWriteOfOwner(agent);
+		}
+		// flushes the files registered for the cycle
+		var agents = fileBufferPerAgentForCycles.entrySet().stream().map(s -> s.getValue().keySet())
+					.collect(Collectors.toSet())
+					.toArray(new AbstractAgent[0]);
+		for (AbstractAgent agent : agents) {
+			flushSaveFilesInCycle(agent);
+		}
+		// finally flushes the files registered per agent
+		agents = fileBufferPerAgent.entrySet().stream().map(s -> s.getValue().keySet())
+				.collect(Collectors.toSet())
+				.toArray(new AbstractAgent[0]);
+		for (AbstractAgent agent : agents) {
+			flushSaveFilesOfOwner(agent);
+		}
+	}
 }

--- a/gama.ui.application/src/gama/ui/application/Application.java
+++ b/gama.ui.application/src/gama/ui/application/Application.java
@@ -154,6 +154,7 @@ public class Application implements IApplication {
 				if (display != null) { display.dispose(); }
 				final Location instanceLoc = Platform.getInstanceLocation();
 				if (instanceLoc != null) { instanceLoc.release(); }
+				GAMA.flushAllBufferings();
 			}
 		}
 		return EXIT_OK;
@@ -269,6 +270,7 @@ public class Application implements IApplication {
 
 	@Override
 	public void stop() {
+		GAMA.flushAllBufferings();
 		final IWorkbench workbench = getWorkbench();
 		if (workbench == null) return;
 		final Display display = workbench.getDisplay();


### PR DESCRIPTION
attempt at flushing the (remaining) outputs when closing gama.
It works when killing the process from the task manager.
@AlexisDrogoul I forced the flush in the start and close function of the Application class, do you see any other location where it would make sense ?