### PR TITLE
[Exploration] Minor fixes in the facets of exploration methods

### DIFF
--- a/gama.core/src/gama/core/kernel/batch/exploration/Exploration.java
+++ b/gama.core/src/gama/core/kernel/batch/exploration/Exploration.java
@@ -87,10 +87,9 @@ import gama.gaml.types.IType;
 						doc = @doc ("The number of sample required, 132 by default")),
 				@facet (
 						name = Exploration.SAMPLE_FACTORIAL,
-						type = IType.LIST,
-						of = IType.INT,
+						type = IType.INT,
 						optional = true,
-						doc = @doc ("The number slices (value) applied to each parameter to build the factorial experimental plan.")),
+						doc = @doc ("The number of slice (value) applied to each parameter to build the factorial experimental plan.")),
 				@facet (
 						name = Exploration.NB_LEVELS,
 						type = IType.INT,

--- a/gama.core/src/gama/core/kernel/batch/exploration/betadistribution/BetaExploration.java
+++ b/gama.core/src/gama/core/kernel/batch/exploration/betadistribution/BetaExploration.java
@@ -92,8 +92,7 @@ import gama.gaml.types.IType;
 						doc = @doc ("The number of sample required.")),
 				@facet (
 						name = BetaExploration.BOOTSTRAP,
-						type = IType.LIST,
-						of = IType.INT,
+						type = IType.INT,
 						optional = true,
 						doc = @doc ("The number of time each parameter value is boostraped (or resampled in another context)")),
 				@facet (

--- a/gama.library/models/Model Exploration/Batch Simulation/Exploration.gaml
+++ b/gama.library/models/Model Exploration/Batch Simulation/Exploration.gaml
@@ -100,7 +100,7 @@ experiment exploration_with_sampling  parent: batch_abstract repeat:3 type: batc
 }
 
 experiment exploration_with_factorial  parent: batch_abstract repeat:3 type: batch until:world.stop_sim() or time>end_cycle {
-	method exploration sampling:"factorial" factorial:[4,10,4,6] sample:100;
+	method exploration sampling:"factorial" factorial:4 sample:100;
 }
 
 // This experiment iterate over 100 point randomly drawn from the parameter space


### PR DESCRIPTION
- Changes the type of `bootstrap` into int to fit its description and actual use
- Changes the model `Exploration.gaml` to use int factorial instead of a list to remove the warning
- fixes a typo in the documentation