### PR TITLE
A better handling of old workspaces (fixes #224)

### DIFF
--- a/gama.ui.application/src/gama/ui/application/Application.java
+++ b/gama.ui.application/src/gama/ui/application/Application.java
@@ -241,8 +241,9 @@ public class Application implements IApplication {
 				// this stage
 				if (ret != null) {
 					remember = "models".equals(ret) && WorkspacePreferences.askBeforeUsingOutdatedWorkspace()
-							&& !openQuestion(null, "Different version of the models library",
-									"The workspace contains a different version of the models library. Do you want to use another workspace ?");
+							&& openQuestion(null, "Different version of the models library",
+									"The workspace contains a different version of the models library. Do you want GAMA to proceed and update it ?");
+					if (remember) { clearWorkspace(true); }
 				}
 			}
 		}
@@ -255,7 +256,7 @@ public class Application implements IApplication {
 			if (pick == 1 /* Window.CANCEL */ || wr == null) {
 				openError(null, IKeyword.ERROR, "GAMA can not start without a workspace and will now exit.");
 				// System.exit(0);
-				return IApplication.EXIT_OK;
+				return EXIT_OK;
 			}
 			/* Tell Eclipse what the selected location was and continue */
 			instanceLoc.set(new URL("file", null, wr), false);

--- a/gama.ui.application/src/gama/ui/application/workspace/WorkspacePreferences.java
+++ b/gama.ui.application/src/gama/ui/application/workspace/WorkspacePreferences.java
@@ -246,11 +246,12 @@ public class WorkspacePreferences {
 				if (askBeforeUsingOutdatedWorkspace()) {
 					create = MessageDialog.openQuestion(Display.getDefault().getActiveShell(),
 							"Different version of the models library",
-							"The workspace contains a different version of the models library. Do you want to proceed anyway ?");
+							"The workspace contains a different version of the models library. Do you want GAMA to proceed and update it ?");
 				}
 				if (create) {
 					try {
 						dotFile.createNewFile();
+						Application.clearWorkspace(true);
 					} catch (final IOException e) {
 						return "Error updating the models library";
 					}
@@ -262,7 +263,7 @@ public class WorkspacePreferences {
 		}
 		if (cloning) {
 			final boolean b = MessageDialog.openQuestion(Display.getDefault().getActiveShell(), "Existing workspace",
-					"The path entered is a path to an existing workspace. All its contents will be erased and replaced by the current workspace contents. Proceed anyway ?");
+					"The path entered is a path to an existing workspace. Its contents will be erased and replaced by the current workspace contents. Proceed anyway ?");
 			if (!b) return "";
 		}
 		return null;


### PR DESCRIPTION
When a workspace created with a previous version of GAMA is opened, the dialog now asks if the user wants to update it -- and we clear the old state if yes (prefs of plugins, etc.). It should cover 90% of the usages. 