### PR TITLE
Addresses #187 by correctly outputting a matrix from an asc file

### DIFF
--- a/gama.core/src/gama/core/util/file/GamaGridFile.java
+++ b/gama.core/src/gama/core/util/file/GamaGridFile.java
@@ -64,6 +64,7 @@ import gama.core.util.IList;
 import gama.core.util.matrix.GamaField;
 import gama.core.util.matrix.GamaFloatMatrix;
 import gama.core.util.matrix.IField;
+import gama.core.util.matrix.IMatrix;
 import gama.gaml.statements.Facets;
 import gama.gaml.types.GamaGeometryType;
 import gama.gaml.types.IType;
@@ -353,7 +354,7 @@ public class GamaGridFile extends GamaGisFile implements IFieldMatrixProvider {
 						ascInfo[2] = xCorner;
 					} else if (yCorner == null && yCenter == null && line.contains("yllcorner")) {
 						yCorner = doubleVal(line);
-						//TODO: very suspicious, probably xllcenter and yllcenter 
+						// TODO: very suspicious, probably xllcenter and yllcenter
 					} else if (xCorner == null && xCenter == null && line.contains("xllcorner")) { // AD To verify: the
 																									// conditions are
 																									// the same as two
@@ -847,6 +848,13 @@ public class GamaGridFile extends GamaGisFile implements IFieldMatrixProvider {
 		createCoverage(scope);
 		read(scope, true, false);
 		return Arrays.copyOf(records.bands.get(index), length(scope));
+	}
+
+	@Override
+	protected IMatrix _matrixValue(final IScope scope, final IType contentsType, final GamaPoint preferredSize,
+			final boolean copy) throws GamaRuntimeException {
+		getContents(scope);
+		return new GamaField(scope, this);
 	}
 
 }


### PR DESCRIPTION
From now on (refer to #187  for context):
- write grid_data.contents will return a geometry (the enclosing envelope)
- write grid_data as matrix will return the matrix<float> of the values
- write grid_data as field will return the same values