### PR TITLE
Patches the bug described in #334

### DIFF
--- a/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
+++ b/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
@@ -358,7 +358,7 @@ public class ExperimentAgent extends GamlAgent implements IExperimentAgent {
 		if (dying || dead) return;
 		dying = true;
 		getSpecies().getArchitecture().abort(ownScope);
-		closeSimulations(getSpecies().isReloading());
+		closeSimulations(!getSpecies().isReloading());
 		GAMA.releaseScope(ownScope);
 		super.dispose();
 	}

--- a/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
+++ b/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
@@ -358,7 +358,7 @@ public class ExperimentAgent extends GamlAgent implements IExperimentAgent {
 		if (dying || dead) return;
 		dying = true;
 		getSpecies().getArchitecture().abort(ownScope);
-		closeSimulations(true);
+		closeSimulations(getSpecies().isReloading());
 		GAMA.releaseScope(ownScope);
 		super.dispose();
 	}

--- a/gama.core/src/gama/core/kernel/experiment/ExperimentPlan.java
+++ b/gama.core/src/gama/core/kernel/experiment/ExperimentPlan.java
@@ -771,11 +771,25 @@ public class ExperimentPlan extends GamlSpecies implements IExperimentPlan {
 		open(seed);
 	}
 
+	// Horrible workaround for #334
+	// ----------------------------------------------------------------------------------
+	private volatile boolean reloading;
+
 	@Override
 	public void reload() {
-		agent.dispose();
+		try {
+
+			reloading = true;
+			agent.dispose();
+		} finally {
+			reloading = false;
+		}
 		open();
 	}
+
+	@Override
+	public boolean isReloading() { return reloading; }
+	// ----------------------------------------------------------------------------------
 
 	@Override
 	public boolean hasParametersOrUserCommands() {

--- a/gama.core/src/gama/core/kernel/experiment/IExperimentPlan.java
+++ b/gama.core/src/gama/core/kernel/experiment/IExperimentPlan.java
@@ -342,4 +342,11 @@ public interface IExperimentPlan extends ISpecies {
 	 * @date 15 oct. 2023
 	 */
 	void setParameterValues(IList params);
+
+	/**
+	 * Whether the current experiment is reloading or not (see #344)
+	 *
+	 * @return
+	 */
+	boolean isReloading();
 }

--- a/gama.core/src/gama/core/outputs/AbstractOutputManager.java
+++ b/gama.core/src/gama/core/outputs/AbstractOutputManager.java
@@ -62,8 +62,8 @@ public abstract class AbstractOutputManager extends Symbol implements IOutputMan
 	LayoutStatement layout;
 
 	/** The outputs. */
-	protected final Map<String, IOutput> outputs = GamaMapFactory.create();
-	// GamaMapFactory.synchronizedOrderedMap();
+	protected final Map<String, IOutput> outputs = // GamaMapFactory.create();
+			GamaMapFactory.synchronizedOrderedMap();
 
 	// protected final IList<MonitorOutput> monitors = GamaListFactory.create();
 


### PR DESCRIPTION
Disposing the ExperimentAgent no longer automatically switches to the "Modeling" perspective: if the ExperimentPlan is marked as "reloading", we stay in the same perspective. @lesquoyb thanks to review this and merge it !