### PR TITLE
Moves the server to GAMA directly (instead of PlatformAgent)

### DIFF
--- a/gama.core/src/gama/core/kernel/experiment/DefaultExperimentController.java
+++ b/gama.core/src/gama/core/kernel/experiment/DefaultExperimentController.java
@@ -185,8 +185,7 @@ public class DefaultExperimentController extends AbstractExperimentController {
 	public void schedule(final ExperimentAgent agent) {
 		this.agent = agent;
 		scope = agent.getScope();
-		serverConfiguration = GAMA.getPlatformAgent().getServer() != null
-				? GAMA.getPlatformAgent().getServer().obtainGuiServerConfiguration() : null;
+		serverConfiguration = GAMA.getServer() != null ? GAMA.getServer().obtainGuiServerConfiguration() : null;
 		scope.setServerConfiguration(serverConfiguration);
 		try {
 			if (!scope.init(agent).passed()) {
@@ -216,7 +215,7 @@ public class DefaultExperimentController extends AbstractExperimentController {
 			}
 		} catch (RuntimeException e) {
 			e.printStackTrace();
-		}finally {
+		} finally {
 			previouslock.release();
 		}
 	}

--- a/gama.core/src/gama/core/runtime/GAMA.java
+++ b/gama.core/src/gama/core/runtime/GAMA.java
@@ -38,6 +38,7 @@ import gama.core.runtime.benchmark.StopWatch;
 import gama.core.runtime.concurrent.BufferingController;
 import gama.core.runtime.exceptions.GamaRuntimeException;
 import gama.core.runtime.exceptions.GamaRuntimeException.GamaRuntimeFileException;
+import gama.core.runtime.server.GamaGuiWebSocketServer;
 import gama.core.runtime.server.IGamaServer;
 import gama.dev.DEBUG;
 import gama.gaml.compilation.ISymbol;
@@ -660,13 +661,6 @@ public class GAMA {
 	}
 
 	/**
-	 * Gets the current websocket server
-	 *
-	 * @return the current top level agent
-	 */
-	public static IGamaServer getServer() { return getPlatformAgent().getServer(); }
-
-	/**
 	 * Gets the current top level agent.
 	 *
 	 * @author Alexis Drogoul (alexis.drogoul@ird.fr)
@@ -852,6 +846,54 @@ public class GAMA {
 	 */
 	public static void updateExperimentState(final IExperimentPlan exp) {
 		updateExperimentState(exp, getExperimentState(exp));
+	}
+
+	/**
+	 * Start server.
+	 */
+	public static void startGuiServer() {
+		if (!GAMA.isInHeadLessMode() && GamaPreferences.Runtime.CORE_SERVER_MODE.getValue()) { createGuiServer(); }
+		GamaPreferences.Runtime.CORE_SERVER_MODE.onChange(newValue -> { if (newValue) { createGuiServer(); } });
+	}
+
+	/** The my server. */
+	private static IGamaServer myServer;
+
+	/**
+	 * Creates the gui server.
+	 */
+	private static void createGuiServer() {
+		final int port = GamaPreferences.Runtime.CORE_SERVER_PORT.getValue();
+		final int ping = GamaPreferences.Runtime.CORE_SERVER_PING.getValue();
+		setServer(GamaGuiWebSocketServer.startForGUI(port, ping));
+	}
+
+	/**
+	 * Gets the server.
+	 *
+	 * @author Alexis Drogoul (alexis.drogoul@ird.fr)
+	 * @return the server
+	 * @date 3 nov. 2023
+	 */
+	public static IGamaServer getServer() { return myServer; }
+
+	/**
+	 * Sets the server.
+	 *
+	 * @param server
+	 *            the new server
+	 */
+	public static void setServer(final IGamaServer server) {
+		if (myServer != null) {
+			try {
+				myServer.stop();
+				myServer = null;
+			} catch (InterruptedException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+		myServer = server;
 	}
 
 }

--- a/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
+++ b/gama.headless/src/gama/headless/runtime/HeadlessApplication.java
@@ -419,8 +419,7 @@ public class HeadlessApplication implements IApplication {
 			final String jks = args.contains(SSOCKET_PARAMETER_JKSPATH) ? after(args, SSOCKET_PARAMETER_JKSPATH) : "";
 			final String spwd = args.contains(SSOCKET_PARAMETER_SPWD) ? after(args, SSOCKET_PARAMETER_SPWD) : "";
 			final String kpwd = args.contains(SSOCKET_PARAMETER_KPWD) ? after(args, SSOCKET_PARAMETER_KPWD) : "";
-			GAMA.getPlatformAgent()
-					.setServer(startForSecureHeadless(socket, processorQueue, true, jks, spwd, kpwd, ping));
+			GAMA.setServer(startForSecureHeadless(socket, processorQueue, true, jks, spwd, kpwd, ping));
 		} else {
 			runSimulation(args);
 		}

--- a/gama.ui.application/src/gama/ui/application/Application.java
+++ b/gama.ui.application/src/gama/ui/application/Application.java
@@ -145,6 +145,7 @@ public class Application implements IApplication {
 					clearWorkspace(false);
 				}
 				try {
+					GAMA.startGuiServer();
 					final int returnCode = Workbench.createAndRunWorkbench(display, new ApplicationWorkbenchAdvisor());
 					if (returnCode == RETURN_RESTART) return EXIT_RESTART;
 				} catch (Exception t) {


### PR DESCRIPTION
Application now calls GAMA.createGuiServer() at startup to avoid the lag mentioned in #631.
Fixes #631 if accepted. 