### PR TITLE
Improvements for the image layer

### DIFF
--- a/gama.core/src/gama/gaml/operators/spatial/SpatialPunctal.java
+++ b/gama.core/src/gama/gaml/operators/spatial/SpatialPunctal.java
@@ -7,14 +7,14 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.operation.distance.DistanceOp;
 
-import gama.annotations.precompiler.IConcept;
-import gama.annotations.precompiler.IOperatorCategory;
-import gama.annotations.precompiler.Reason;
 import gama.annotations.precompiler.GamlAnnotations.doc;
 import gama.annotations.precompiler.GamlAnnotations.example;
 import gama.annotations.precompiler.GamlAnnotations.no_test;
 import gama.annotations.precompiler.GamlAnnotations.operator;
 import gama.annotations.precompiler.GamlAnnotations.test;
+import gama.annotations.precompiler.IConcept;
+import gama.annotations.precompiler.IOperatorCategory;
+import gama.annotations.precompiler.Reason;
 import gama.core.common.geometry.GeometryUtils;
 import gama.core.metamodel.shape.GamaPoint;
 import gama.core.metamodel.shape.IShape;

--- a/gama.extension.image/src/gama/extension/image/GamaImage.java
+++ b/gama.extension.image/src/gama/extension/image/GamaImage.java
@@ -228,7 +228,7 @@ public class GamaImage extends BufferedImage implements IImageProvider, IAsset, 
 	 * @return the gama image
 	 */
 	public static GamaImage from(final GamaSpatialMatrix g) {
-		GamaImage gi = new GamaImage(g.numCols, g.numRows, TYPE_INT_RGB, "matrix" + System.currentTimeMillis());
+		GamaImage gi = new GamaImage(g.numCols, g.numRows, TYPE_INT_ARGB, "matrix" + System.currentTimeMillis());
 		final int[] imageData = ((DataBufferInt) gi.getRaster().getDataBuffer()).getData();
 		System.arraycopy(g.getDisplayData(), 0, imageData, 0, imageData.length);
 		return gi;
@@ -243,7 +243,7 @@ public class GamaImage extends BufferedImage implements IImageProvider, IAsset, 
 	 */
 	public static GamaImage from(final IScope scope, final GamaIntMatrix g) {
 		BufferedImage im = g.getImage(scope);
-		return from(im, false, "matrix" + System.currentTimeMillis());
+		return from(im, true, "matrix" + System.currentTimeMillis());
 	}
 
 	/**


### PR DESCRIPTION
fixes #262 but also some clues for further improvements.
@AlexisDrogoul could you double check this one as there are some points that I think could be improved in this class but I'm not sure yet:

1. This class uses a cached ImageProvider, but as the layer is only refreshed when the refresh facet is true, and that is checked in different parts of the code, I wonder what's the point of this object ? Maybe for files ? 
2. The BufferedImage to be drawn is actually generated in the `buildImage` method, but it is not returned, instead the ImageProvider that did generate it is returned and is then drawn with the `drawAsset` method. I think that this method is generating another bufferedimage but I'm not sure and it may depend on many factors (nature of the provider, facets of the layer/display etc.). I did a test it with a matrix that changed every cycle and compared the average cycle time with current method and with one were we return the buffered image and draw it with the method `drawImage` instead: I noticed a slight improvement (around 10%) in the average cycle execution time but it may as well be normal variability in simulations and I didn't dig much more.