### PR TITLE
Fixes #467 and other bugs related to escaping/unescaping strings

### DIFF
--- a/gaml.compiler/src/gaml/compiler/gaml/expression/GamlExpressionCompiler.java
+++ b/gaml.compiler/src/gaml/compiler/gaml/expression/GamlExpressionCompiler.java
@@ -1179,7 +1179,7 @@ public class GamlExpressionCompiler extends GamlSwitch<IExpression> implements I
 
 	@Override
 	public IExpression caseStringLiteral(final StringLiteral object) {
-		return getFactory().createConst(StringUtils.unescapeJava(EGaml.getInstance().getKeyOf(object)), Types.STRING);
+		return getFactory().createConst(EGaml.getInstance().getKeyOf(object), Types.STRING);
 	}
 
 	@Override


### PR DESCRIPTION
I've removed the unescaping of string happening when transforming a StringLitteral into an expression because it seems like StringLitterals by definition are already escaped. This double unescaping leads in some edge cases to the "creation" special characters or trigger runtime exceptions, especially because the method was supporting escapings that were not allowed by gaml's syntax.
I've run all the unit tests, tried models that were using files, and a few examples that were causing troubles and everything seems alright. That being said, the change happening in the compiler, it could have unexpected repercussion so please test properly before merging