### PR TITLE
[MACOS] Resolve embedded JDK with simlink

### DIFF
--- a/travis/zip_withjdk.sh
+++ b/travis/zip_withjdk.sh
@@ -54,6 +54,9 @@ for targetPlatform in "linux.gtk.x86_64" "win32.win32.x86_64" "macosx.cocoa.x86_
 	jdkLocation=$RUNNER_TMP
 	if [[ "$os" == "macosx"* ]]; then
 		jdkLocation=$RUNNER_TMP/Gama.app/Contents
+		# Create symlink of jdk next to GAMA's executable
+		# Fix #229
+		ln -sf ../jdk $RUNNER_TMP/Gama.app/Contents/MacOS/jdk
 	fi
 
 	#
@@ -78,7 +81,7 @@ for targetPlatform in "linux.gtk.x86_64" "win32.win32.x86_64" "macosx.cocoa.x86_
 	# Make GAMA use embedded JDK
 	sed -i '1s/^/-vm\n/' $folderEclipse/Gama.ini
 	if [[ "$os" == "macosx"* ]]; then
-		sed -i '2s/^/..\/jdk\/Contents\/Home\/bin\/java\n/' $folderEclipse/Gama.ini
+		sed -i '2s/^/.\/jdk\/Contents\/Home\/bin\/java\n/' $folderEclipse/Gama.ini
 	elif [[ "$os" == "win32"* ]]; then
 		sed -i '2s/^/.\/jdk\/bin\/javaw\n/' $folderEclipse/Gama.ini
 	else


### PR DESCRIPTION
For some reason, Eclipse or JDK doesn't like to resolve JDK find at an upper level than the executable. Therefore, creating a symbolic link next to the GAMA bin pointing at the historical place of the JDK (ie. one level above) fixes this issue. Who knows... 

Fix #229

---

Tested on a Mac Mini M2 :heavy_check_mark: 