### PR TITLE
Refactor IScope and ExecutionScope for cleaner context handling

### DIFF
--- a/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
+++ b/gama.core/src/gama/core/kernel/experiment/ExperimentAgent.java
@@ -27,7 +27,6 @@ import gama.annotations.precompiler.GamlAnnotations.species;
 import gama.annotations.precompiler.GamlAnnotations.variable;
 import gama.annotations.precompiler.GamlAnnotations.vars;
 import gama.annotations.precompiler.ITypeProvider;
-import gama.core.common.interfaces.IGui;
 import gama.core.common.interfaces.IKeyword;
 import gama.core.common.preferences.GamaPreferences;
 import gama.core.common.util.RandomUtils;
@@ -1215,16 +1214,16 @@ public class ExperimentAgent extends GamlAgent implements IExperimentAgent {
 			return super.getAgentVarValue(a, varName);
 		}
 
-		/**
-		 * Gets the gui.
-		 *
-		 * @return the gui
-		 */
-		@Override
-		public IGui getGui() {
-			if (getSpecies().isHeadless()) return GAMA.getHeadlessGui();
-			return GAMA.getRegularGui();
-		}
+		// /**
+		// * Gets the gui.
+		// *
+		// * @return the gui
+		// */
+		// @Override
+		// public IGui getGui() {
+		// if (getSpecies().isHeadless()) return GAMA.getHeadlessGui();
+		// return GAMA.getRegularGui();
+		// }
 
 	}
 

--- a/gama.core/src/gama/core/runtime/IScope.java
+++ b/gama.core/src/gama/core/runtime/IScope.java
@@ -52,6 +52,18 @@ import gama.gaml.types.Types;
 @SuppressWarnings ({ "rawtypes" })
 public interface IScope extends Closeable, IBenchmarkable {
 
+	/** The Constant ATTRIBUTES. */
+	String KEY_ATTRIBUTES = "%_key_attributes_%";
+
+	/**
+	 * The "temporary output" key. Used to indicate in the scope (see {@link IScope#setData(String, Object)} that the
+	 * current file is created for serving as an output file, for saving data
+	 */
+	String KEY_TEMPORARY_OUTPUT = "%_key_temporary_output_%";
+
+	/** The key current error. */
+	String KEY_CURRENT_ERROR = "%_key_current_error_%";
+
 	/** The interrupting statuses. */
 	EnumSet<FlowStatus> INTERRUPTING_STATUSES =
 			EnumSet.of(FlowStatus.BREAK, FlowStatus.RETURN, FlowStatus.CONTINUE, FlowStatus.DIE, FlowStatus.DISPOSE);
@@ -250,7 +262,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @param values
 	 *            the values
 	 */
-	void pushReadAttributes(Map values);
+	default void pushReadAttributes(final Map values) {
+		addVarWithValue(KEY_ATTRIBUTES, values);
+	}
 
 	/**
 	 * Pop read attributes.
@@ -264,7 +278,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 *
 	 * @return the map
 	 */
-	Map peekReadAttributes();
+	default Map peekReadAttributes() {
+		return (Map) this.getVarValue(KEY_ATTRIBUTES);
+	}
 
 	/**
 	 * Access to various agents and objects
@@ -289,7 +305,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @param value
 	 *            the value
 	 */
-	void setEach(String name, Object value);
+	default void setEach(final String name, final Object value) {
+		addVarWithValue(name, value);
+	}
 
 	/**
 	 * Gets the value of 'each' when inside an iterator. Note that this form is deprecated, in favor of the form that
@@ -307,7 +325,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @param each
 	 * @return
 	 */
-	Object getEach(String each);
+	default Object getEach(final String each) {
+		return getVarValue(each);
+	}
 
 	/**
 	 * Gets the root.
@@ -382,7 +402,7 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 *
 	 * @return the gui
 	 */
-	IGui getGui();
+	default IGui getGui() { return GAMA.getGui(); }
 
 	/**
 	 * Gets the clock.
@@ -401,11 +421,10 @@ public interface IScope extends Closeable, IBenchmarkable {
 	/**
 	 * Sets the topology.
 	 *
-	 * @param topology
-	 *            the topology
-	 * @return the i topology
+	 * @param topo
+	 *            the new topology
 	 */
-	ITopology setTopology(ITopology topology);
+	void setTopology(final ITopology topo);
 
 	/**
 	 * Execute.
@@ -536,19 +555,7 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @param val
 	 *            the val
 	 */
-	default void setVarValue(final String varName, final Object val) {
-		setVarValue(varName, val, false);
-	}
-
-	/**
-	 * Sets the var value, and states whether the var should be written in an outer scope (if it is defined there) or
-	 * kept in this scope (like for instance the variable defined in a loop (see Issue #3085)
-	 *
-	 * @param varName
-	 * @param val
-	 * @param localScopeOnly
-	 */
-	void setVarValue(String varName, Object val, boolean localScopeOnly);
+	void setVarValue(final String varName, final Object val);
 
 	/**
 	 * Save all var values in.
@@ -557,11 +564,6 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 *            the vars to save
 	 */
 	void saveAllVarValuesIn(Map<String, Object> varsToSave);
-
-	/**
-	 * Removes the all vars.
-	 */
-	void removeAllVars();
 
 	/**
 	 * Adds the var with value.
@@ -659,7 +661,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @throws GamaRuntimeException
 	 *             the gama runtime exception
 	 */
-	Integer getIntArg(String string) throws GamaRuntimeException;
+	default Integer getIntArg(final String string) throws GamaRuntimeException {
+		return (Integer) getArg(string, IType.INT);
+	}
 
 	/**
 	 * Gets the float arg.
@@ -670,7 +674,9 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @throws GamaRuntimeException
 	 *             the gama runtime exception
 	 */
-	Double getFloatArg(String string) throws GamaRuntimeException;
+	default Double getFloatArg(final String string) throws GamaRuntimeException {
+		return (Double) getArg(string, IType.FLOAT);
+	}
 
 	/**
 	 * Gets the list arg.
@@ -681,7 +687,10 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @throws GamaRuntimeException
 	 *             the gama runtime exception
 	 */
-	<T> IList<T> getListArg(String string) throws GamaRuntimeException;
+	@SuppressWarnings ("unchecked")
+	default <T> IList<T> getListArg(final String string) throws GamaRuntimeException {
+		return (IList<T>) getArg(string, IType.LIST);
+	}
 
 	/**
 	 * Gets the string arg.
@@ -692,7 +701,10 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @throws GamaRuntimeException
 	 *             the gama runtime exception
 	 */
-	String getStringArg(String string) throws GamaRuntimeException;
+	default String getStringArg(final String string) throws GamaRuntimeException {
+		return (String) getArg(string, IType.STRING);
+
+	}
 
 	/**
 	 * Gets the bool arg.
@@ -703,7 +715,10 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @throws GamaRuntimeException
 	 *             the gama runtime exception
 	 */
-	Boolean getBoolArg(String string) throws GamaRuntimeException;
+	default Boolean getBoolArg(final String string) throws GamaRuntimeException {
+		return (Boolean) getArg(string, IType.BOOL);
+
+	}
 
 	/**
 	 * Returns the argument using getBoolArg if it exists, else returns ifNotExist value
@@ -831,14 +846,16 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @return the current statement or null if none
 	 */
 
-	void setCurrentError(GamaRuntimeException g);
+	default void setCurrentError(final GamaRuntimeException g) {
+		setVarValue(KEY_CURRENT_ERROR, g);
+	}
 
 	/**
 	 * Gets the current error.
 	 *
 	 * @return the current error
 	 */
-	GamaRuntimeException getCurrentError();
+	default GamaRuntimeException getCurrentError() { return (GamaRuntimeException) getVarValue(KEY_CURRENT_ERROR); }
 
 	/**
 	 * Checks if is graphics.
@@ -933,27 +950,6 @@ public interface IScope extends Closeable, IBenchmarkable {
 	 * @return true, if is closed
 	 */
 	boolean isClosed();
-
-	/**
-	 * Gets the data.
-	 *
-	 * @param key
-	 *            the key
-	 * @return the data
-	 */
-	default Object getData(final String key) {
-		return null;
-	}
-
-	/**
-	 * Sets the data.
-	 *
-	 * @param key
-	 *            the key
-	 * @param value
-	 *            the value
-	 */
-	default void setData(final String key, final Object value) {}
 
 	/**
 	 * Gets the population factory.

--- a/gama.core/src/gama/core/util/file/GamaFile.java
+++ b/gama.core/src/gama/core/util/file/GamaFile.java
@@ -149,7 +149,7 @@ public abstract class GamaFile<Container extends IAddressableContainer & IModifi
 	 */
 	protected GamaFile(final IScope scope, final String pn, boolean forReading) throws GamaRuntimeException {
 		// See #3684 -- we temporarily consider files as output files if we are invoked by 'save'
-		if (forReading) { forReading = scope != null && scope.getData(IGamaFile.KEY_TEMPORARY_OUTPUT) == null; }
+		if (forReading) { forReading = scope != null && scope.getVarValue(IScope.KEY_TEMPORARY_OUTPUT) == null; }
 		originalPath = pn;
 		String tempPath = originalPath;
 		if (originalPath == null)

--- a/gama.core/src/gama/core/util/file/IGamaFile.java
+++ b/gama.core/src/gama/core/util/file/IGamaFile.java
@@ -88,12 +88,6 @@ public interface IGamaFile<C extends IModifiableContainer, Contents>
 	}
 
 	/**
-	 * The "temporary output" key. Used to indicate in the scope (see {@link IScope#setData(String, Object)} that the
-	 * current file is created for serving as an output file, for saving data
-	 */
-	String KEY_TEMPORARY_OUTPUT = "key_temporary_output";
-
-	/**
 	 * Sets the writable.
 	 *
 	 * @param scope

--- a/gama.core/src/gama/gaml/statements/LoopStatement.java
+++ b/gama.core/src/gama/gaml/statements/LoopStatement.java
@@ -460,7 +460,7 @@ public class LoopStatement extends AbstractStatementSequence implements Breakabl
 		scope.push(this);
 		try {
 			// We set it explicitly to the newly created scope
-			if (varName != null) { scope.setVarValue(varName, currentValue, true); }
+			if (varName != null) { scope.addVarWithValue(varName, currentValue); }
 			result[0] = super.privateExecuteIn(scope);
 		} finally {
 			scope.pop(this);

--- a/gama.core/src/gama/gaml/statements/SaveStatement.java
+++ b/gama.core/src/gama/gaml/statements/SaveStatement.java
@@ -1,9 +1,9 @@
 /*******************************************************************************************************
  *
  * SaveStatement.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
- * .
+ * (v.2025-03).
  *
- * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
+ * (c) 2007-2025 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
  *
  * Visit https://github.com/gama-platform/gama for license information and contacts.
  *
@@ -113,19 +113,25 @@ import gama.gaml.types.Types;
 						remote_context = true,
 						optional = true,
 						doc = @doc (
-								value = "Allows to specify the attributes of a shape file or GeoJson file where agents are saved. Can be expressed as a list of string or as a literal map. When expressed as a list, each value should represent the name of an attribute of the shape or agent. The keys of the map are the names of the attributes that will be present in the file, the values are whatever expressions neeeded to define their value. ")), 
+								value = "Allows to specify the attributes of a shape file or GeoJson file where agents are saved. Can be expressed as a list of string or as a literal map. When expressed as a list, each value should represent the name of an attribute of the shape or agent. The keys of the map are the names of the attributes that will be present in the file, the values are whatever expressions neeeded to define their value. ")),
 				@facet (
 						name = IKeyword.BUFFERING,
-						type = { IType.STRING},
+						type = { IType.STRING },
 						optional = true,
 						doc = @doc (
-								value = "Allows to specify a buffering strategy to write the file. Accepted values are `" + BufferingController.PER_CYCLE_BUFFERING +"` and `" + BufferingController.PER_SIMULATION_BUFFERING + "`, `" + BufferingController.NO_BUFFERING + "`. "
-										+ "In the case of `"+ BufferingController.PER_CYCLE_BUFFERING +"` or `"+ BufferingController.PER_SIMULATION_BUFFERING +"`, all the write operations in the simulation which used these values would be "
-										+ "executed all at once at the end of the cycle or simulation while keeping the initial order. In case of '" + BufferingController.PER_AGENT
+								value = "Allows to specify a buffering strategy to write the file. Accepted values are `"
+										+ BufferingController.PER_CYCLE_BUFFERING + "` and `"
+										+ BufferingController.PER_SIMULATION_BUFFERING + "`, `"
+										+ BufferingController.NO_BUFFERING + "`. " + "In the case of `"
+										+ BufferingController.PER_CYCLE_BUFFERING + "` or `"
+										+ BufferingController.PER_SIMULATION_BUFFERING
+										+ "`, all the write operations in the simulation which used these values would be "
+										+ "executed all at once at the end of the cycle or simulation while keeping the initial order. In case of '"
+										+ BufferingController.PER_AGENT
 										+ "' all operations will be released when the agent is killed (or the simulation ends). Those strategies can be used to optimise a "
 										+ "simulation's execution time on models that extensively write in files. "
-										+ "The `" + BufferingController.NO_BUFFERING + "` (which is the system's default) will directly write into the file.")),
-		},
+										+ "The `" + BufferingController.NO_BUFFERING
+										+ "` (which is the system's default) will directly write into the file.")), },
 		omissible = IKeyword.DATA)
 @doc (
 		value = "Allows to save data in a file.",
@@ -166,8 +172,8 @@ import gama.gaml.types.Types;
 						value = "The save statement can be use in an init block, a reflex, an action or in a user command. Do not use it in experiments.") })
 @validator (SaveValidator.class)
 @SuppressWarnings ({ "rawtypes" })
-public class SaveStatement extends AbstractStatementSequence{
-	
+public class SaveStatement extends AbstractStatementSequence {
+
 	/** The Constant NON_SAVEABLE_ATTRIBUTE_NAMES. */
 	public static final Set<String> NON_SAVEABLE_ATTRIBUTE_NAMES =
 			Set.of(IKeyword.PEERS, IKeyword.LOCATION, IKeyword.HOST, IKeyword.AGENTS, IKeyword.MEMBERS, IKeyword.SHAPE);
@@ -180,7 +186,6 @@ public class SaveStatement extends AbstractStatementSequence{
 
 	/** The Constant SYNONYMS. */
 	private static final SetMultimap<String, String> SYNONYMS = TreeMultimap.create();
-	
 
 	/**
 	 * @param createExecutableExtension
@@ -209,7 +214,6 @@ public class SaveStatement extends AbstractStatementSequence{
 
 	}
 
-	
 	/**
 	 * The Class SaveValidator.
 	 */
@@ -227,7 +231,7 @@ public class SaveStatement extends AbstractStatementSequence{
 			final IExpression att = desc.getFacetExpr(ATTRIBUTES);
 			final IExpressionDescription type = desc.getFacet(FORMAT);
 			final IExpression bufferingStrategy = desc.getFacetExpr(IKeyword.BUFFERING);
-			
+
 			if (type != null) { desc.setFacetExprDescription(FORMAT, type); }
 			final IExpression format = type == null ? null : type.getExpression();
 
@@ -286,14 +290,18 @@ public class SaveStatement extends AbstractStatementSequence{
 
 			}
 
-			if (bufferingStrategy != null && ! BufferingController.BUFFERING_STRATEGIES.contains(bufferingStrategy.literalValue())) {
-				desc.error("The value for buffering must be '" + BufferingController.NO_BUFFERING +"', '" + BufferingController.PER_CYCLE_BUFFERING + "', '" + BufferingController.PER_AGENT + "'" + "' or '" + BufferingController.PER_SIMULATION_BUFFERING +"'.", 
+			if (bufferingStrategy != null
+					&& !BufferingController.BUFFERING_STRATEGIES.contains(bufferingStrategy.literalValue())) {
+				desc.error(
+						"The value for buffering must be '" + BufferingController.NO_BUFFERING + "', '"
+								+ BufferingController.PER_CYCLE_BUFFERING + "', '" + BufferingController.PER_AGENT + "'"
+								+ "' or '" + BufferingController.PER_SIMULATION_BUFFERING + "'.",
 						IGamlIssue.WRONG_TYPE);
 			}
-			
+
 			// Starting from here we validate the attributes, other validations must be done before
 			if (att == null) return;
-			
+
 			final boolean isMap = att instanceof MapExpression;
 			if (!isMap && !att.getGamlType().isTranslatableInto(Types.LIST.of(Types.STRING))) {
 				desc.error("attributes must be expressed as a map<string, unknown> or as a list<string>",
@@ -310,8 +318,9 @@ public class SaveStatement extends AbstractStatementSequence{
 				}
 			}
 
-			if (ext != null && format == null && !"shp".equals(ext) && !"json".equals(ext) && !"geojson".equals(ext) || format != null
-					&& !"shp".equals(format.literalValue()) && !"geojson".equals(format.literalValue()) && !"json".equals(format.literalValue())) {
+			if (ext != null && format == null && !"shp".equals(ext) && !"json".equals(ext) && !"geojson".equals(ext)
+					|| format != null && !"shp".equals(format.literalValue())
+							&& !"geojson".equals(format.literalValue()) && !"json".equals(format.literalValue())) {
 				desc.warning("Attributes can only be defined for shape, geojson or json files", IGamlIssue.WRONG_TYPE,
 						ATTRIBUTES);
 			}
@@ -322,17 +331,14 @@ public class SaveStatement extends AbstractStatementSequence{
 			/** The species. */
 			final SpeciesDescription species = t.getSpecies();
 
+			if (species == null && isMap) {
+				desc.error("Attributes of geometries can only be specified with a list of attribute names",
+						IGamlIssue.UNKNOWN_FACET, ATTRIBUTES);
+			}
+			// Error deactivated for fixing #2982.
+			// desc.error("Attributes can only be saved for agents", IGamlIssue.UNKNOWN_FACET,
+			// att == null ? WITH : ATTRIBUTES);
 
-			if (species == null) {
-				if (isMap) {
-					desc.error("Attributes of geometries can only be specified with a list of attribute names",
-							IGamlIssue.UNKNOWN_FACET, ATTRIBUTES);
-				}
-				// Error deactivated for fixing #2982.
-				// desc.error("Attributes can only be saved for agents", IGamlIssue.UNKNOWN_FACET,
-				// att == null ? WITH : ATTRIBUTES);
-			} 
-			
 		}
 
 		/**
@@ -366,7 +372,8 @@ public class SaveStatement extends AbstractStatementSequence{
 
 	/** The rewrite expr. */
 	private final IExpression rewriteExpr;
-	
+
+	/** The buffering strategy. */
 	private final IExpression bufferingStrategy;
 
 	/**
@@ -396,13 +403,14 @@ public class SaveStatement extends AbstractStatementSequence{
 		if (rewriteExpr == null) return true;
 		return Cast.asBool(scope, rewriteExpr.value(scope));
 	}
-	
+
 	/**
 	 * In case the save statement is called with a file object, calls the save method from this object
+	 *
 	 * @param scope
 	 * @return
 	 */
-	protected Object saveFile(IScope scope) {
+	protected Object saveFile(final IScope scope) {
 		if (!Types.FILE.isAssignableFrom(item.getGamlType())) return null;
 		final IGamaFile theFile = (IGamaFile) item.value(scope);
 		if (theFile != null) {
@@ -417,12 +425,10 @@ public class SaveStatement extends AbstractStatementSequence{
 	public Object privateExecuteIn(final IScope scope) throws GamaRuntimeException {
 		// if item is null, there's nothing to write
 		if (item == null) return null;
-		
+
 		// First case: we have no destination file, so it means the item is a file;
-		if (file == null) {
-			return saveFile(scope);
-		}
-		
+		if (file == null) return saveFile(scope);
+
 		final String fileName = Cast.asString(scope, file.value(scope));
 		final String filePath = FileUtils.constructAbsoluteFilePath(scope, fileName, false);
 		if (filePath == null || "".equals(filePath)) return null;
@@ -437,7 +443,7 @@ public class SaveStatement extends AbstractStatementSequence{
 					// We set a temporary flag to the scope, which should be readable by the GamaFile and indicate that
 					// the file is created "for saving" (and not reading). Otherwise it might create an exception if the
 					// file does not exist already (see #3684)
-					scope.setData(IGamaFile.KEY_TEMPORARY_OUTPUT, true);
+					scope.setVarValue(IScope.KEY_TEMPORARY_OUTPUT, true);
 					final IGamaFile f = GamaFileType.createFile(scope, fileName, false, mc);
 					f.save(scope, description.getFacets());
 					return f;
@@ -447,7 +453,7 @@ public class SaveStatement extends AbstractStatementSequence{
 					DEBUG.OUT(e.getMessage());
 				} finally {
 					// We remove the temporary flag
-					scope.setData(IGamaFile.KEY_TEMPORARY_OUTPUT, null);
+					scope.setVarValue(IScope.KEY_TEMPORARY_OUTPUT, null);
 				}
 			}
 			typeExp = com.google.common.io.Files.getFileExtension(fileName);
@@ -459,13 +465,14 @@ public class SaveStatement extends AbstractStatementSequence{
 			typeExp = Cast.asString(scope, format.value(scope));
 			if (!DELEGATES.containsKey(typeExp)) { typeExp = null; }
 		}
-		
+
 		// get the buffering strategy
-		BufferingStrategies strategy = BufferingController.stringToBufferingStrategies(scope, (String)GamaPreferences.get(GamaPreferences.PREF_SAVE_BUFFERING_STRATEGY).value(scope));
+		BufferingStrategies strategy = BufferingController.stringToBufferingStrategies(scope,
+				(String) GamaPreferences.get(GamaPreferences.PREF_SAVE_BUFFERING_STRATEGY).value(scope));
 		if (bufferingStrategy != null) {
-			strategy = BufferingController.stringToBufferingStrategies(scope, (String)bufferingStrategy.value(scope));
+			strategy = BufferingController.stringToBufferingStrategies(scope, (String) bufferingStrategy.value(scope));
 		}
-		
+
 		try {
 			Files.createDirectories(fileToSave.toPath().getParent());
 			boolean exists = fileToSave.exists() || GAMA.getBufferingController().isFileWaitingToBeWritten(fileToSave);

--- a/gama.core/src/gama/gaml/statements/UsingStatement.java
+++ b/gama.core/src/gama/gaml/statements/UsingStatement.java
@@ -1,17 +1,15 @@
 /*******************************************************************************************************
  *
- * UsingStatement.java, in gama.core, is part of the source code of the
- * GAMA modeling and simulation platform .
+ * UsingStatement.java, in gama.core, is part of the source code of the GAMA modeling and simulation platform
+ * (v.2025-03).
  *
- * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
+ * (c) 2007-2025 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
  *
  * Visit https://github.com/gama-platform/gama for license information and contacts.
- * 
+ *
  ********************************************************************************************************/
 package gama.gaml.statements;
 
-import gama.annotations.precompiler.IConcept;
-import gama.annotations.precompiler.ISymbolKind;
 import gama.annotations.precompiler.GamlAnnotations.doc;
 import gama.annotations.precompiler.GamlAnnotations.example;
 import gama.annotations.precompiler.GamlAnnotations.facet;
@@ -19,6 +17,8 @@ import gama.annotations.precompiler.GamlAnnotations.facets;
 import gama.annotations.precompiler.GamlAnnotations.inside;
 import gama.annotations.precompiler.GamlAnnotations.symbol;
 import gama.annotations.precompiler.GamlAnnotations.usage;
+import gama.annotations.precompiler.IConcept;
+import gama.annotations.precompiler.ISymbolKind;
 import gama.core.common.interfaces.IKeyword;
 import gama.core.metamodel.topology.ITopology;
 import gama.core.runtime.IScope;
@@ -28,36 +28,56 @@ import gama.gaml.operators.Cast;
 import gama.gaml.types.IType;
 
 /**
- * "using" is a statement that allows to set the topology to use by its
- * sub-statements. They can gather it by asking the scope to provide it.
- * 
+ * "using" is a statement that allows to set the topology to use by its sub-statements. They can gather it by asking the
+ * scope to provide it.
+ *
  * @author drogoul 19 janv. 13
  */
-@symbol(name = IKeyword.USING, kind = ISymbolKind.SEQUENCE_STATEMENT, with_sequence = true, concept = {
-		IConcept.TOPOLOGY })
-@inside(kinds = { ISymbolKind.BEHAVIOR, ISymbolKind.SEQUENCE_STATEMENT, ISymbolKind.LAYER }, symbols = IKeyword.CHART)
-@facets(value = {
-		@facet(name = IKeyword.TOPOLOGY, type = IType.TOPOLOGY, optional = false, doc = @doc("the topology")) }, omissible = IKeyword.TOPOLOGY)
-@doc(value = "`" + IKeyword.USING
-		+ "` is a statement that allows to set the topology to use by its sub-statements. They can gather it by asking the scope to provide it.", usages = {
-				@usage(value = "All the spatial operations are topology-dependent (e.g. neighbors are not the same in a continuous and in a grid topology). So `"
+@symbol (
+		name = IKeyword.USING,
+		kind = ISymbolKind.SEQUENCE_STATEMENT,
+		with_sequence = true,
+		concept = { IConcept.TOPOLOGY })
+@inside (
+		kinds = { ISymbolKind.BEHAVIOR, ISymbolKind.SEQUENCE_STATEMENT, ISymbolKind.LAYER },
+		symbols = IKeyword.CHART)
+@facets (
+		value = { @facet (
+				name = IKeyword.TOPOLOGY,
+				type = IType.TOPOLOGY,
+				optional = false,
+				doc = @doc ("the topology")) },
+		omissible = IKeyword.TOPOLOGY)
+@doc (
+		value = "`" + IKeyword.USING
+				+ "` is a statement that allows to set the topology to use by its sub-statements. They can gather it by asking the scope to provide it.",
+		usages = { @usage (
+				value = "All the spatial operations are topology-dependent (e.g. neighbors are not the same in a continuous and in a grid topology). So `"
 						+ IKeyword.USING
-						+ "` statement allows modelers to specify the topology in which the spatial operation will be computed.", examples = {
-								@example(value = "float dist <- 0.0;", isExecutable = false),
-								@example(value = "using topology(grid_ant) {", isExecutable = false),
-								@example(value = "	d (self.location distance_to target.location);", isExecutable = false),
-								@example(value = "}", isExecutable = false) }) })
+						+ "` statement allows modelers to specify the topology in which the spatial operation will be computed.",
+				examples = { @example (
+						value = "float dist <- 0.0;",
+						isExecutable = false),
+						@example (
+								value = "using topology(grid_ant) {",
+								isExecutable = false),
+						@example (
+								value = "	d (self.location distance_to target.location);",
+								isExecutable = false),
+						@example (
+								value = "}",
+								isExecutable = false) }) })
 public class UsingStatement extends AbstractStatementSequence {
 
 	/** The topology. */
 	final IExpression topology;
-	
+
 	/** The previous. */
 	final ThreadLocal<ITopology> previous = new ThreadLocal<>();
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param desc,
 	 *            the description of the statement.
 	 */
@@ -68,9 +88,9 @@ public class UsingStatement extends AbstractStatementSequence {
 	}
 
 	/**
-	 * When entering the scope, the statement pushes the topology (if not null)
-	 * to it and remembers the one that was previously pushed.
-	 * 
+	 * When entering the scope, the statement pushes the topology (if not null) to it and remembers the one that was
+	 * previously pushed.
+	 *
 	 * @see gama.gaml.statements.AbstractStatementSequence#enterScope(gama.core.runtime.IScope)
 	 */
 	@Override
@@ -78,14 +98,14 @@ public class UsingStatement extends AbstractStatementSequence {
 		super.enterScope(scope);
 		final ITopology topo = Cast.asTopology(scope, topology.value(scope));
 		if (topo != null) {
-			previous.set(scope.setTopology(topo));
+			previous.set(scope.getTopology());
+			scope.setTopology(topo);
 		}
 	}
 
 	/**
-	 * When leaving the scope, the statement replaces its topology by the
-	 * previous one.
-	 * 
+	 * When leaving the scope, the statement replaces its topology by the previous one.
+	 *
 	 * @see gama.gaml.statements.AbstractStatementSequence#leaveScope(gama.core.runtime.IScope)
 	 */
 


### PR DESCRIPTION
Moved special context data (such as topology, 'each', and temporary output keys) from ExecutionScope's SpecialContext to direct variables and default methods in IScope. Removed unused or redundant methods, updated file handling to use new keys, and simplified variable and attribute management. This refactoring improves code clarity, thread safety, and maintainability, and addresses issues with variable pollution and context duplication.