### PR TITLE
Fixes a potential NPE in network when closing an experiment

### DIFF
--- a/gama.extension.network/src/gama/extension/network/tcp/ClientService.java
+++ b/gama.extension.network/src/gama/extension/network/tcp/ClientService.java
@@ -110,7 +110,9 @@ public class ClientService extends Thread implements SocketService {
 		if (sender != null) { sender.close(); }
 		try {
 			if (receiver != null) { receiver.close(); }
-			socket.close();
+			if (socket != null) {
+				socket.close();				
+			}
 		} catch (final IOException e) {
 			
 			e.printStackTrace();


### PR DESCRIPTION
In case the socket was null (no call to connect or an exception when trying to), gama would raise a NPE when closing the simulation, which breaks the UI.