### PR TITLE
Restores backward direction in experiments and saving/reading of agents in files

### DIFF
--- a/gama.core/src/gama/core/metamodel/population/GamaPopulation.java
+++ b/gama.core/src/gama/core/metamodel/population/GamaPopulation.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * GamaPopulation.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * GamaPopulation.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -348,7 +347,6 @@ public class GamaPopulation<T extends IAgent> extends GamaList<T> implements IPo
 		return GamaExecutorService.step(scope, this, getSpecies());
 	}
 
-
 	/**
 	 * Take copy into account and always creates a list (necessary for #2254)
 	 */
@@ -524,7 +522,7 @@ public class GamaPopulation<T extends IAgent> extends GamaList<T> implements IPo
 		return listAgt.firstValue(scope);
 	}
 
-	@SuppressWarnings ("unchecked") 
+	@SuppressWarnings ("unchecked")
 	@Override
 	public IList<T> createAgents(final IScope scope, final int number,
 			final List<? extends Map<String, Object>> initialValues, final boolean isRestored,
@@ -816,7 +814,8 @@ public class GamaPopulation<T extends IAgent> extends GamaList<T> implements IPo
 	 * @param container
 	 *            the container
 	 */
-	protected <T extends IAgent> void fireAgentsAdded(final IScope scope, final IList<T> agents) {
+	@Override
+	public <T extends IAgent> void fireAgentsAdded(final IScope scope, final IList<T> agents) {
 		notifier.notifyAgentsAdded(scope, this, agents);
 	}
 

--- a/gama.core/src/gama/core/metamodel/population/IPopulation.java
+++ b/gama.core/src/gama/core/metamodel/population/IPopulation.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * IPopulation.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * IPopulation.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -447,5 +446,7 @@ public interface IPopulation<T extends IAgent>
 		return json.object("population", getSpecies().getName(), "agents", this.subList(0, size()));
 		// return json.valueOf(new SerialisedPopulation(this));
 	}
+
+	default <T extends IAgent> void fireAgentsAdded(final IScope scope, final IList<T> agents) {}
 
 }

--- a/gama.core/src/gama/gaml/statements/RemoteSequence.java
+++ b/gama.core/src/gama/gaml/statements/RemoteSequence.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * RemoteSequence.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * RemoteSequence.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -55,12 +54,6 @@ public class RemoteSequence extends AbstractStatementSequence {
 		super.leaveScope(scope);
 	}
 
-	// @Override
-	// public Object privateExecuteIn(final IScope scope) throws GamaRuntimeException {
-	// scope.addVarWithValue(IKeyword.MYSELF, myself.get());
-	// return super.privateExecuteIn(scope);
-	// }
-
 	@Override
 	public Object privateExecuteIn(final IScope scope) throws GamaRuntimeException {
 		scope.addVarWithValue(IKeyword.MYSELF, myself.get());
@@ -69,10 +62,7 @@ public class RemoteSequence extends AbstractStatementSequence {
 			final ExecutionResult result = scope.execute(command);
 			if (!result.passed()) return lastResult;
 			FlowStatus fs = scope.getAndClearContinueStatus();
-			if (scope.interrupted() || fs == FlowStatus.BREAK) // scope.setFlowStatus(IScope.FlowStatus.BREAK); // we
-																// set it again for
-				// the outer statement
-				return lastResult;
+			if (scope.interrupted() || fs == FlowStatus.BREAK) return lastResult;
 			if (fs == FlowStatus.CONTINUE) { continue; }
 			lastResult = result.getValue();
 		}

--- a/gama.extension.serialize/src/gama/extension/serialize/binary/BinarySerialisation.java
+++ b/gama.extension.serialize/src/gama/extension/serialize/binary/BinarySerialisation.java
@@ -1,12 +1,12 @@
 /*******************************************************************************************************
  *
- * BinarySerialisation.java, in gama.extension.serialize, is part of the source code of the
- * GAMA modeling and simulation platform (v.2024-06).
+ * BinarySerialisation.java, in gama.extension.serialize, is part of the source code of the GAMA modeling and simulation
+ * platform (v.2024-06).
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
  *
  * Visit https://github.com/gama-platform/gama for license information and contacts.
- * 
+ *
  ********************************************************************************************************/
 package gama.extension.serialize.binary;
 
@@ -55,7 +55,7 @@ public class BinarySerialisation implements ISerialisationConstants {
 			byte[] all = Files.readAllBytes(Path.of(FileUtils.constructAbsoluteFilePath(scope, path, true)));
 			return createFromBytes(scope, all);
 		} catch (IOException e) {
-			throw GamaRuntimeException.create(e, GAMA.getRuntimeScope());
+			throw GamaRuntimeException.create(e, scope);
 		}
 	}
 
@@ -154,7 +154,7 @@ public class BinarySerialisation implements ISerialisationConstants {
 			try {
 				restoreFromFile(agent, string);
 			} catch (Throwable ex) {
-				GAMA.reportAndThrowIfNeeded(agent.getScope(),GamaRuntimeException.create(ex, agent.getScope()), true);
+				GAMA.reportAndThrowIfNeeded(agent.getScope(), GamaRuntimeException.create(ex, agent.getScope()), true);
 			}
 		}
 	}

--- a/gama.extension.serialize/src/gama/extension/serialize/binary/BinarySerialiser.java
+++ b/gama.extension.serialize/src/gama/extension/serialize/binary/BinarySerialiser.java
@@ -180,7 +180,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 	 * @author Alexis Drogoul (alexis.drogoul@ird.fr)
 	 * @date 5 août 2023
 	 */
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings ("rawtypes")
 	protected void registerSerialisers(final FSTConfiguration conf) {
 
 		register(conf, GamaShape.class, new FSTIndividualSerialiser<GamaShape>() {
@@ -199,7 +199,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 				out.writeDouble(d == null ? 0d : d);
 				out.writeInt(t.ordinal());
 				out.writeObject(toWrite.getInnerGeometry());
-				out.writeObject(AgentReference.of(toWrite.getAgent()));
+				// out.writeObject(AgentReference.of(toWrite.getAgent()));
 			}
 
 			@Override
@@ -207,8 +207,8 @@ public class BinarySerialiser implements ISerialisationConstants {
 				double d = in.readDouble();
 				IShape.Type t = IShape.Type.values()[in.readInt()];
 				GamaShape result = GamaShapeFactory.createFrom((Geometry) in.readObject());
-				AgentReference agent = (AgentReference) in.readObject();
-				if (agent != AgentReference.NULL) { result.setAgent(agent.getReferencedAgent(scope)); }
+				// AgentReference agent = (AgentReference) in.readObject();
+				// if (agent != AgentReference.NULL) { result.setAgent(agent.getReferencedAgent(scope)); }
 				if (d > 0d) { result.setDepth(d); }
 				if (t != Type.NULL) { result.setGeometricalType(t); }
 				return result;
@@ -399,7 +399,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 
 		register(conf, IMap.class, new FSTIndividualSerialiser<IMap>() {
 
-			@SuppressWarnings("unchecked")
+			@SuppressWarnings ("unchecked")
 			@Override
 			public void serialise(final FSTObjectOutput out, final IMap o) throws Exception {
 				out.writeObject(o.getGamlType().getKeyType());
@@ -416,7 +416,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 				});
 			}
 
-			@SuppressWarnings({ "unchecked" })
+			@SuppressWarnings ({ "unchecked" })
 			@Override
 			public IMap deserialise(final IScope scope, final FSTObjectInput in) throws Exception {
 				IType k = (IType) in.readObject();
@@ -437,7 +437,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 				return false;
 			}
 
-			@SuppressWarnings({ "unchecked" })
+			@SuppressWarnings ({ "unchecked" })
 			@Override
 			public void serialise(final FSTObjectOutput out, final IList o) throws Exception {
 				out.writeObject(o.getGamlType().getContentType());
@@ -516,7 +516,6 @@ public class BinarySerialiser implements ISerialisationConstants {
 	 */
 	abstract class FSTIndividualSerialiser<T> extends FSTBasicObjectSerializer {
 
-
 		/**
 		 * Should register.
 		 *
@@ -547,7 +546,7 @@ public class BinarySerialiser implements ISerialisationConstants {
 		 *             the exception
 		 * @date 7 août 2023
 		 */
-		@SuppressWarnings("rawtypes")
+		@SuppressWarnings ("rawtypes")
 		@Override
 		public final T instantiate(final Class objectClass, final FSTObjectInput in,
 				final FSTClazzInfo serializationInfo, final FSTFieldInfo referencee, final int streamPosition)

--- a/gama.extension.serialize/src/gama/extension/serialize/binary/SimulationHistory.java
+++ b/gama.extension.serialize/src/gama/extension/serialize/binary/SimulationHistory.java
@@ -13,7 +13,6 @@ package gama.extension.serialize.binary;
 import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import gama.core.util.ByteArrayZipper;
 import gama.dev.DEBUG;
@@ -25,91 +24,19 @@ import gama.extension.serialize.binary.SimulationHistory.SimulationHistoryNode;
 public class SimulationHistory extends LinkedList<SimulationHistoryNode> {
 
 	/**
-	 * The Class SimulationHistoryNode.
+	 * The Record SimulationHistoryNode.
 	 */
-	static class SimulationHistoryNode {
-
-		/** The bytes. */
-		byte[] bytes;
-
-		/** The cycle. */
-		long cycle;
-
-		/**
-		 * Instantiates a new history node.
-		 *
-		 * @author Alexis Drogoul (alexis.drogoul@ird.fr)
-		 * @param state
-		 *            the state
-		 * @date 22 oct. 2023
-		 */
-		public SimulationHistoryNode(final byte[] state, final long cycle) {
-			bytes = state;
-			this.cycle = cycle;
-		}
-
-	}
+	static record SimulationHistoryNode(byte[] bytes, long cycle) {}
 
 	static {
-		DEBUG.ON();
+		DEBUG.OFF();
 	}
 
 	/** The executor. */
 	final ExecutorService executor = Executors.newCachedThreadPool();
 
-	/** The delta. Part of https://github.com/mantlik/xdeltaencoder/tree/master to compute diffs */
-	// Delta delta = new Delta();
-
-	/** The diffs. */
-//	LinkedList<SimulationHistoryNode> diffs = new LinkedList<>();
-
-	@Override
-	public void push(final SimulationHistoryNode node) {
-		// SimulationHistoryNode old = peek();
-		asyncProcess(node, System.nanoTime());
-		super.push(node);
-
-	}
-
-	// /**
-	// * Async zip.
-	// *
-	// * @author Alexis Drogoul (alexis.drogoul@ird.fr)
-	// * @param newFrame
-	// * the node
-	// * @date 8 août 2023
-	// */
-	// protected void asyncProcess(final SimulationHistoryNode keyFrame, final SimulationHistoryNode newFrame,
-	// final long startTime) {
-	// if (keyFrame == null) return;
-	// executor.execute(() -> {
-	// try {
-	// byte[] diff = delta.compute(keyFrame.bytes, newFrame.bytes);
-	// SimulationHistoryNode diffNode = new SimulationHistoryNode(diff, newFrame.cycle);
-	// diffs.push(diffNode);
-	// diffNode.bytes = ByteArrayZipper.zip(diff);
-	// DEBUG.OUT("Serialised and compressed to " + diffNode.bytes.length / 1000000d + "Mb in "
-	// + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
-	// } catch (IOException e) {}
-	//
-	// });
-	// }
-
-	/**
-	 * Async process.
-	 *
-	 * @param newFrame
-	 *            the new frame
-	 * @param startTime
-	 *            the start time
-	 */
-	protected void asyncProcess(final SimulationHistoryNode newFrame, final long startTime) {
-		executor.execute(() -> {
-			newFrame.bytes = ByteArrayZipper.zip(newFrame.bytes);
-			DEBUG.OUT("Serialised and compressed to " + newFrame.bytes.length / 1000000d + "Mb in "
-					+ TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
-
-		});
+	public void push(final byte[] state, final int cycle) {
+		executor.execute(() -> { push(new SimulationHistoryNode(ByteArrayZipper.zip(state), cycle)); });
 	}
 
 }

--- a/gama.extension.serialize/src/gama/extension/serialize/binary/SimulationSerialiser.java
+++ b/gama.extension.serialize/src/gama/extension/serialize/binary/SimulationSerialiser.java
@@ -11,12 +11,12 @@
 package gama.extension.serialize.binary;
 
 import java.util.LinkedList;
-import java.util.concurrent.TimeUnit;
 
 import gama.core.common.interfaces.ISerialisationConstants;
 import gama.core.kernel.experiment.ISimulationRecorder;
 import gama.core.kernel.simulation.SimulationAgent;
 import gama.core.metamodel.agent.SerialisedAgent;
+import gama.core.util.ByteArrayZipper;
 import gama.dev.DEBUG;
 import gama.extension.serialize.binary.SimulationHistory.SimulationHistoryNode;
 
@@ -29,7 +29,7 @@ import gama.extension.serialize.binary.SimulationHistory.SimulationHistoryNode;
 public class SimulationSerialiser implements ISimulationRecorder, ISerialisationConstants {
 
 	static {
-		DEBUG.ON();
+		DEBUG.OFF();
 	}
 
 	/** The processor. */
@@ -46,12 +46,9 @@ public class SimulationSerialiser implements ISimulationRecorder, ISerialisation
 	@Override
 	public void record(final SimulationAgent sim) {
 		try {
-			// long startTime = System.nanoTime();
 			byte[] state = processor.saveAgentToBytes(sim.getScope(), sim);
 			SimulationHistory history = getSimulationHistory(sim);
-			SimulationHistoryNode node = new SimulationHistoryNode(state, sim.getClock().getCycle());
-			history.push(node);
-			// asyncZip(node, startTime);
+			history.push(state, sim.getClock().getCycle());
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
@@ -89,12 +86,12 @@ public class SimulationSerialiser implements ISimulationRecorder, ISerialisation
 			synchronized (sim) {
 				LinkedList<SimulationHistoryNode> history = getSimulationHistory(sim);
 				SimulationHistoryNode node = history.pop();
-				if (node != null && node.cycle == sim.getClock().getCycle()) { node = history.pop(); }
+				if (node != null && node.cycle() == sim.getClock().getCycle()) { node = history.pop(); }
 				if (node != null) {
-					long startTime = System.nanoTime();
-					processor.restoreAgentFromBytes(sim, node.bytes);
-
-					DEBUG.OUT("Deserialised in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
+					// long startTime = System.nanoTime();
+					processor.restoreAgentFromBytes(sim, ByteArrayZipper.unzip(node.bytes()));
+					// DEBUG.OUT("Deserialised in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) +
+					// "ms");
 				}
 			}
 		} catch (Throwable e) {

--- a/gama.extension.serialize/src/gama/extension/serialize/gaml/CreateAgentsFromSerialisedFileDelegate.java
+++ b/gama.extension.serialize/src/gama/extension/serialize/gaml/CreateAgentsFromSerialisedFileDelegate.java
@@ -1,7 +1,7 @@
 /*******************************************************************************************************
  *
- * CreateAgentsFromSerialisedFileDelegate.java, in gama.serialize, is part of the source code of the GAMA
- * modeling and simulation platform .
+ * CreateAgentsFromSerialisedFileDelegate.java, in gama.serialize, is part of the source code of the GAMA modeling and
+ * simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -50,7 +50,8 @@ public class CreateAgentsFromSerialisedFileDelegate implements ICreateDelegate {
 		String path = (String) inits.get(0).get("saved_file");
 		BinarySerialisation.restoreFromFile(agent, path);
 		// The sequence is executed only after the restoration
-		scope.execute(sequence, agent, null);
+		if (sequence != null && !sequence.isEmpty()) { scope.execute(sequence, agent, null); }
+		pop.fireAgentsAdded(scope, agents);
 		return agents;
 	}
 
@@ -61,7 +62,7 @@ public class CreateAgentsFromSerialisedFileDelegate implements ICreateDelegate {
 	 */
 	@Override
 	public boolean acceptSource(final IScope scope, final Object source) {
-		return source instanceof GamaSavedSimulationFile;
+		return source instanceof GamaSavedAgentFile;
 	}
 
 	/**
@@ -71,7 +72,7 @@ public class CreateAgentsFromSerialisedFileDelegate implements ICreateDelegate {
 	@Override
 	public boolean createFrom(final IScope scope, final List<Map<String, Object>> inits, final Integer max,
 			final Object source, final Arguments init, final CreateStatement statement) {
-		inits.add(Map.of("saved_file", ((GamaSavedSimulationFile) source).getPath(scope)));
+		inits.add(Map.of("saved_file", ((GamaSavedAgentFile) source).getPath(scope)));
 		return true;
 	}
 


### PR DESCRIPTION
This commit should fix #246. The bytes composing the agent was compressed when saved but not decompressed. 