### PR TITLE
Miscellaneous fixes for headless legacy

### DIFF
--- a/gama.headless/src/gama/headless/common/HeadLessErrors.java
+++ b/gama.headless/src/gama/headless/common/HeadLessErrors.java
@@ -29,15 +29,15 @@ public abstract class HeadLessErrors {
 	
 	/** The Constant NOT_EXIST_FILE_ERROR. */
 	public static final int NOT_EXIST_FILE_ERROR = 4;
-	
-	/** The Constant HPC_PARAMETER_ERROR. */
-	public static final int HPC_PARAMETER_ERROR = 5;
+//	
+//	/** The Constant HPC_PARAMETER_ERROR. */
+//	public static final int HPC_PARAMETER_ERROR = 5;
 	
 	/** The Constant INPUT_NOT_DEFINED. */
-	public static final int INPUT_NOT_DEFINED = 6;
+	public static final int INPUT_NOT_DEFINED = 5 /* 6 */;
 	
 	/** The Constant OUTPUT_NOT_DEFINED. */
-	public static final int OUTPUT_NOT_DEFINED = 7;
+	public static final int OUTPUT_NOT_DEFINED = 6 /* 7 */;
 
 	/** The Constant ERRORS. */
 	private final static String[] ERRORS =
@@ -46,7 +46,7 @@ public abstract class HeadLessErrors {
 			"Launching error... try again",
 			"Unable to create directory at #. Check your file permission!",
 			"Unable to create directory at #. Directory already exist!",
-			"Unable to read input file #. File not exist!",
+			"Unable to read input file #. File does not exist!",
 			"Input file is not defined",
 			"Output directory is not defined"};
 

--- a/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
+++ b/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
@@ -121,6 +121,9 @@ public class HeadlessApplication implements IApplication {
 	/** The Constant THREAD_PARAMETER. */
 	final public static String THREAD_PARAMETER = "-hpc";
 
+	/** The Constant THREAD_PARAMETER. */
+	final public static String STEPS_PARAMETER = "-steps";
+
 	/** The Constant PING_INTERVAL. */
 	final public static String PING_INTERVAL = "-ping_interval";
 
@@ -667,14 +670,17 @@ public class HeadlessApplication implements IApplication {
 	public void runGamlSimulation(final List<String> args)
 			throws IOException, GamaCompilationFailedException, InterruptedException {
 
+
 		final String argExperimentName = args.get(args.size() - 3);
 		final String argGamlFile = args.get(args.size() - 2);
 		final String argOutDir = args.get(args.size() - 1);
+		final Integer numberOfSteps = args.contains(STEPS_PARAMETER)	? Integer.parseInt(after(args, STEPS_PARAMETER)) : null;
+		final Integer numberOfCores = args.contains(THREAD_PARAMETER) 	? Integer.parseInt(after(args, THREAD_PARAMETER)) : null;
+		
 		assertIsAModelFile(argGamlFile);
 
-		Integer numberOfCores =
-				args.contains(THREAD_PARAMETER) ? Integer.parseInt(after(args, THREAD_PARAMETER)) : null;
-		final List<IExperimentJob> jb = ExperimentationPlanFactory.buildExperiment(argGamlFile, numberOfCores);
+		final List<IExperimentJob> jb = ExperimentationPlanFactory.buildExperiment(argGamlFile,numberOfSteps, numberOfCores);
+
 		ExperimentJob selectedJob = null;
 		for (final IExperimentJob j : jb) {
 			if (j.getExperimentName().equals(argExperimentName)) {

--- a/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
+++ b/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
@@ -305,6 +305,10 @@ public class HeadlessApplication implements IApplication {
 			size = size - 4;
 			mustContainInFile = mustContainOutFolder = false;
 		}
+		
+		if (args.contains(GAML_PARAMETER)) {
+			size = size - 2;
+		}
 
 		// Runner verification
 		// ========================
@@ -319,11 +323,15 @@ public class HeadlessApplication implements IApplication {
 			// Check and create output folder
 			Globals.OUTPUT_PATH = args.get(args.size() - 1);
 			final File output = new File(Globals.OUTPUT_PATH);
-			if (!output.exists()) { output.mkdir(); }
+			if (!output.exists() && !output.mkdir()) {
+				return showError(HeadLessErrors.PERMISSION_ERROR, Globals.OUTPUT_PATH);					
+			}
 			// Check and create output image folder
 			Globals.IMAGES_PATH = Globals.OUTPUT_PATH + "/snapshot";
 			final File images = new File(Globals.IMAGES_PATH);
-			if (!images.exists()) { images.mkdir(); }
+			if (!images.exists() && !images.mkdir()) {
+					return showError(HeadLessErrors.PERMISSION_ERROR, Globals.IMAGES_PATH);
+			}
 		}
 		if (mustContainInFile) {
 			final int inIndex = args.size() - (mustContainOutFolder ? 2 : 1);
@@ -658,10 +666,11 @@ public class HeadlessApplication implements IApplication {
 	 */
 	public void runGamlSimulation(final List<String> args)
 			throws IOException, GamaCompilationFailedException, InterruptedException {
-		final String pathToModel = args.get(args.size() - 1);
-		assertIsAModelFile(pathToModel);
-		final String argExperimentName = args.get(args.size() - 2);
-		final String argGamlFile = args.get(args.size() - 1);
+
+		final String argExperimentName = args.get(args.size() - 3);
+		final String argGamlFile = args.get(args.size() - 2);
+		final String argOutDir = args.get(args.size() - 1);
+		assertIsAModelFile(argGamlFile);
 
 		Integer numberOfCores =
 				args.contains(THREAD_PARAMETER) ? Integer.parseInt(after(args, THREAD_PARAMETER)) : null;
@@ -674,7 +683,7 @@ public class HeadlessApplication implements IApplication {
 			}
 		}
 		if (selectedJob == null) return;
-		Globals.OUTPUT_PATH = args.get(args.size() - 3);
+		Globals.OUTPUT_PATH = argOutDir;
 
 		selectedJob.setBufferedWriter(new XMLWriter(Globals.OUTPUT_PATH + "/" + Globals.OUTPUT_FILENAME + ".xml"));
 		processorQueue.setNumberOfThreads(numberOfCores != null ? numberOfCores : SimulationRuntime.DEFAULT_NB_THREADS);

--- a/gama.headless/src/gama/headless/script/ExperimentationPlanFactory.java
+++ b/gama.headless/src/gama/headless/script/ExperimentationPlanFactory.java
@@ -158,17 +158,17 @@ public class ExperimentationPlanFactory {
 	 * @param modelFileName
 	 *            the model file name
 	 * @param numberOfCores
-	 *            the number of cores passed throuhg the '-hpc' parameter. If null, means that '-hpc' is not set
+	 *            the number of cores passed through the '-hpc' parameter. If null, means that '-hpc' is not set
 	 * @return the list
 	 * @throws IOException
 	 *             Signals that an I/O exception has occurred.
 	 * @throws GamaHeadlessException
 	 *             the gama headless exception
 	 */
-	public static List<IExperimentJob> buildExperiment(final String modelFileName, final Integer numberOfCores)
+	public static List<IExperimentJob> buildExperiment(final String modelFileName, final Integer numberOfSteps, final Integer numberOfCores)
 			throws IOException, GamaCompilationFailedException {
 		final long[] seeds = { DEFAULT_SEED };
-		return JobListFactory.constructAllJobs(modelFileName, seeds, DEFAULT_FINAL_STEP, numberOfCores);
+		return JobListFactory.constructAllJobs(modelFileName, seeds, numberOfSteps == null ? DEFAULT_FINAL_STEP : numberOfSteps, numberOfCores);
 	}
 
 	/**
@@ -184,7 +184,7 @@ public class ExperimentationPlanFactory {
 	 */
 	public static List<IExperimentJob> buildExperiment(final String modelFileName)
 			throws IOException, GamaCompilationFailedException {
-		return buildExperiment(modelFileName, null);
+		return buildExperiment(modelFileName,null,  null);
 	}
 
 	/**

--- a/gama.headless/src/gama/headless/xml/XMLWriter.java
+++ b/gama.headless/src/gama/headless/xml/XMLWriter.java
@@ -12,6 +12,7 @@ package gama.headless.xml;
 
 import java.io.*;
 
+import gama.headless.common.DataType;
 import gama.headless.core.*;
 import gama.headless.job.ExperimentJob;
 import gama.headless.job.ListenedVariable;
@@ -66,7 +67,9 @@ public class XMLWriter implements Writer {
 	public void writeResultStep(final long step, final ListenedVariable[] vars) {
 		StringBuilder sb = new StringBuilder().append("\t<Step id='").append(step).append("' >\n");
 		for ( int i = 0; i < vars.length; i++ ) {
-			sb.append("\t\t<Variable name='").append(vars[i].getName()).append("' type='").append(vars[i].getDataType().name()).append("'>").append(vars[i].getValue())
+			sb.append("\t\t<Variable name='").append(vars[i].getName())
+								.append("' type='").append((vars[i].getDataType() == null ? DataType.UNDEFINED : vars[i].getDataType()).name())
+								.append("'>").append(vars[i].getValue())
 				.append("</Variable>\n");
 		}
 		sb.append("\t</Step>\n");

--- a/gama.headless/src/gama/headless/xml/XMLWriter.java
+++ b/gama.headless/src/gama/headless/xml/XMLWriter.java
@@ -10,10 +10,12 @@
  ********************************************************************************************************/
 package gama.headless.xml;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
 
 import gama.headless.common.DataType;
-import gama.headless.core.*;
 import gama.headless.job.ExperimentJob;
 import gama.headless.job.ListenedVariable;
 


### PR DESCRIPTION
Starting by fixing  #352: the problem happened when reaching the exportVariable function and trying to serialize the displays.
For now I'm just handling the case where the dataType variable is not defined. 
But the issue appeared on `Model 12.gaml` from the library of models, in which the displays are explicitly defined as 2d, so shouldn't dataType be DataType.DISPLAY2D when entering this function? And if so, what is the expected dataType in case of 3d display ?
@AlexisDrogoul any pointer ?