### PR TITLE
Provides a fix for #379

### DIFF
--- a/gama.core/src/gama/core/outputs/InspectDisplayOutput.java
+++ b/gama.core/src/gama/core/outputs/InspectDisplayOutput.java
@@ -1,7 +1,6 @@
 /*******************************************************************************************************
  *
- * InspectDisplayOutput.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * InspectDisplayOutput.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform .
  *
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
@@ -15,8 +14,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import gama.annotations.precompiler.IConcept;
-import gama.annotations.precompiler.ISymbolKind;
 import gama.annotations.precompiler.GamlAnnotations.doc;
 import gama.annotations.precompiler.GamlAnnotations.example;
 import gama.annotations.precompiler.GamlAnnotations.facet;
@@ -24,6 +21,8 @@ import gama.annotations.precompiler.GamlAnnotations.facets;
 import gama.annotations.precompiler.GamlAnnotations.inside;
 import gama.annotations.precompiler.GamlAnnotations.symbol;
 import gama.annotations.precompiler.GamlAnnotations.usage;
+import gama.annotations.precompiler.IConcept;
+import gama.annotations.precompiler.ISymbolKind;
 import gama.core.common.interfaces.IGui;
 import gama.core.common.interfaces.IKeyword;
 import gama.core.common.util.StringUtils;
@@ -333,22 +332,34 @@ public class InspectDisplayOutput extends AbstractValuedDisplayOutput implements
 		return EMPTY;
 	}
 
-	/**
-	 * Gets the species.
-	 *
-	 * @return the species
-	 */
-	public ISpecies getSpecies() {
+	// /**
+	// * Gets the species.
+	// *
+	// * @return the species
+	// */
+	// public ISpecies getSpecies() {
+	// final IExpression valueExpr = getValue();
+	// if (valueExpr == null) return null;
+	// final IType theType = valueExpr.getGamlType().getContentType();
+	// if (theType == Types.get(IKeyword.MODEL)) return getScope().getModel().getSpecies();
+	// final SpeciesDescription sd = theType.getSpecies();
+	// if (sd == null) return getScope().getModel().getSpecies(IKeyword.AGENT);
+	// if (sd.equals(getScope().getModel().getDescription())) return getScope().getModel().getSpecies();
+	// String speciesName = sd.getName();
+	// if (speciesName == null) { speciesName = IKeyword.AGENT; }
+	// return rootAgent.getSpecies().getMicroSpecies(speciesName);
+	// }
+
+	public SpeciesDescription getSpeciesDescription() {
 		final IExpression valueExpr = getValue();
 		if (valueExpr == null) return null;
 		final IType theType = valueExpr.getGamlType().getContentType();
-		if (theType == Types.get(IKeyword.MODEL)) return getScope().getModel().getSpecies();
+		if (theType == Types.get(IKeyword.MODEL)) return getScope().getModel().getDescription();
 		final SpeciesDescription sd = theType.getSpecies();
-		if (sd == null) return getScope().getModel().getSpecies(IKeyword.AGENT);
-		if (sd.equals(getScope().getModel().getDescription())) return getScope().getModel().getSpecies();
+		if (sd == null) return Types.AGENT.getDenotedSpecies();
 		String speciesName = sd.getName();
-		if (speciesName == null) { speciesName = IKeyword.AGENT; }
-		return rootAgent.getSpecies().getMicroSpecies(speciesName);
+		if (speciesName == null) return Types.AGENT.getDenotedSpecies();
+		return rootAgent.getSpecies().getDescription().getMicroSpecies(speciesName);
 	}
 
 	/**

--- a/gama.ui.experiment/src/gama/ui/experiment/views/inspectors/PopulationInspectView.java
+++ b/gama.ui.experiment/src/gama/ui/experiment/views/inspectors/PopulationInspectView.java
@@ -66,13 +66,13 @@ import gama.core.runtime.IScope;
 import gama.core.runtime.exceptions.GamaRuntimeException;
 import gama.core.util.file.csv.CsvWriter;
 import gama.dev.DEBUG;
+import gama.gaml.descriptions.SpeciesDescription;
+import gama.gaml.descriptions.VariableDescription;
 import gama.gaml.expressions.IExpression;
 import gama.gaml.expressions.types.SpeciesConstantExpression;
 import gama.gaml.operators.Files;
-import gama.gaml.species.ISpecies;
 import gama.gaml.types.IType;
 import gama.gaml.types.Types;
-import gama.gaml.variables.IVariable;
 import gama.ui.experiment.menus.AgentsMenu;
 import gama.ui.shared.controls.SwitchButton;
 import gama.ui.shared.menus.GamaMenu;
@@ -256,7 +256,7 @@ public class PopulationInspectView extends GamaViewPart
 	 * Update species.
 	 */
 	void updateSpecies() {
-		final ISpecies species = getOutput().getSpecies();
+		final SpeciesDescription species = getOutput().getSpeciesDescription();
 		final IExpression expr = getOutput().getValue();
 
 		final String name = species == null ? IKeyword.AGENT : species.getName();
@@ -269,7 +269,7 @@ public class PopulationInspectView extends GamaViewPart
 				selectedColumns.get(name).addAll(attributes.keySet());
 			} else if (getOutput().getValue() != null) {
 				if (species == null) return;
-				selectedColumns.get(name).addAll(species.getVarNames());
+				selectedColumns.get(name).addAll(species.getAttributeNames());
 				selectedColumns.get(name).removeAll(DONT_INSPECT_BY_DEFAULT);
 			}
 			Collections.sort(selectedColumns.get(name));
@@ -356,9 +356,9 @@ public class PopulationInspectView extends GamaViewPart
 		attributesMenu.setToolTipText(tooltipText);
 		final boolean hasPreviousSelection = selectedColumns.get(speciesName) != null;
 		final InspectDisplayOutput output = getOutput();
-		final ISpecies species = output.getSpecies();
-		final List<String> names = new ArrayList(
-				getOutput().getAttributes() == null ? species.getVarNames() : getOutput().getAttributes().keySet());
+		final SpeciesDescription species = output.getSpeciesDescription();
+		final List<String> names = new ArrayList(getOutput().getAttributes() == null ? species.getAttributeNames()
+				: getOutput().getAttributes().keySet());
 		Collections.sort(names);
 		DEBUG.OUT("" + names);
 		for (final String name : names) {
@@ -452,7 +452,7 @@ public class PopulationInspectView extends GamaViewPart
 	 */
 	String getSpeciesName() {
 		if (getOutput() == null) return "";
-		final ISpecies species = getOutput().getSpecies();
+		final SpeciesDescription species = getOutput().getSpeciesDescription();
 		if (species == null) return IKeyword.AGENT;
 		return species.getName();
 	}
@@ -699,8 +699,8 @@ public class PopulationInspectView extends GamaViewPart
 						if (v2 == null) {
 							rc = 1;
 						} else {
-							final IVariable v = getOutput().getSpecies().getVar(attribute);
-							final int id = v.getType().id();
+							final VariableDescription v = getOutput().getSpeciesDescription().getAttribute(attribute);
+							final int id = v.getGamlType().id();
 							rc = switch (id) {
 								case IType.INT -> ((Integer) v1).compareTo((Integer) v2);
 								case IType.FLOAT -> ((Double) v1).compareTo((Double) v2);


### PR DESCRIPTION
The issue was due to the browsing of agents from different species. The "common denominator" (i.e. `agent`) could not be found in the model. Problem is solved by moving to `SpeciesDescription` (rather than `ISpecies`) for traversing the species hierarchy. 