### PR TITLE
Displays the examples in the usages (popup doc, cf. #260)

### DIFF
--- a/gama.annotations/src/gama/annotations/precompiler/GamlAnnotations.java
+++ b/gama.annotations/src/gama/annotations/precompiler/GamlAnnotations.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * GamlAnnotations.java, in gama.annotations, is part of the source code of the GAMA modeling and simulation
- * platform .
+ * GamlAnnotations.java, in gama.annotations, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -443,7 +442,6 @@ public final class GamlAnnotations {
 		 */
 		doc[] doc() default {};
 	}
-
 
 	/**
 	 *
@@ -1096,9 +1094,16 @@ public final class GamlAnnotations {
 	 * An @usage can also be used for defining a template for a GAML structure, and in that case requires the following
 	 * to be defined :
 	 *
-	 * A name (attribute "name"), optional, but better A description (attribute "value"), optional A menu name
-	 * (attribute "menu"), optional A hierarchical path within this menu (attribute "path"), optional A pattern
-	 * (attribute "pattern" or concatenation of the @example present in "examples" that define "isPattern" as true)
+	 * A name (attribute "name"), optional, but better
+	 *
+	 * A description (attribute "value"), optional
+	 *
+	 * A menu name (attribute "menu"), optional
+	 *
+	 * A hierarchical path within this menu (attribute "path"), optional
+	 *
+	 * A pattern (attribute "pattern" or concatenation of the @example present in "examples" that define "isPattern" as
+	 * true)
 	 *
 	 * (see <code>org.eclipse.jface.text.templates.Template</code>) These templates are then classified and accessible
 	 * during runtime for editing models

--- a/gama.core/src/gama/gaml/compilation/GamlAddition.java
+++ b/gama.core/src/gama/gaml/compilation/GamlAddition.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * GamlAddition.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * GamlAddition.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -13,6 +12,7 @@ package gama.gaml.compilation;
 import java.lang.reflect.AnnotatedElement;
 
 import gama.annotations.precompiler.GamlAnnotations.doc;
+import gama.annotations.precompiler.GamlAnnotations.example;
 import gama.annotations.precompiler.GamlAnnotations.usage;
 import gama.gaml.interfaces.IGamlDescription;
 
@@ -76,7 +76,15 @@ public abstract class GamlAddition implements IGamlDescription {
 				String s = d.value();
 				if (s != null && !s.isEmpty()) { documentation.append(s).append("<br/>"); }
 				usage[] usages = d.usages();
-				for (usage u : usages) { documentation.append(u.value()).append("<br/>"); }
+				for (usage u : usages) {
+					documentation.append(u.value()).append("<br/><pre>");
+					for (example e : u.examples()) {
+						s = e.value();
+						if (s != null && !s.isEmpty()) { documentation.append("<t/>&#x09;").append(s).append("<br/>"); }
+					}
+					documentation.append("</pre>");
+
+				}
 				s = d.deprecated();
 				if (s != null && !s.isEmpty()) {
 					documentation.append("<b>Deprecated</b>: ").append("<i>").append(s).append("</i><br/>");


### PR DESCRIPTION
Issue #260 should be fixed with this PR, as the examples are now correctly displayed in the editor hover popups