### PR TITLE
Clean connections when killing an agent/closing the experiment

### DIFF
--- a/gama.extension.network/src/gama/extension/network/tcp/ClientService.java
+++ b/gama.extension.network/src/gama/extension/network/tcp/ClientService.java
@@ -109,10 +109,10 @@ public class ClientService extends Thread implements SocketService {
 		this.isAlive = false;
 		if (sender != null) { sender.close(); }
 		try {
-			if (receiver != null) { receiver.close(); }
 			if (socket != null) {
 				socket.close();				
 			}
+			if (receiver != null) { receiver.close(); }
 		} catch (final IOException e) {
 			
 			e.printStackTrace();


### PR DESCRIPTION
- Fixes #483

first draft, not perfect yet

@AlexisDrogoul could you have a look ? I have a problem with this code: because I register a listener every time an agent does a connect, the cleanup function is called many times in example with multiple connections/multiple agents. It is working properly but I don't find it satisfying, and I don't know how to **properly** only register one listener per population (and per experiment I guess).