### PR TITLE
docs: Add migration guide for GAMA Version 2026 (JDK 25 and Eclipse 2025-12)

### DIFF
--- a/CHANGELOG_2026.md
+++ b/CHANGELOG_2026.md
@@ -1,35 +1,59 @@
 # GAMA 2026 Changelog
 
-This document lists the major technical modifications and commits grouped by themes introduced in the GAMA Version 2026 update (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`).
+This document lists the major technical modifications and commits introduced in the GAMA Version 2026 update (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`).
+
+All commits listed below point to specific changes that drive the massive architectural evolution of this release.
 
 ## [2026.0.0] - Unreleased
 
-### Core Technology & Modern Java (JDK 25)
-*   **Platform Upgrade:** Rebased the entire project to require JDK 25 and target the Eclipse 2025-12 RCP environment.
-*   **Record adoption:** Converted heavily used classes (e.g., `GamlCompilationError`) into immutable Java records to improve safety and reduce memory overhead.
-*   **Pattern Matching:** Extensive refactoring to use Java pattern matching for `instanceof` (e.g., `SpeciesDescription` checks), greatly improving code readability and reducing explicit casts.
+### 🏗️ Architecture & Core API (`gama.api`)
+The new `gama.api` module has been created to decouple public interfaces from internal implementations (`gama.core`). Core types have been extensively relocated, and heavily used classes have been modernized to use Java Records.
 
-### Architecture & API Separation (`gama.api`)
-*   **Module extraction:** Created the isolated `gama.api` module. Hundreds of core interfaces (`IAgent`, `IPoint`, `IList`, `ITopology`) were moved here from `gama.core` and `gama.annotations` to guarantee stable public contracts for plugin developers.
-*   **Factory Generalization:** Centralized object creation via Factories (`GamaListFactory`, `GamaShapeFactory`, `GamaMapFactory`). `PoolUtils` was rewritten using concurrent queues and `AtomicLong` counters to safely pool instances like `AgentExecutionContext` and geometry factories.
-*   **Agent Encapsulation:** `IAgent` interface profoundly redesigned to extend `IDelegatingShape`, delegating geometry implementations securely. Modification of agent properties via the container interface is strictly blocked in favor of standard variable updates.
-*   **Population Centralization:** Extracted common population management logic (internal containers, grid handling, topology handling) into the `AbstractPopulation` base class to DRY the code. `IPopulation.createAgentAt()` renamed to `createAgentAtIndex()`.
-*   **Cast Evolution:** The massive `Cast` utility class was decentralized. Type conversion logic is now implemented by the respective `IType` classes. `GamaColorFactory.createFrom` renamed to `castToColor` to unify color coercion across layers and displays.
+*   `[79be879]` Create IDelegatingShape.java (Agent shape delegation)
+*   `[8e84ad3]` Use IDelegatingShape and remove IShape defaults
+*   `[cfa0b36]` Introduce AbstractPopulation and refactor populations
+*   `[33fff95]` Use record for GamlCompilationError and update callers
+*   `[0c26602]` Refactor envelope classes to utils.geometry
+*   `[8940dcc]` Restructure packages: move types & interfaces to gama.api
+*   `[13b2eea]` Add built-in platform and global species lookup
+*   `[f1c2e72]` Refactor color API, pooling and movement helpers (Cast to Color unification)
+*   `[7085b17]` Move GamaGeometryFactory; optimize GamaListFactory (Factory Generalization)
 
-### GAML Language, Compiler, & AST
-*   **Grammar Plugin Extraction:** The Xtext grammar definition (`Gaml.xtext`) has been extracted from the compiler into its own dedicated plugin (`gaml.grammar`), alongside optimization of parsing rules and code generators.
-*   **Object-Oriented GAML:** Native support introduced for `class` and `object` constructs, bridging the gap between agent-based modeling and classical software engineering for data modeling.
-*   **Stateless Compilation:** Re-engineered the expression compiler to be entirely stateless via `ExpressionCompilationContext` and `ExpressionCompilationSwitch`. Thread-local states were removed, significantly improving thread-safety and parallel compilation stability.
-*   **Validation Contexts:** Refactored `ValidationContext` and `IDocumentationContext` to separately track validations and documentation, reducing lock contention. `GamlResourceServices` rewritten to use thread-safe maps and atomic operations.
-*   **Cleaner Syntax:** Deprecated and removed noisy grammar keywords (`diffuse var:` becomes `diffuse`, `transition to:` becomes `transition`).
-*   **Syntax Enhancements:** Parameter lists (`with:`) now use parentheses and colons `(a:1)` instead of brackets and double-colons. Arrow expressions `->` no longer require curly braces around single statements.
+### 🚀 GAML Language & Compiler (AST)
+The GAML compiler has been completely rewritten into a stateless architecture, ensuring faster compilation. Furthermore, GAML now natively supports Object-Oriented concepts (`class` and `object`).
 
-### Concurrency & Parallel Execution
-*   **Multi-threading Optimizations:** Overhauled internal multi-threading mechanisms. Implemented a `ConcurrentHashMap` cache for parallel execution evaluation.
-*   **ForkJoin executor:** Upgraded the `AGENT_PARALLEL_EXECUTOR`. Switched the internal pool to async mode, customized the `ForkJoinWorkerThreadFactory`, and improved robustness against interrupts and timeouts during engine shutdown.
-*   **Parallel Steppers:** Switched agent result tracking in `ParallelAgentExecuter` and `ParallelAgentStepper` from `Boolean[]` arrays to high-performance `AtomicBoolean` implementations.
+*   `[ca3cded]` Add IClass and IObject interfaces
+*   `[e033a1c]` Add CLASS support and AST updates
+*   `[95e7f7e]` Add ClassDescription and refactor IClass/IObject
+*   `[5105a81]` Add class support and refactor constructors/actions
+*   `[99a015e]` Add gaml.grammar project and refactoring tools (Xtext Extraction)
+*   `[7c85472]` Make expression compilation stateless
+*   `[ee3b660]` Add documentation context and refactor validation
+*   `[fcf7321]` Reduce synchronization in import indexing
+*   `[a61ece7]` Make GamlResourceServices thread-safe
+*   `[b3fd49f]` Replace 'image' keyword with 'picture'
 
-### UI, Displays, & OpenGL
-*   **OpenGL 4.1 Native Engine:** Complete release of `gama.ui.display.opengl4`, the first pure OpenGL 4.1 Core Profile display plugin. Replaced legacy OpenGL 2 fixed pipelines with modern Shaders, VAOs, VBOs, and the JOML matrix math library.
-*   **New Launching Overlay:** Replaced the legacy loading screen with a modern, responsive launching overlay when loading and compiling experiments, preventing UI unresponsiveness.
-*   **Display Syntax:** The `image` layer inside display blocks was renamed to `picture`. Displays now strictly separate logical identifiers from user-visible string titles.
+### ⚡ Concurrency & Parallel Execution
+Massive performance upgrades taking advantage of JDK 25 multithreading enhancements for parallel agent execution.
+
+*   `[65a958e]` Improve ForkJoin executor and parallelism cache
+*   `[5e637b9]` Improve thread-safety and performance in statements
+*   `[dd3af06]` (via `a61ece7`) Thread-safe registry handling and Atomic ops
+
+### 🖥️ UI, Displays & OpenGL 4.1 Native
+A brand-new, blazing-fast native display plugin relying solely on OpenGL 4.1 Core Profile logic. Legacy APIs have been removed.
+
+*   `[47f55ee]` Migrate renderer to OpenGL 4 core profile
+*   `[7614445]` Migrate OpenGL4 renderer away from fixed-function
+*   `[973f54c]` Add FastTriangulation and use for polygons
+*   `[117e307]` Remove bundled JOGL and shaders from OpenGL4
+*   `[2322a83]` Introduce output title API and UI fixes (New overlay handling)
+
+### 🧹 Refactoring & Code Quality
+The codebase makes extensive use of new Java features like pattern matching, resulting in cleaner and more maintainable backend code.
+
+*   `[775b94c]` Refactor TypePair equals and descriptions (Pattern matching)
+*   `[6ff70b5]` Refactor annotations, replace literals with constants
+*   `[8440794]` Move IKeyword to annotations package
+*   `[c138702]` Add package-info and improve API Javadocs
+*   `[ac8b13c]` Migrate transition transformers from Python to Java

--- a/CHANGELOG_2026.md
+++ b/CHANGELOG_2026.md
@@ -1,29 +1,34 @@
 # GAMA 2026 Changelog
 
-All notable changes to the GAMA platform for the 2026 version (JDK 25 / Eclipse 2025-12 upgrade) will be documented in this file.
+This document lists the major technical modifications and commits grouped by themes introduced in the GAMA Version 2026 update (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`).
 
 ## [2026.0.0] - Unreleased
 
-### Added
-- **GAML Language:** Native support for `class` and `object` constructs, allowing for lightweight, object-oriented data structures without the overhead of full simulation agents.
-- **Graphics:** A brand new, highly optimized native display plugin (`gama.ui.display.opengl4`) built strictly on the OpenGL 4.1 Core Profile, utilizing Shaders, VAOs/VBOs, and the JOML math library.
-- **UI:** A new, responsive launching overlay that provides clear feedback during model compilation, agent initialization, and setup progress.
-- **Architecture (`gama.api`):** A brand new, isolated `gama.api` module acting as the definitive public contract for the platform, completely decoupling public interfaces from internal implementations.
-- **Architecture (Factories):** Generalization of the Factory pattern for core data structures (e.g., `GamaListFactory`, `GamaShapeFactory`, `GamaMapFactory`).
+### Core Technology & Modern Java (JDK 25)
+*   **Platform Upgrade:** Rebased the entire project to require JDK 25 and target the Eclipse 2025-12 RCP environment.
+*   **Record adoption:** Converted heavily used classes (e.g., `GamlCompilationError`) into immutable Java records to improve safety and reduce memory overhead.
+*   **Pattern Matching:** Extensive refactoring to use Java pattern matching for `instanceof` (e.g., `SpeciesDescription` checks), greatly improving code readability and reducing explicit casts.
 
-### Changed
-- **Platform:** Upgraded the underlying execution environment to Java Development Kit (JDK) 25 and the Eclipse 2025-12 Rich Client Platform.
-- **Performance:** Massive improvements to concurrency support (both internal engine multi-threading and GAML parallel operations) and significantly faster model compilation times due to AST restructuring.
-- **GAML Syntax (Arguments):** The syntax for parameter passing (`with:`) has been modernized from bracket/double-colon `[a::1]` to parenthesis/single-colon `(a:1)`.
-- **GAML Syntax (Arrow Functions):** The outermost curly braces surrounding the body of `->` (arrow) expressions are no longer required by the parser (`action my_action -> do something;`).
-- **GAML Syntax (Displays):** The layer previously known as `image` is renamed to `picture` to avoid keyword collisions. Displays and experiments now enforce a separation between programmatic identifiers and UI titles (`display My_Chart title: "My Chart"`).
-- **Core API (`IAgent`):** The `IAgent` interface has been profoundly redesigned for safety. It now extends `IDelegatingShape`, deprecates direct attribute mutation via container methods, and ensures `getPeers()` is strictly read-only.
-- **Core API (`IPopulation`):** Population logic is centralized into a new `AbstractPopulation` base class. Methods have been renamed for clarity (e.g., `createAgentAt` to `createAgentAtIndex`).
-- **Java Annotations:** The monolithic `GamlAnnotations` class has been flattened. All GAML annotations (`@operator`, `@species`, etc.) are now top-level interfaces in the `gama.annotations` package.
-- **Type Casting:** The central `Cast` utility class has been significantly reduced. Type conversions are now intelligently delegated directly to `IType` implementations.
-- **Utilities:** Core utilities and I/O methods (e.g., `FileUtils`, `GamaPreferences`, `StringUtils`) have been centralized and moved to the `gama.api.utils.*` package.
+### Architecture & API Separation (`gama.api`)
+*   **Module extraction:** Created the isolated `gama.api` module. Hundreds of core interfaces (`IAgent`, `IPoint`, `IList`, `ITopology`) were moved here from `gama.core` and `gama.annotations` to guarantee stable public contracts for plugin developers.
+*   **Factory Generalization:** Centralized object creation via Factories (`GamaListFactory`, `GamaShapeFactory`, `GamaMapFactory`). `PoolUtils` was rewritten using concurrent queues and `AtomicLong` counters to safely pool instances like `AgentExecutionContext` and geometry factories.
+*   **Agent Encapsulation:** `IAgent` interface profoundly redesigned to extend `IDelegatingShape`, delegating geometry implementations securely. Modification of agent properties via the container interface is strictly blocked in favor of standard variable updates.
+*   **Population Centralization:** Extracted common population management logic (internal containers, grid handling, topology handling) into the `AbstractPopulation` base class to DRY the code. `IPopulation.createAgentAt()` renamed to `createAgentAtIndex()`.
+*   **Cast Evolution:** The massive `Cast` utility class was decentralized. Type conversion logic is now implemented by the respective `IType` classes. `GamaColorFactory.createFrom` renamed to `castToColor` to unify color coercion across layers and displays.
 
-### Removed / Deprecated
-- **GAML Syntax:** The redundant keywords `var:` (in `diffuse` statements) and `to:` (in `transition` statements) have been deprecated and removed.
-- **Legacy Graphics:** Legacy OpenGL 2 fixed-function pipeline features (`glBegin`/`glEnd`, `glMatrixMode`) are no longer used by the primary OpenGL4 rendering engine.
-- **Direct Instantiation:** Direct constructor calls for core types (e.g., `new GamaList()`, `new GamaPoint()`) are strictly prohibited in plugin development, replaced entirely by Factories.
+### GAML Language, Compiler, & AST
+*   **Object-Oriented GAML:** Native support introduced for `class` and `object` constructs, bridging the gap between agent-based modeling and classical software engineering for data modeling.
+*   **Stateless Compilation:** Re-engineered the expression compiler to be entirely stateless via `ExpressionCompilationContext` and `ExpressionCompilationSwitch`. Thread-local states were removed, significantly improving thread-safety and parallel compilation stability.
+*   **Validation Contexts:** Refactored `ValidationContext` and `IDocumentationContext` to separately track validations and documentation, reducing lock contention. `GamlResourceServices` rewritten to use thread-safe maps and atomic operations.
+*   **Cleaner Syntax:** Deprecated and removed noisy grammar keywords (`diffuse var:` becomes `diffuse`, `transition to:` becomes `transition`).
+*   **Syntax Enhancements:** Parameter lists (`with:`) now use parentheses and colons `(a:1)` instead of brackets and double-colons. Arrow expressions `->` no longer require curly braces around single statements.
+
+### Concurrency & Parallel Execution
+*   **Multi-threading Optimizations:** Overhauled internal multi-threading mechanisms. Implemented a `ConcurrentHashMap` cache for parallel execution evaluation.
+*   **ForkJoin executor:** Upgraded the `AGENT_PARALLEL_EXECUTOR`. Switched the internal pool to async mode, customized the `ForkJoinWorkerThreadFactory`, and improved robustness against interrupts and timeouts during engine shutdown.
+*   **Parallel Steppers:** Switched agent result tracking in `ParallelAgentExecuter` and `ParallelAgentStepper` from `Boolean[]` arrays to high-performance `AtomicBoolean` implementations.
+
+### UI, Displays, & OpenGL
+*   **OpenGL 4.1 Native Engine:** Complete release of `gama.ui.display.opengl4`, the first pure OpenGL 4.1 Core Profile display plugin. Replaced legacy OpenGL 2 fixed pipelines with modern Shaders, VAOs, VBOs, and the JOML matrix math library.
+*   **New Launching Overlay:** Replaced the legacy loading screen with a modern, responsive launching overlay when loading and compiling experiments, preventing UI unresponsiveness.
+*   **Display Syntax:** The `image` layer inside display blocks was renamed to `picture`. Displays now strictly separate logical identifiers from user-visible string titles.

--- a/CHANGELOG_2026.md
+++ b/CHANGELOG_2026.md
@@ -1,0 +1,29 @@
+# GAMA 2026 Changelog
+
+All notable changes to the GAMA platform for the 2026 version (JDK 25 / Eclipse 2025-12 upgrade) will be documented in this file.
+
+## [2026.0.0] - Unreleased
+
+### Added
+- **GAML Language:** Native support for `class` and `object` constructs, allowing for lightweight, object-oriented data structures without the overhead of full simulation agents.
+- **Graphics:** A brand new, highly optimized native display plugin (`gama.ui.display.opengl4`) built strictly on the OpenGL 4.1 Core Profile, utilizing Shaders, VAOs/VBOs, and the JOML math library.
+- **UI:** A new, responsive launching overlay that provides clear feedback during model compilation, agent initialization, and setup progress.
+- **Architecture (`gama.api`):** A brand new, isolated `gama.api` module acting as the definitive public contract for the platform, completely decoupling public interfaces from internal implementations.
+- **Architecture (Factories):** Generalization of the Factory pattern for core data structures (e.g., `GamaListFactory`, `GamaShapeFactory`, `GamaMapFactory`).
+
+### Changed
+- **Platform:** Upgraded the underlying execution environment to Java Development Kit (JDK) 25 and the Eclipse 2025-12 Rich Client Platform.
+- **Performance:** Massive improvements to concurrency support (both internal engine multi-threading and GAML parallel operations) and significantly faster model compilation times due to AST restructuring.
+- **GAML Syntax (Arguments):** The syntax for parameter passing (`with:`) has been modernized from bracket/double-colon `[a::1]` to parenthesis/single-colon `(a:1)`.
+- **GAML Syntax (Arrow Functions):** The outermost curly braces surrounding the body of `->` (arrow) expressions are no longer required by the parser (`action my_action -> do something;`).
+- **GAML Syntax (Displays):** The layer previously known as `image` is renamed to `picture` to avoid keyword collisions. Displays and experiments now enforce a separation between programmatic identifiers and UI titles (`display My_Chart title: "My Chart"`).
+- **Core API (`IAgent`):** The `IAgent` interface has been profoundly redesigned for safety. It now extends `IDelegatingShape`, deprecates direct attribute mutation via container methods, and ensures `getPeers()` is strictly read-only.
+- **Core API (`IPopulation`):** Population logic is centralized into a new `AbstractPopulation` base class. Methods have been renamed for clarity (e.g., `createAgentAt` to `createAgentAtIndex`).
+- **Java Annotations:** The monolithic `GamlAnnotations` class has been flattened. All GAML annotations (`@operator`, `@species`, etc.) are now top-level interfaces in the `gama.annotations` package.
+- **Type Casting:** The central `Cast` utility class has been significantly reduced. Type conversions are now intelligently delegated directly to `IType` implementations.
+- **Utilities:** Core utilities and I/O methods (e.g., `FileUtils`, `GamaPreferences`, `StringUtils`) have been centralized and moved to the `gama.api.utils.*` package.
+
+### Removed / Deprecated
+- **GAML Syntax:** The redundant keywords `var:` (in `diffuse` statements) and `to:` (in `transition` statements) have been deprecated and removed.
+- **Legacy Graphics:** Legacy OpenGL 2 fixed-function pipeline features (`glBegin`/`glEnd`, `glMatrixMode`) are no longer used by the primary OpenGL4 rendering engine.
+- **Direct Instantiation:** Direct constructor calls for core types (e.g., `new GamaList()`, `new GamaPoint()`) are strictly prohibited in plugin development, replaced entirely by Factories.

--- a/CHANGELOG_2026.md
+++ b/CHANGELOG_2026.md
@@ -17,6 +17,7 @@ This document lists the major technical modifications and commits grouped by the
 *   **Cast Evolution:** The massive `Cast` utility class was decentralized. Type conversion logic is now implemented by the respective `IType` classes. `GamaColorFactory.createFrom` renamed to `castToColor` to unify color coercion across layers and displays.
 
 ### GAML Language, Compiler, & AST
+*   **Grammar Plugin Extraction:** The Xtext grammar definition (`Gaml.xtext`) has been extracted from the compiler into its own dedicated plugin (`gaml.grammar`), alongside optimization of parsing rules and code generators.
 *   **Object-Oriented GAML:** Native support introduced for `class` and `object` constructs, bridging the gap between agent-based modeling and classical software engineering for data modeling.
 *   **Stateless Compilation:** Re-engineered the expression compiler to be entirely stateless via `ExpressionCompilationContext` and `ExpressionCompilationSwitch`. Thread-local states were removed, significantly improving thread-safety and parallel compilation stability.
 *   **Validation Contexts:** Refactored `ValidationContext` and `IDocumentationContext` to separately track validations and documentation, reducing lock contention. `GamlResourceServices` rewritten to use thread-safe maps and atomic operations.

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -1,39 +1,88 @@
-# Comprehensive Migration Guide: GAMA Version 2026 (Eclipse 2025-12 and JDK 25)
+# GAMA Version 2026: Innovations and Comprehensive Migration Guide
 
-This document provides a comprehensive and exhaustive reference of the API, architectural, and syntax changes introduced between the previous version of GAMA (on the `main` branch) and the 2026 version (on the `Upgrade-to-Eclipse-2025-12-and-JDK-25` branch).
-
-The goal of this massive update is to modernize GAMA, improve compatibility with modern standards (JDK 25, Eclipse 2025-12), and cleanly separate implementation details from the public API by introducing a brand-new module: **`gama.api`**.
+This document is divided into two major sections. The **first part** details the profound innovations, technological leaps, and grammatical evolutions introduced in GAMA Version 2026 (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`). The **second part** serves as an exhaustive, technical migration reference guide for developers and modelers transitioning from previous versions.
 
 ---
 
+# Part 1: Innovations in GAMA and GAML (Version 2026)
+
+GAMA 2026 represents one of the most significant architectural overhauls in the history of the platform. More than just an incremental update, it is a foundational leap designed to secure GAMA’s future, enhance the modeler’s experience, and provide a robust, modern API for plugin developers. The modifications span across over 10,000 files, touching every aspect of the engine, the language, and the user interface.
+
+## 1. Technological Leap: Embracing JDK 25 and Eclipse 2025-12
+
+At its core, GAMA 2026 abandons legacy Java constraints by upgrading directly to **Java Development Kit (JDK) 25** and the **Eclipse 2025-12** Rich Client Platform.
+
+### What this brings to the platform:
+*   **Performance and Memory Management:** JDK 25 introduces cutting-edge garbage collection optimizations, improved thread management, and underlying enhancements that directly translate to faster simulation execution times and a reduced memory footprint for massive agent-based models.
+*   **Modern Java Features:** For plugin developers, this means the ability to use modern Java paradigms. The codebase has been extensively refactored to utilize features like **Pattern Matching for `instanceof`** (e.g., `if (obj instanceof MyClass myVar) { ... }`), Records, and Switch Expressions. This drastically reduces boilerplate code, minimizes casting errors, and improves code readability across the entire platform.
+*   **Future-Proofing the IDE:** By aligning with the upcoming Eclipse 2025-12 release, GAMA ensures continued support for the latest OS updates, high-DPI displays, and modern UI rendering engines.
+
+## 2. The Language Evolution: A Cleaner, Modern GAML
+
+The GAML language (GAMA Modeling Language) has been refined to be more intuitive, concise, and aligned with modern programming aesthetics. The goal was to remove unnecessary verbosity and "boilerplate" syntax that hindered readability without adding semantic value.
+
+### Key Grammatical Innovations:
+*   **Streamlined Parameter Passing (`with:`):** The legacy syntax for passing arguments to actions or creating agents involved clunky brackets and double colons (e.g., `with: [a::1, b::2]`). GAMA 2026 introduces a much cleaner, JSON-like syntax using parentheses and single colons: **`with: (a:1, b:2)`**. This makes model code significantly easier to read and write.
+*   **Flattening of Arrow Functions (`->`):** Previously, defining inline actions or evaluations required surrounding the body in curly braces: `action my_action -> { do something; };`. The parser now intelligently handles the arrow operator without requiring the outermost braces: **`action my_action -> do something;`**. This functional programming style allows for highly expressive, one-line declarations.
+*   **Removal of Redundant Keywords:**
+    *   The `diffuse` statement no longer requires the `var:` keyword. `diffuse var: heat` is now simply **`diffuse heat`**.
+    *   The `transition` statement inside state machines no longer uses `to:`. `transition to: next_state` is now just **`transition next_state`**.
+*   **Separating Identifiers from Titles:** In previous versions, displays and experiments could be named using a string (e.g., `display "My Chart"`), which internally acted as an awkward identifier. GAMA 2026 enforces a clear separation between the programmatic identifier and the human-readable UI title: **`display My_Chart title: "My Chart"`**. This eliminates internal parsing ambiguities and bugs related to special characters in names.
+*   **Contextual Clarity (`image` vs. `picture`):** To avoid keyword collisions and confusion, the display layer used for rendering images has been renamed from `image` to **`picture`**.
+
+## 3. The Architectural Revolution: The `gama.api` Module
+
+For years, GAMA extension developers struggled with a monolithic `gama.core` module where public interfaces were entangled with internal implementations.
+
+GAMA 2026 introduces **`gama.api`**, a completely new, isolated module that serves as the definitive public contract for the platform.
+
+### Why this is a game-changer:
+*   **True Encapsulation:** Implementation details are now hidden. Plugin developers rely solely on interfaces (`IPoint`, `IAgent`, `IList`, `IGraph`) located in `gama.api`. This guarantees that internal optimizations in `gama.core` will not break third-party plugins in the future.
+*   **Interface-Driven Design:** Methods across the platform now strictly return interfaces rather than concrete classes. For instance, `agent.getLocation()` returns an `IPoint` rather than a `GamaPoint`. This allows the engine to swap out underlying implementations (e.g., swapping a standard point for a highly optimized, memory-mapped spatial coordinate) without the modeler or plugin developer ever noticing.
+
+## 4. Reinventing the Core: `IAgent`, `IPopulation`, and Factories
+
+Under the hood, the fundamental building blocks of a simulation have been redesigned for safety, speed, and consistency.
+
+*   **The `IAgent` Interface Redefined:** The agent interface has been stripped of direct shape inheritance and mutable container properties. It now extends `IDelegatingShape`, delegating geometry handling to specialized, swappable components. Furthermore, direct attribute mutation via the container interface is deprecated; attributes must be accessed via robust GAML variables, preventing untracked state changes.
+*   **Population Centralization:** The logic that manages collections of agents has been centralized into an `AbstractPopulation` base class. This DRY (Don't Repeat Yourself) approach eliminates inconsistencies between grid populations, standard agent populations, and graph-based populations, making the engine much easier to maintain.
+*   **The Factory Pattern Generalization:** To support the `gama.api` encapsulation, the direct instantiation of core types using `new` (e.g., `new GamaList()`) is strictly prohibited. Everything is now created via Factories (`GamaListFactory.create()`, `GamaShapeFactory.buildCircle()`). This is a crucial innovation: it gives the GAMA kernel absolute control over memory allocation, allowing it to pool objects, reuse memory, and optimize data structures transparently based on the simulation's needs.
+
+## 5. Cleaning the Utilities and Annotations
+
+*   **Flattening Annotations:** The GAML annotation framework (used by developers to define `@operator`, `@species`, `@action`) was previously nested inside a massive `GamlAnnotations` class. In 2026, these are now elegant, top-level interfaces directly in the `gama.annotations` package, greatly cleaning up Java imports and class definitions.
+*   **The Fall of the Monolithic `Cast` Class:** Type casting in Java plugins used to be routed through a single, gigantic `Cast` utility class. This created a massive bottleneck and architectural dependency nightmare. In 2026, casting logic has been decentralized. Each `IType` implementation now knows how to cast objects to itself (e.g., `Types.POINT.cast(...)`), adhering to solid object-oriented design principles and improving extensibility.
+
+***
+
+# Part 2: Comprehensive Migration Guide
+
+This section provides an exhaustive reference of the API, architectural, and syntax changes.
+
 ## 1. GAML Language Syntax Changes
 
-The GAML grammar and parser have been significantly updated. Below is the exhaustive list of syntax modifications. Existing models may need to be updated.
+Existing `.gaml` models will need to be updated to comply with the new grammar.
 
 ### 1.1 Flattening of Arrow (`->`) Braces
-The outermost curly braces surrounding the body of `->` (arrow) expressions are now removed by the parser.
+The outermost curly braces surrounding the body of `->` (arrow) expressions are removed.
 *   **Before:** `action my_action -> { do something; };`
 *   **After:** `action my_action -> do something;`
 
 ### 1.2 Deprecation of `diffuse var:` and `transition to:`
-The verbose keywords `var:` and `to:` are no longer used in `diffuse` and `transition` statements.
 *   **Before:** `diffuse var: heat`
 *   **After:** `diffuse heat`
 *   **Before:** `transition to: idle`
 *   **After:** `transition idle`
 
 ### 1.3 Renaming `image` to `picture` in Displays
-To avoid keyword collisions and improve clarity, the `image` layer inside `display` blocks is renamed to `picture`.
 *   **Before:** `display my_disp { image "background.jpg"; }`
 *   **After:** `display my_disp { picture "background.jpg"; }`
 
 ### 1.4 Explicit `title:` for Displays and Experiments
-Display and experiment names declared only as strings are now rewritten to separate the identifier from the human-readable title.
 *   **Before:** `display "3 Simulations"`
 *   **After:** `display _3_Simulations title: "3 Simulations"`
 
 ### 1.5 Evolution of the `with:` argument list
-The `with:` syntax for parameter passing has been modernized from bracket/double-colon `[::]` to parenthesis/single-colon `(:)`.
 *   **Before:** `with: [agents::ag, values::[1,2,3]]`
 *   **After:** `with: (agents:ag, values:[1,2,3])`
 
@@ -41,46 +90,41 @@ The `with:` syntax for parameter passing has been modernized from bracket/double
 
 ## 2. Java Annotations Flattening (`gama.annotations`)
 
-The global `GamlAnnotations` class (which previously contained all the `@interface` definitions as inner classes) has been flattened. Annotations are now top-level interfaces in the `gama.annotations` package.
+You must update your imports from `gama.annotations.precompiler.GamlAnnotations.*` to `gama.annotations.*` for all GAML annotations.
 
 **Exhaustive list of migrated annotations:**
-You must update your imports from `gama.annotations.precompiler.GamlAnnotations.*` to `gama.annotations.*` for the following:
 `@action`, `@arg`, `@constant`, `@display`, `@doc`, `@example`, `@experiment`, `@facet`, `@facets`, `@file`, `@getter`, `@inside`, `@listener`, `@no_test`, `@operator`, `@setter`, `@skill`, `@species`, `@symbol`, `@test`, `@type`, `@usage`, `@variable`, `@vars`, `@factory`.
 
 **Example:**
 *   **Before:** `@gama.annotations.precompiler.GamlAnnotations.operator(value = "my_operator")`
 *   **After:** `@gama.annotations.operator(value = "my_operator")`
 
-Additionally, `IKeyword` has moved from `gama.core.common.interfaces.IKeyword` to `gama.annotations.constants.IKeyword`.
+*Note: `IKeyword` has moved from `gama.core.common.interfaces.IKeyword` to `gama.annotations.constants.IKeyword`.*
 
 ---
 
 ## 3. Redesign of the `IAgent` Interface
 
-The root interface for agents, `IAgent`, has undergone profound structural modifications to enhance encapsulation.
-
 *   **Location:** Moved from `gama.core.metamodel.agent.IAgent` to `gama.api.kernel.agent.IAgent`.
 *   **Inheritance:** No longer extends `IShape` and `IAttributed`. It now extends `IDelegatingShape`.
-*   **Container Interface:** Changed from `IContainer.Addressable<String, Object>` to `IContainer.ToGet<String, Object>`. Direct attribute mutation via the container is forbidden.
-*   **Geometry:** Methods like `getLocation()` now return `IPoint` instead of `GamaPoint`. `getGeometry()` returns `IShape`.
-*   **Peers:** The `getPeers()` method returns a conceptually read-only list. The `setPeers()` default implementation is empty.
+*   **Container Interface:** Changed from `IContainer.Addressable<String, Object>` to `IContainer.ToGet<String, Object>`.
+*   **Geometry:** `getLocation()` now returns `IPoint` instead of `GamaPoint`. `getGeometry()` returns `IShape`.
+*   **Peers:** `getPeers()` returns a read-only list. The `setPeers()` default implementation is empty.
 
 ---
 
 ## 4. Redesign of Populations (`AbstractPopulation`)
 
-*   **Base Class:** Common population logic is now centralized in `gama.core.metamodel.population.AbstractPopulation`. `GamaPopulation` extends it.
+*   **Base Class:** Common logic centralized in `gama.core.metamodel.population.AbstractPopulation`.
 *   **API Updates (`IPopulation`):**
     *   `IsLiving` nested predicate: **Removed**.
     *   `createAgentAt(...)`: **Renamed** to `createAgentAtIndex(...)`.
     *   `createOneAgent(...)`: **Added** as a default method.
-    *   `fireAgentsAdded`: No longer a default method; delegated to implementations.
+    *   `fireAgentsAdded`: No longer a default method.
 
 ---
 
 ## 5. Exhaustive Package Mapping: The `gama.api` Module
-
-The creation of the `gama.api` module required the relocation of hundreds of interfaces, types, and factories. Below is the exhaustive list of the most important structural migrations.
 
 **Action:** Update imports systematically from `gama.core.*` to `gama.api.*`.
 
@@ -122,7 +166,6 @@ The creation of the `gama.api` module required the relocation of hundreds of int
 
 ## 6. Generalization of Factories for Instantiation
 
-A major architectural shift in GAMA 2026 is the **generalization of the Factory pattern** for creating core data structures and geometries.
 You must no longer use direct constructors (e.g., `new GamaList(...)`, `new GamaPoint(...)`).
 
 **Exhaustive Migration Examples:**
@@ -150,8 +193,6 @@ You must no longer use direct constructors (e.g., `new GamaList(...)`, `new Gama
 
 ## 7. Evolution of Casting Mechanisms (The `Cast` class)
 
-The central `Cast` class, previously located at `gama.core.gaml.operators.Cast`, handled almost all type conversions.
-
 1.  **Moved to API:** Located at `gama.api.gaml.types.Cast`.
 2.  **Decreased Role:** Static cast methods specific to data structures have been removed.
 3.  **Delegation:** Type casting is now handled directly by the target `IType` implementations.
@@ -175,8 +216,3 @@ The central `Cast` class, previously located at `gama.core.gaml.operators.Cast`,
     *   *After:* `Types.MATRIX.cast(scope, obj, null, false)`
 
 *Note: Primitive conversions like `asInt`, `asFloat`, `asString`, and `asAgent` remain in `gama.api.gaml.types.Cast`.*
-
----
-
-**Note for CI/CD developers:**
-Ensure that your local build environments (Maven Tycho) and CI pipelines use **JDK 25** (or higher) and the Eclipse 2025-12 target platform to successfully compile this new version of GAMA.

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -208,3 +208,71 @@ The central `Cast` class, which was previously a massive utility class in `gama.
     ```
 
 *Note: Some very generic casts or base type conversions (like `asInt`, `asFloat`, `asString`, `asAgent`) are still present in the new `gama.api.gaml.types.Cast` utility, but for structured types, always prefer using `Types.YOUR_TYPE.cast(...)`.*
+
+
+## 8. Flattening of GAML Annotations (`gama.annotations`)
+
+A significant syntactic change affects all GAMA extension and plugin developers: the global `GamlAnnotations` class (which previously contained all the `@interface` definitions as inner classes) has been flattened.
+
+Annotations are now top-level interfaces in the `gama.annotations` package.
+
+**Required Action:** You must update your imports and the way you declare annotations on your Java classes and methods.
+
+**Systematic Migration Examples for Annotations:**
+
+*   **Operator Definition**
+    ```java
+    // BEFORE
+    import gama.annotations.precompiler.GamlAnnotations.operator;
+    import gama.annotations.precompiler.GamlAnnotations.doc;
+
+    @operator(value = "my_operator", can_be_const = true)
+    @doc("Returns something")
+    public Object myOperator(...) { ... }
+
+    // AFTER
+    import gama.annotations.operator;
+    import gama.annotations.doc;
+
+    @operator(value = "my_operator", can_be_const = true)
+    @doc("Returns something")
+    public Object myOperator(...) { ... }
+    ```
+
+*   **Action Definition**
+    ```java
+    // BEFORE
+    import gama.annotations.precompiler.GamlAnnotations.action;
+
+    @action(name = "my_action")
+    public Object myAction(...) { ... }
+
+    // AFTER
+    import gama.annotations.action;
+
+    @action(name = "my_action")
+    public Object myAction(...) { ... }
+    ```
+
+*This applies systematically to all annotations: `@species`, `@skill`, `@getter`, `@setter`, `@variable`, `@vars`, `@type`, `@symbol`, `@display`, `@experiment`, etc.*
+
+---
+
+## 9. UI and Display Interfaces Extraction (`gama.api.ui`)
+
+In alignment with the core architecture extraction, the graphical and user interface APIs have been separated from their Eclipse RCP, SWT, Java2D, or OpenGL implementations. The core interfaces now reside in the `gama.api.ui` package.
+
+If your plugin interacts with the UI, dialogs, or display surfaces, you need to update the following references:
+
+*   **General UI and Dialogs:**
+    *   `gama.core.common.interfaces.IGui` $\rightarrow$ `gama.api.ui.IGui`
+    *   `gama.api.ui.IDialogFactory` (new factory for user dialogs, file dialogs, etc.)
+*   **Displays and Graphics:**
+    *   `gama.core.outputs.display.IDisplaySurface` $\rightarrow$ `gama.api.ui.displays.IDisplaySurface`
+    *   `gama.core.common.interfaces.IGraphics` $\rightarrow$ `gama.api.ui.displays.IGraphics`
+    *   `gama.core.outputs.LayeredDisplayData` $\rightarrow$ `gama.api.ui.displays.IDisplayData`
+*   **Layers:**
+    *   `gama.core.outputs.layers.ILayer` $\rightarrow$ `gama.api.ui.layers.ILayer`
+    *   `gama.api.ui.layers.IDrawingAttributes` (used to encapsulate styling when drawing shapes).
+
+---

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -52,7 +52,9 @@ While GAMA has always been Agent-based (where species define agents with complex
 
 ## 3. The Language Evolution: A Cleaner, Faster GAML
 
-The GAML syntax has been refined to be more intuitive, concise, and aligned with modern programming aesthetics. Furthermore, the underlying Xtext compiler has been rewritten with a strict AST.
+The Xtext grammar definition (`Gaml.xtext`) has been entirely extracted from the compiler into its own dedicated plugin (`gaml.grammar`). This separation of concerns allowed for massive optimization of the parsing rules and code generators.
+
+Furthermore, the GAML syntax has been refined to be more intuitive, concise, and aligned with modern programming aesthetics. Furthermore, the underlying Xtext compiler has been rewritten with a strict AST.
 
 *   **Faster Compilation:** The rigid formalization of the AST (`SyntacticAttributeElement`, `SyntacticClassElement`) and optimized parsing rules mean that large models compile and initialize significantly faster than in previous versions.
 *   **Streamlined Parameter Passing (`with:`):** The legacy syntax `with: [a::1, b::2]` is replaced by a cleaner, JSON-like syntax: **`with: (a:1, b:2)`**.

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -1,0 +1,94 @@
+# Guide de Migration : GAMA Version 2026 (Eclipse 2025-12 et JDK 25)
+
+Ce document décrit les changements architecturaux et d'API majeurs intervenus entre la version précédente de GAMA (sur la branche `main`) et la version 2026 (sur la branche `Upgrade-to-Eclipse-2025-12-and-JDK-25`).
+
+L'objectif de cette mise à jour massive (plus de 10 000 fichiers modifiés) est de moderniser GAMA, d'améliorer sa compatibilité avec les standards récents (JDK 25, Eclipse 2025-12) et de séparer les détails d'implémentation de l'API publique via la création d'un tout nouveau module `gama.api`.
+
+---
+
+## 1. Changements de Modules et Importations (Création de `gama.api`)
+
+Le changement le plus impactant pour les développeurs d'extensions GAMA est la création du module **`gama.api`**.
+Auparavant, la plupart des interfaces publiques et des utilitaires étaient mélangés avec le code d'implémentation dans `gama.core` ou `gama.annotations`.
+
+**Action requise :** La majorité de vos imports pointant vers `gama.core.*` ou `gama.annotations.*` devront être mis à jour vers `gama.api.*`.
+
+### Correspondances des packages principaux :
+*   **Types de base :**
+    *   `gama.core.common.interfaces.ITyped` $\rightarrow$ `gama.api.gaml.types.ITyped`
+    *   `gama.gaml.types.IType` $\rightarrow$ `gama.api.gaml.types.IType`
+    *   `gama.gaml.types.ITypesManager` $\rightarrow$ `gama.api.gaml.types.ITypesManager`
+*   **Collections :**
+    *   `gama.core.util.IList` $\rightarrow$ `gama.api.types.list.IList`
+    *   `gama.core.util.graph.IGraph` $\rightarrow$ `gama.api.types.graph.IGraph`
+*   **Géométrie et Topologie :**
+    *   La classe concrète `GamaPoint` est remplacée par l'interface `IPoint` dans les signatures de l'API (`gama.api.types.geometry.IPoint`).
+    *   `gama.core.metamodel.topology.ITopology` $\rightarrow$ `gama.api.types.topology.ITopology`
+*   **AST et Expressions :**
+    *   `gama.gaml.expressions.IExpression` $\rightarrow$ `gama.api.gaml.expressions.IExpression`
+    *   `gama.gaml.statements.IStatement` $\rightarrow$ `gama.api.gaml.statements.IStatement`
+
+---
+
+## 2. Refonte de l'interface `IAgent`
+
+L'interface racine des agents, `IAgent`, a subi de profondes modifications structurelles.
+
+1.  **Changement de Package :**
+    *   *Ancien :* `gama.core.metamodel.agent.IAgent`
+    *   *Nouveau :* `gama.api.kernel.agent.IAgent`
+2.  **Héritage et Géométrie :**
+    *   `IAgent` n'hérite plus directement de `IShape` et `IAttributed`.
+    *   Il hérite désormais de `IDelegatingShape`, ce qui permet une meilleure séparation des responsabilités concernant la géométrie de l'agent.
+3.  **Utilisation des Interfaces Géométriques :**
+    *   Les méthodes comme `getLocation()` et `setLocation(...)` retournent et prennent désormais une interface `IPoint` au lieu de la classe concrète `GamaPoint`.
+4.  **Gestion des Attributs et Conteneurs :**
+    *   `IAgent` n'étend plus `IContainer.Addressable<String, Object>`.
+    *   Il étend désormais `IContainer.ToGet<String, Object>`. Les modifications directes d'attributs via l'interface conteneur nécessitent de passer par les mécanismes de variables du GAML (`IVariable`) ou de `IVarAndActionSupport`.
+5.  **Propriété `peers` :**
+    *   La liste des agents pairs (`getPeers()`) est désormais considérée conceptuellement comme étant en **lecture seule**.
+    *   L'implémentation par défaut de la méthode `setPeers(IList<IAgent> peers)` dans `IAgent` est vide. Ne comptez plus sur cette méthode pour modifier le voisinage d'un agent.
+
+---
+
+## 3. Refonte des Populations (`IPopulation` et `AbstractPopulation`)
+
+La gestion interne des populations d'agents a été refactorisée pour réduire la duplication de code et clarifier l'API.
+
+1.  **Introduction de `AbstractPopulation` :**
+    *   La logique commune (conteneur d'agents interne, gestion des miroirs, de la topologie, `init` et `step`) a été extraite dans une nouvelle classe abstraite de base : `AbstractPopulation`.
+    *   `GamaPopulation` a été refactorisée pour étendre cette classe abstraite.
+2.  **Changements dans l'API `IPopulation` :**
+    *   **Suppression** : Le prédicat imbriqué `IsLiving` a été retiré.
+    *   **Renommage** : La méthode `createAgentAt(...)` est renommée en `createAgentAtIndex(...)`. *Tous les appels existants doivent être mis à jour.*
+    *   **Ajout** : Une méthode par défaut `createOneAgent(...)` a été ajoutée.
+    *   **Changement de comportement** : La méthode `fireAgentsAdded` n'est plus une méthode par défaut dans l'interface, son implémentation est déléguée aux classes concrètes.
+
+---
+
+## 4. Compilateur et Parseur GAML (`gaml.compiler`)
+
+De très gros changements ont eu lieu dans le compilateur Xtext GAML.
+
+1.  **AST Strictement Typé :**
+    *   Création de nombreux éléments syntaxiques formels : `SyntacticAttributeElement`, `SyntacticSpeciesElement`, `SyntacticModelElement`, etc.
+2.  **Descriptions :**
+    *   Les fabriques (`DescriptionFactory`) et les objets de descriptions (comme `SpeciesDescription`, `ModelDescription`, `StatementDescription`) ont été remaniés et déplacés.
+3.  **Ressources et Shaders GLSL :**
+    *   Les shaders GLSL (pour le plugin `gama.ui.display.opengl4`) ne sont plus stockés sous forme de chaînes de caractères (String literals) dans le code Java.
+    *   Ils doivent obligatoirement être placés dans des fichiers `.vert` et `.frag` dédiés dans un sous-dossier `glsl` du plugin et chargés dynamiquement avec `getClass().getResourceAsStream()`.
+
+---
+
+## 5. Utilitaires et I/O (`gama.api.utils.*`)
+
+La gestion des fichiers et les bibliothèques utilitaires ont été rationalisées et isolées dans `gama.api.utils`.
+
+*   **Refactorisation de `FileUtils` :** Les méthodes d'I/O ont été centralisées. L'utilisation d'anciens utilitaires dispersés doit être remplacée par l'API centralisée dans `gama.api.utils.files.FileUtils`.
+*   **Outils Généraux :** De nombreux utilitaires (`GamaPreferences`, `StringUtils`, manipulations `CSV` et `JSON`, générateurs aléatoires `GamaRNG`) ont été déplacés dans `gama.api.utils.*`.
+*   **Pattern Matching :** L'utilisation du *pattern matching* Java pour `instanceof` est désormais la norme (introduite avec la migration JDK), ce qui simplifie grandement les tests de types dans les implémentations (`if (obj instanceof MyClass myVar) { ... }`).
+
+---
+
+**Note pour les développeurs CI/CD :**
+Veillez à ce que vos environnements de compilation locaux (Maven Tycho) et CI utilisent bien le **JDK 25** (ou supérieur) pour pouvoir compiler cette nouvelle version de GAMA.

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -167,3 +167,44 @@ File management and utility libraries have been streamlined and isolated within 
 
 **Note for CI/CD developers:**
 Ensure that your local build environments (Maven Tycho) and CI pipelines use **JDK 25** (or higher) and the Eclipse 2025-12 target platform to successfully compile this new version of GAMA.
+
+## 7. Evolution of Casting Mechanisms (The `Cast` class)
+
+The central `Cast` class, which was previously a massive utility class in `gama.core.gaml.operators.Cast` handling almost all type conversions in Java, has been refactored.
+
+1.  **Moved to API:** The class is now located at `gama.api.gaml.types.Cast`.
+2.  **Decreased Role:** Its role has been significantly decreased. Many static cast methods specific to data structures (e.g., `asPoint`, `asList`, `asMap`, `asMatrix`, `asGeometry`) have been **removed** from the `Cast` class.
+3.  **Delegation to Types and Factories:** Type casting and conversions are now handled directly by the static methods within the target `IType` implementations or via the corresponding `Factory`.
+
+**Systematic Migration Examples for Casting:**
+
+*   **Casting to a Point (`IPoint`)**
+    ```java
+    // BEFORE
+    import gama.gaml.operators.Cast;
+    GamaPoint p = Cast.asPoint(scope, someObject);
+
+    // AFTER
+    import gama.api.gaml.types.Types;
+    IPoint p = Types.POINT.cast(scope, someObject, null, false);
+    ```
+
+*   **Casting to a List (`IList`)**
+    ```java
+    // BEFORE
+    IList list = Cast.asList(scope, someObject);
+
+    // AFTER
+    IList list = Types.LIST.cast(scope, someObject, null, false);
+    ```
+
+*   **Casting to a Geometry (`IShape`)**
+    ```java
+    // BEFORE
+    IShape shape = Cast.asGeometry(scope, someObject);
+
+    // AFTER
+    IShape shape = Types.GEOMETRY.cast(scope, someObject, null, false);
+    ```
+
+*Note: Some very generic casts or base type conversions (like `asInt`, `asFloat`, `asString`, `asAgent`) are still present in the new `gama.api.gaml.types.Cast` utility, but for structured types, always prefer using `Types.YOUR_TYPE.cast(...)`.*

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -1,57 +1,90 @@
 # GAMA Version 2026: Innovations and Comprehensive Migration Guide
 
-This document is divided into two major sections. The **first part** details the profound innovations, technological leaps, and grammatical evolutions introduced in GAMA Version 2026 (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`). The **second part** serves as an exhaustive, technical migration reference guide for developers and modelers transitioning from previous versions.
+This document is divided into three major sections. **Part 0** offers a complete, summarized ChangeLog. **Part 1** details the profound innovations, technological leaps, and grammatical evolutions introduced in GAMA Version 2026 (branch `Upgrade-to-Eclipse-2025-12-and-JDK-25`). **Part 2** serves as an exhaustive, technical migration reference guide for developers and modelers transitioning from previous versions.
+
+---
+
+# Part 0: Executive Summary & ChangeLog
+
+This high-level ChangeLog summarizes the entire scope of the GAMA Version 2026 update.
+
+### Core Technology & Architecture
+*   **JDK 25 & Eclipse 2025-12:** Platform entirely upgraded to the latest Java Development Kit (JDK 25) and Eclipse 2025-12 RCP.
+*   **Module Split (`gama.api`):** Creation of the `gama.api` module. Complete decoupling of public interfaces (`IAgent`, `IPoint`, `IList`) from implementation details (`gama.core`).
+*   **Factory Generalization:** Direct constructors (e.g., `new GamaList()`) are abolished in favor of Factory patterns (`GamaListFactory.create()`).
+*   **Decentralized Casting:** The monolithic `Cast` utility class is reduced; casting is delegated to individual type implementations (`Types.LIST.cast()`).
+*   **Population Refactoring:** Centralization of population logic into `AbstractPopulation`. API updates (`createAgentAt` renamed to `createAgentAtIndex`).
+*   **Agent Encapsulation:** `IAgent` extends `IDelegatingShape`. Modifying attributes via standard container methods is restricted in favor of proper variable evaluation.
+
+### Language Innovations (GAML)
+*   **Object-Oriented Constructs:** Introduction of the **`class`** and **`object`** concepts into the GAML language, bringing robust object-oriented paradigms to model building.
+*   **Faster Compilation:** The Xtext parser and AST (Abstract Syntax Tree) have been completely redesigned with formal syntactic elements, resulting in vastly faster compilation times.
+*   **Cleaner Syntax:**
+    *   Removal of Arrow Braces: `action my_action -> { do something; }` is now `action my_action -> do something;`.
+    *   Argument Lists (`with:`): `[a::1]` replaced by `(a:1)`.
+    *   Keyword Deprecation: `diffuse var: heat` is now `diffuse heat`; `transition to: x` is now `transition x`.
+*   **Annotation Flattening:** Java Annotations used for GAML (`@operator`, `@action`, `@species`) are flattened into top-level interfaces in the `gama.annotations` package.
+
+### Engine, UI, and Graphics
+*   **OpenGL 4.1 Native Display Plugin:** Introduction of `gama.ui.display.opengl4`, the first display plugin completely based on the modern OpenGL 4.1 Core Profile architecture. It abandons legacy fixed-function pipelines in favor of Shaders, VAOs/VBOs, and the JOML library.
+*   **New Launching Overlay:** A redesigned and highly responsive launching overlay appears when preparing and starting experiments.
+*   **Enhanced Concurrency:** Massive improvements to concurrency support, both internally for the simulation engine and externally for parallel execution of GAML operations.
 
 ---
 
 # Part 1: Innovations in GAMA and GAML (Version 2026)
 
-GAMA 2026 represents one of the most significant architectural overhauls in the history of the platform. More than just an incremental update, it is a foundational leap designed to secure GAMA’s future, enhance the modeler’s experience, and provide a robust, modern API for plugin developers. The modifications span across over 10,000 files, touching every aspect of the engine, the language, and the user interface.
+GAMA 2026 represents one of the most significant architectural overhauls in the history of the platform. More than just an incremental update, it is a foundational leap designed to secure GAMA’s future, enhance the modeler’s experience, and provide a robust, modern API for plugin developers.
 
-## 1. Technological Leap: Embracing JDK 25 and Eclipse 2025-12
+## 1. Technological Leap: JDK 25 and Concurrency
 
 At its core, GAMA 2026 abandons legacy Java constraints by upgrading directly to **Java Development Kit (JDK) 25** and the **Eclipse 2025-12** Rich Client Platform.
 
 ### What this brings to the platform:
-*   **Performance and Memory Management:** JDK 25 introduces cutting-edge garbage collection optimizations, improved thread management, and underlying enhancements that directly translate to faster simulation execution times and a reduced memory footprint for massive agent-based models.
-*   **Modern Java Features:** For plugin developers, this means the ability to use modern Java paradigms. The codebase has been extensively refactored to utilize features like **Pattern Matching for `instanceof`** (e.g., `if (obj instanceof MyClass myVar) { ... }`), Records, and Switch Expressions. This drastically reduces boilerplate code, minimizes casting errors, and improves code readability across the entire platform.
-*   **Future-Proofing the IDE:** By aligning with the upcoming Eclipse 2025-12 release, GAMA ensures continued support for the latest OS updates, high-DPI displays, and modern UI rendering engines.
+*   **Pattern Matching & Modern Java:** Code readability is massively improved. The engine relies heavily on Pattern Matching for `instanceof` (e.g., `if (obj instanceof MyClass myVar) { ... }`), Records, and Switch Expressions, stripping away thousands of lines of boilerplate casting.
+*   **Much Better Concurrency Support:** The shift to modern Java has enabled the engine to implement vastly superior concurrency models. Internal threading mechanisms for the platform and the scheduler have been optimized. Furthermore, GAML parallel operations (e.g., parallel lists, parallel asks) now execute with significantly lower overhead and better thread pooling, leveraging JDK 25's advanced thread management.
 
-## 2. The Language Evolution: A Cleaner, Modern GAML
+## 2. Introducing Object-Oriented GAML: `class` and `object`
 
-The GAML language (GAMA Modeling Language) has been refined to be more intuitive, concise, and aligned with modern programming aesthetics. The goal was to remove unnecessary verbosity and "boilerplate" syntax that hindered readability without adding semantic value.
+For the first time, GAMA introduces native support for **`class`** and **`object`** structures directly within the GAML language.
 
-### Key Grammatical Innovations:
-*   **Streamlined Parameter Passing (`with:`):** The legacy syntax for passing arguments to actions or creating agents involved clunky brackets and double colons (e.g., `with: [a::1, b::2]`). GAMA 2026 introduces a much cleaner, JSON-like syntax using parentheses and single colons: **`with: (a:1, b:2)`**. This makes model code significantly easier to read and write.
-*   **Flattening of Arrow Functions (`->`):** Previously, defining inline actions or evaluations required surrounding the body in curly braces: `action my_action -> { do something; };`. The parser now intelligently handles the arrow operator without requiring the outermost braces: **`action my_action -> do something;`**. This functional programming style allows for highly expressive, one-line declarations.
+While GAMA has always been Agent-based (where species define agents with complex lifecycles, shapes, and locations in topologies), the introduction of `class` provides a lightweight, purely data-and-logic structure. Classes allow modelers to define complex, nested data structures and utility objects without incurring the overhead of a full simulation agent (no geometry, no automatic scheduling). This closes a major gap for developers writing complex, software-engineering-heavy models in GAML.
+
+## 3. The Language Evolution: A Cleaner, Faster GAML
+
+The GAML syntax has been refined to be more intuitive, concise, and aligned with modern programming aesthetics. Furthermore, the underlying Xtext compiler has been rewritten with a strict AST.
+
+*   **Faster Compilation:** The rigid formalization of the AST (`SyntacticAttributeElement`, `SyntacticClassElement`) and optimized parsing rules mean that large models compile and initialize significantly faster than in previous versions.
+*   **Streamlined Parameter Passing (`with:`):** The legacy syntax `with: [a::1, b::2]` is replaced by a cleaner, JSON-like syntax: **`with: (a:1, b:2)`**.
+*   **Flattening of Arrow Functions (`->`):** The parser now handles the arrow operator without requiring the outermost braces: **`action my_action -> do something;`**.
 *   **Removal of Redundant Keywords:**
-    *   The `diffuse` statement no longer requires the `var:` keyword. `diffuse var: heat` is now simply **`diffuse heat`**.
-    *   The `transition` statement inside state machines no longer uses `to:`. `transition to: next_state` is now just **`transition next_state`**.
-*   **Separating Identifiers from Titles:** In previous versions, displays and experiments could be named using a string (e.g., `display "My Chart"`), which internally acted as an awkward identifier. GAMA 2026 enforces a clear separation between the programmatic identifier and the human-readable UI title: **`display My_Chart title: "My Chart"`**. This eliminates internal parsing ambiguities and bugs related to special characters in names.
-*   **Contextual Clarity (`image` vs. `picture`):** To avoid keyword collisions and confusion, the display layer used for rendering images has been renamed from `image` to **`picture`**.
+    *   `diffuse var: heat` is now simply **`diffuse heat`**.
+    *   `transition to: next_state` is now just **`transition next_state`**.
+*   **Separating Identifiers from Titles:** Displays and experiments enforce a clear separation between the programmatic identifier and the human-readable UI title: **`display My_Chart title: "My Chart"`**.
+*   **Contextual Clarity:** The display layer used for rendering images has been renamed from `image` to **`picture`**.
 
-## 3. The Architectural Revolution: The `gama.api` Module
+## 4. Graphics Revolution: The OpenGL 4.1 Display Plugin
 
-For years, GAMA extension developers struggled with a monolithic `gama.core` module where public interfaces were entangled with internal implementations.
+GAMA 2026 ships with a brand new, highly optimized display plugin: **`gama.ui.display.opengl4`**.
 
-GAMA 2026 introduces **`gama.api`**, a completely new, isolated module that serves as the definitive public contract for the platform.
+This is the first display plugin built from the ground up on the **OpenGL 4.1 Core Profile**. It completely abandons the legacy OpenGL 2 fixed-function pipeline (removing `glBegin`/`glEnd`, `glMatrixMode`, etc.).
+*   **Modern Rendering:** All rendering is now based exclusively on Shaders (loaded from `.vert` and `.frag` files), Vertex Array Objects (VAOs), and Vertex Buffer Objects (VBOs).
+*   **JOML Math Library:** The legacy matrix stack has been replaced by the high-performance Java OpenGL Math Library (JOML).
+*   **Performance:** This architecture ensures extremely high execution speed, massive polygon throughput, and significantly lower GPU memory usage compared to previous renderers.
 
-### Why this is a game-changer:
-*   **True Encapsulation:** Implementation details are now hidden. Plugin developers rely solely on interfaces (`IPoint`, `IAgent`, `IList`, `IGraph`) located in `gama.api`. This guarantees that internal optimizations in `gama.core` will not break third-party plugins in the future.
-*   **Interface-Driven Design:** Methods across the platform now strictly return interfaces rather than concrete classes. For instance, `agent.getLocation()` returns an `IPoint` rather than a `GamaPoint`. This allows the engine to swap out underlying implementations (e.g., swapping a standard point for a highly optimized, memory-mapped spatial coordinate) without the modeler or plugin developer ever noticing.
+## 5. UI Improvements: The Launching Overlay
 
-## 4. Reinventing the Core: `IAgent`, `IPopulation`, and Factories
+The user experience during model execution has been smoothed out with the introduction of a **new launching overlay**. When an experiment is launched, a highly responsive UI overlay takes over to display compilation, agent initialization, and setup progress. This prevents UI lock-ups and provides clear feedback to the modeler before the simulation officially begins stepping.
 
-Under the hood, the fundamental building blocks of a simulation have been redesigned for safety, speed, and consistency.
+## 6. The Architectural Revolution: `gama.api` and Factories
 
-*   **The `IAgent` Interface Redefined:** The agent interface has been stripped of direct shape inheritance and mutable container properties. It now extends `IDelegatingShape`, delegating geometry handling to specialized, swappable components. Furthermore, direct attribute mutation via the container interface is deprecated; attributes must be accessed via robust GAML variables, preventing untracked state changes.
-*   **Population Centralization:** The logic that manages collections of agents has been centralized into an `AbstractPopulation` base class. This DRY (Don't Repeat Yourself) approach eliminates inconsistencies between grid populations, standard agent populations, and graph-based populations, making the engine much easier to maintain.
-*   **The Factory Pattern Generalization:** To support the `gama.api` encapsulation, the direct instantiation of core types using `new` (e.g., `new GamaList()`) is strictly prohibited. Everything is now created via Factories (`GamaListFactory.create()`, `GamaShapeFactory.buildCircle()`). This is a crucial innovation: it gives the GAMA kernel absolute control over memory allocation, allowing it to pool objects, reuse memory, and optimize data structures transparently based on the simulation's needs.
+GAMA 2026 introduces **`gama.api`**, an isolated module that serves as the definitive public contract for the platform.
 
-## 5. Cleaning the Utilities and Annotations
+*   **True Encapsulation:** Implementation details are hidden in `gama.core`. Plugin developers rely solely on interfaces (`IPoint`, `IAgent`, `IList`).
+*   **The Factory Pattern Generalization:** Direct instantiation of core types (e.g., `new GamaList()`) is strictly prohibited. Everything is created via Factories (`GamaListFactory.create()`). This allows the GAMA kernel absolute control over memory allocation, object pooling, and optimization.
+*   **Reinventing `IAgent`:** The agent interface delegates geometry handling to specialized components (`IDelegatingShape`) and deprecates direct attribute mutation via containers in favor of robust GAML variable access.
+*   **Decentralizing `Cast`:** The monolithic `Cast` utility class has been broken down. Type casting is now handled intelligently by the target `IType` implementations.
 
-*   **Flattening Annotations:** The GAML annotation framework (used by developers to define `@operator`, `@species`, `@action`) was previously nested inside a massive `GamlAnnotations` class. In 2026, these are now elegant, top-level interfaces directly in the `gama.annotations` package, greatly cleaning up Java imports and class definitions.
-*   **The Fall of the Monolithic `Cast` Class:** Type casting in Java plugins used to be routed through a single, gigantic `Cast` utility class. This created a massive bottleneck and architectural dependency nightmare. In 2026, casting logic has been decentralized. Each `IType` implementation now knows how to cast objects to itself (e.g., `Types.POINT.cast(...)`), adhering to solid object-oriented design principles and improving extensibility.
 
 ***
 

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -1,94 +1,119 @@
-# Guide de Migration : GAMA Version 2026 (Eclipse 2025-12 et JDK 25)
+# Migration Guide: GAMA Version 2026 (Eclipse 2025-12 and JDK 25)
 
-Ce document décrit les changements architecturaux et d'API majeurs intervenus entre la version précédente de GAMA (sur la branche `main`) et la version 2026 (sur la branche `Upgrade-to-Eclipse-2025-12-and-JDK-25`).
+This document describes the major API and architectural changes introduced between the previous version of GAMA (on the `main` branch) and the 2026 version (on the `Upgrade-to-Eclipse-2025-12-and-JDK-25` branch).
 
-L'objectif de cette mise à jour massive (plus de 10 000 fichiers modifiés) est de moderniser GAMA, d'améliorer sa compatibilité avec les standards récents (JDK 25, Eclipse 2025-12) et de séparer les détails d'implémentation de l'API publique via la création d'un tout nouveau module `gama.api`.
-
----
-
-## 1. Changements de Modules et Importations (Création de `gama.api`)
-
-Le changement le plus impactant pour les développeurs d'extensions GAMA est la création du module **`gama.api`**.
-Auparavant, la plupart des interfaces publiques et des utilitaires étaient mélangés avec le code d'implémentation dans `gama.core` ou `gama.annotations`.
-
-**Action requise :** La majorité de vos imports pointant vers `gama.core.*` ou `gama.annotations.*` devront être mis à jour vers `gama.api.*`.
-
-### Correspondances des packages principaux :
-*   **Types de base :**
-    *   `gama.core.common.interfaces.ITyped` $\rightarrow$ `gama.api.gaml.types.ITyped`
-    *   `gama.gaml.types.IType` $\rightarrow$ `gama.api.gaml.types.IType`
-    *   `gama.gaml.types.ITypesManager` $\rightarrow$ `gama.api.gaml.types.ITypesManager`
-*   **Collections :**
-    *   `gama.core.util.IList` $\rightarrow$ `gama.api.types.list.IList`
-    *   `gama.core.util.graph.IGraph` $\rightarrow$ `gama.api.types.graph.IGraph`
-*   **Géométrie et Topologie :**
-    *   La classe concrète `GamaPoint` est remplacée par l'interface `IPoint` dans les signatures de l'API (`gama.api.types.geometry.IPoint`).
-    *   `gama.core.metamodel.topology.ITopology` $\rightarrow$ `gama.api.types.topology.ITopology`
-*   **AST et Expressions :**
-    *   `gama.gaml.expressions.IExpression` $\rightarrow$ `gama.api.gaml.expressions.IExpression`
-    *   `gama.gaml.statements.IStatement` $\rightarrow$ `gama.api.gaml.statements.IStatement`
+The goal of this massive update (over 10,000 files modified) is to modernize GAMA, improve compatibility with modern standards (JDK 25, Eclipse 2025-12), and cleanly separate implementation details from the public API by introducing a brand-new module: **`gama.api`**.
 
 ---
 
-## 2. Refonte de l'interface `IAgent`
+## 1. Module Changes and Imports (The `gama.api` Module)
 
-L'interface racine des agents, `IAgent`, a subi de profondes modifications structurelles.
+The most impactful change for GAMA extension developers is the creation of the `gama.api` module. Previously, public interfaces, types, and utilities were mixed with implementation code inside `gama.core` and `gama.annotations`.
 
-1.  **Changement de Package :**
-    *   *Ancien :* `gama.core.metamodel.agent.IAgent`
-    *   *Nouveau :* `gama.api.kernel.agent.IAgent`
-2.  **Héritage et Géométrie :**
-    *   `IAgent` n'hérite plus directement de `IShape` et `IAttributed`.
-    *   Il hérite désormais de `IDelegatingShape`, ce qui permet une meilleure séparation des responsabilités concernant la géométrie de l'agent.
-3.  **Utilisation des Interfaces Géométriques :**
-    *   Les méthodes comme `getLocation()` et `setLocation(...)` retournent et prennent désormais une interface `IPoint` au lieu de la classe concrète `GamaPoint`.
-4.  **Gestion des Attributs et Conteneurs :**
-    *   `IAgent` n'étend plus `IContainer.Addressable<String, Object>`.
-    *   Il étend désormais `IContainer.ToGet<String, Object>`. Les modifications directes d'attributs via l'interface conteneur nécessitent de passer par les mécanismes de variables du GAML (`IVariable`) ou de `IVarAndActionSupport`.
-5.  **Propriété `peers` :**
-    *   La liste des agents pairs (`getPeers()`) est désormais considérée conceptuellement comme étant en **lecture seule**.
-    *   L'implémentation par défaut de la méthode `setPeers(IList<IAgent> peers)` dans `IAgent` est vide. Ne comptez plus sur cette méthode pour modifier le voisinage d'un agent.
+**Required Action:** Most of your imports pointing to `gama.core.*` or `gama.annotations.*` will need to be updated to `gama.api.*`.
 
----
+### Package Correspondences: Core Types and Utilities
 
-## 3. Refonte des Populations (`IPopulation` et `AbstractPopulation`)
+The basic GAML types and their managers have moved:
+*   `gama.core.common.interfaces.ITyped` $\rightarrow$ `gama.api.gaml.types.ITyped`
+*   `gama.gaml.types.IType` $\rightarrow$ `gama.api.gaml.types.IType`
+*   `gama.gaml.types.ITypesManager` $\rightarrow$ `gama.api.gaml.types.ITypesManager`
 
-La gestion interne des populations d'agents a été refactorisée pour réduire la duplication de code et clarifier l'API.
+*All the concrete GAML type definitions have been migrated.* For example:
+*   `gama.gaml.types.GamaPointType` $\rightarrow$ `gama.api.gaml.types.GamaPointType`
+*   `gama.gaml.types.GamaListType` $\rightarrow$ `gama.api.gaml.types.GamaListType`
+*   `gama.gaml.types.GamaMatrixType` $\rightarrow$ `gama.api.gaml.types.GamaMatrixType`
+*   *And similarly for GamaActionType, GamaAgentType, GamaBoolType, GamaColorType, GamaFloatType, GamaGeometryType, GamaStringType, etc.*
 
-1.  **Introduction de `AbstractPopulation` :**
-    *   La logique commune (conteneur d'agents interne, gestion des miroirs, de la topologie, `init` et `step`) a été extraite dans une nouvelle classe abstraite de base : `AbstractPopulation`.
-    *   `GamaPopulation` a été refactorisée pour étendre cette classe abstraite.
-2.  **Changements dans l'API `IPopulation` :**
-    *   **Suppression** : Le prédicat imbriqué `IsLiving` a été retiré.
-    *   **Renommage** : La méthode `createAgentAt(...)` est renommée en `createAgentAtIndex(...)`. *Tous les appels existants doivent être mis à jour.*
-    *   **Ajout** : Une méthode par défaut `createOneAgent(...)` a été ajoutée.
-    *   **Changement de comportement** : La méthode `fireAgentsAdded` n'est plus une méthode par défaut dans l'interface, son implémentation est déléguée aux classes concrètes.
+### Package Correspondences: Data Structures
+The actual Java interfaces and classes representing GAMA structures have been grouped under `gama.api.types.*`:
+*   `gama.core.util.IList` $\rightarrow$ `gama.api.types.list.IList`
+*   `gama.core.util.GamaList` $\rightarrow$ `gama.api.types.list.GamaList`
+*   `gama.core.util.GamaMap` $\rightarrow$ `gama.api.types.map.GamaMap`
+*   `gama.core.util.graph.IGraph` $\rightarrow$ `gama.api.types.graph.IGraph`
+*   `gama.core.metamodel.topology.ITopology` $\rightarrow$ `gama.api.types.topology.ITopology`
+*   `gama.core.metamodel.shape.GamaPoint` $\rightarrow$ `gama.api.types.geometry.GamaPoint`
 
 ---
 
-## 4. Compilateur et Parseur GAML (`gaml.compiler`)
+## 2. Redesign of the `IAgent` Interface
 
-De très gros changements ont eu lieu dans le compilateur Xtext GAML.
+The root interface for agents, `IAgent`, has undergone profound structural modifications to enhance encapsulation.
 
-1.  **AST Strictement Typé :**
-    *   Création de nombreux éléments syntaxiques formels : `SyntacticAttributeElement`, `SyntacticSpeciesElement`, `SyntacticModelElement`, etc.
-2.  **Descriptions :**
-    *   Les fabriques (`DescriptionFactory`) et les objets de descriptions (comme `SpeciesDescription`, `ModelDescription`, `StatementDescription`) ont été remaniés et déplacés.
-3.  **Ressources et Shaders GLSL :**
-    *   Les shaders GLSL (pour le plugin `gama.ui.display.opengl4`) ne sont plus stockés sous forme de chaînes de caractères (String literals) dans le code Java.
-    *   Ils doivent obligatoirement être placés dans des fichiers `.vert` et `.frag` dédiés dans un sous-dossier `glsl` du plugin et chargés dynamiquement avec `getClass().getResourceAsStream()`.
+1.  **Package Change:**
+    *   *Before:* `gama.core.metamodel.agent.IAgent`
+    *   *After:* `gama.api.kernel.agent.IAgent`
+2.  **Inheritance and Geometry:**
+    *   `IAgent` no longer directly extends `IShape` and `IAttributed`.
+    *   It now extends **`IDelegatingShape`**, allowing a cleaner separation of concerns regarding the agent's geometry.
+3.  **Using Geometric Interfaces instead of Concrete Classes:**
+    *   Methods like `getLocation()` and `setLocation(...)` now return and accept the `IPoint` interface rather than the concrete `GamaPoint` class.
+    *   **Example:**
+        ```java
+        // BEFORE (GAMA 1.9 / main)
+        GamaPoint location = agent.getLocation();
+
+        // AFTER (GAMA 2026)
+        IPoint location = agent.getLocation();
+        ```
+4.  **Attribute Management and Containers:**
+    *   `IAgent` no longer extends `IContainer.Addressable<String, Object>`.
+    *   It now extends `IContainer.ToGet<String, Object>`. Direct attribute modification via the container interface is no longer supported; developers must use GAML variable mechanisms (`IVariable`) or `IVarAndActionSupport`.
+5.  **The `peers` Property:**
+    *   The list of peer agents (`getPeers()`) is now conceptually **read-only**.
+    *   The default implementation of the `setPeers(IList<IAgent> peers)` method in `IAgent` is now empty. Do not rely on this method to modify an agent's neighborhood.
 
 ---
 
-## 5. Utilitaires et I/O (`gama.api.utils.*`)
+## 3. Redesign of Populations (`IPopulation` and `AbstractPopulation`)
 
-La gestion des fichiers et les bibliothèques utilitaires ont été rationalisées et isolées dans `gama.api.utils`.
+The internal management of agent populations has been refactored to reduce code duplication and clarify the API.
 
-*   **Refactorisation de `FileUtils` :** Les méthodes d'I/O ont été centralisées. L'utilisation d'anciens utilitaires dispersés doit être remplacée par l'API centralisée dans `gama.api.utils.files.FileUtils`.
-*   **Outils Généraux :** De nombreux utilitaires (`GamaPreferences`, `StringUtils`, manipulations `CSV` et `JSON`, générateurs aléatoires `GamaRNG`) ont été déplacés dans `gama.api.utils.*`.
-*   **Pattern Matching :** L'utilisation du *pattern matching* Java pour `instanceof` est désormais la norme (introduite avec la migration JDK), ce qui simplifie grandement les tests de types dans les implémentations (`if (obj instanceof MyClass myVar) { ... }`).
+1.  **Introduction of `AbstractPopulation`:**
+    *   Common logic (internal agent container, mirror management, topology, `init`, and `step`) has been extracted into a new abstract base class: `gama.core.metamodel.population.AbstractPopulation`.
+    *   `GamaPopulation` has been refactored to extend this abstract class.
+2.  **Changes in the `IPopulation` API:**
+    *   **Removed:** The nested `IsLiving` predicate has been removed.
+    *   **Renamed:** The `createAgentAt(...)` method is renamed to `createAgentAtIndex(...)`. *All existing calls must be updated.*
+    *   **Added:** A default `createOneAgent(...)` method has been added.
+    *   **Behavior Change:** The `fireAgentsAdded` method is no longer a default method in the interface; its implementation is delegated to concrete classes.
+    *   **Example:**
+        ```java
+        // BEFORE
+        myPopulation.createAgentAt(scope, index, initialValues, isRestored);
+
+        // AFTER
+        myPopulation.createAgentAtIndex(scope, index, initialValues, isRestored);
+        ```
 
 ---
 
-**Note pour les développeurs CI/CD :**
-Veillez à ce que vos environnements de compilation locaux (Maven Tycho) et CI utilisent bien le **JDK 25** (ou supérieur) pour pouvoir compiler cette nouvelle version de GAMA.
+## 4. GAML Compiler and Parser (`gaml.compiler`)
+
+Major changes occurred in the GAML Xtext compiler.
+
+1.  **Strictly Typed AST (Abstract Syntax Tree):**
+    *   Introduction of formal syntactic elements such as `SyntacticAttributeElement`, `SyntacticSpeciesElement`, `SyntacticModelElement`, etc., replacing generic AST node structures.
+2.  **Descriptions and Expressions:**
+    *   Factories (`DescriptionFactory`) and description objects (like `SpeciesDescription`, `ModelDescription`, `StatementDescription`) have been significantly overhauled.
+    *   *Expression Interfaces moved:*
+        *   `gama.gaml.expressions.IExpression` $\rightarrow$ `gama.api.gaml.expressions.IExpression`
+        *   `gama.gaml.statements.IStatement` $\rightarrow$ `gama.api.gaml.statements.IStatement`
+3.  **Resources and GLSL Shaders:**
+    *   GLSL shaders (used in the `gama.ui.display.opengl4` plugin) are no longer stored as String literals within the Java code.
+    *   They must be placed in dedicated `.vert` and `.frag` files within a `glsl` subfolder of the plugin and loaded dynamically using `getClass().getResourceAsStream()`.
+
+---
+
+## 5. Utilities and I/O (`gama.api.utils.*`)
+
+File management and utility libraries have been streamlined and isolated within `gama.api.utils`.
+
+*   **Refactoring `FileUtils`:** I/O methods have been centralized. The use of scattered legacy utilities must be replaced by the centralized API in `gama.api.utils.files.FileUtils`.
+*   **General Tools:** Many utilities (`GamaPreferences`, `StringUtils`, `CSV` and `JSON` manipulators, and random generators like `GamaRNG`) have been moved to `gama.api.utils.*`.
+*   **Java Pattern Matching:** The use of Java's pattern matching for `instanceof` is now the standard across the platform (introduced with the JDK migration), which greatly simplifies type checking in implementations (`if (obj instanceof MyClass myVar) { ... }`).
+
+---
+
+**Note for CI/CD developers:**
+Ensure that your local build environments (Maven Tycho) and CI pipelines use **JDK 25** (or higher) and the Eclipse 2025-12 target platform to successfully compile this new version of GAMA.

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -10,7 +10,7 @@ The goal of this massive update (over 10,000 files modified) is to modernize GAM
 
 The most impactful change for GAMA extension developers is the creation of the `gama.api` module. Previously, public interfaces, types, and utilities were mixed with implementation code inside `gama.core` and `gama.annotations`.
 
-**Required Action:** Most of your imports pointing to `gama.core.*` or `gama.annotations.*` will need to be updated to `gama.api.*`.
+**Required Action:** Most of your imports pointing to `gama.core.*` or `gama.annotations.*` will need to be systematically updated to `gama.api.*`.
 
 ### Package Correspondences: Core Types and Utilities
 
@@ -48,13 +48,17 @@ The root interface for agents, `IAgent`, has undergone profound structural modif
     *   It now extends **`IDelegatingShape`**, allowing a cleaner separation of concerns regarding the agent's geometry.
 3.  **Using Geometric Interfaces instead of Concrete Classes:**
     *   Methods like `getLocation()` and `setLocation(...)` now return and accept the `IPoint` interface rather than the concrete `GamaPoint` class.
-    *   **Example:**
+    *   **Systematic Migration Example:**
         ```java
         // BEFORE (GAMA 1.9 / main)
         GamaPoint location = agent.getLocation();
+        agent.setLocation(new GamaPoint(10, 20));
+        IShape geometry = agent.getGeometry();
 
         // AFTER (GAMA 2026)
         IPoint location = agent.getLocation();
+        agent.setLocation(GamaPointFactory.create(10, 20));
+        IShape geometry = agent.getGeometry(); // IShape interface is now in gama.api.types.geometry.IShape
         ```
 4.  **Attribute Management and Containers:**
     *   `IAgent` no longer extends `IContainer.Addressable<String, Object>`.
@@ -65,7 +69,53 @@ The root interface for agents, `IAgent`, has undergone profound structural modif
 
 ---
 
-## 3. Redesign of Populations (`IPopulation` and `AbstractPopulation`)
+## 3. Generalization of Factories for Instantiation
+
+A major architectural shift in GAMA 2026 is the **generalization of the Factory pattern** for creating core data structures and geometries.
+You should no longer use direct constructors (e.g., `new GamaList(...)`, `new GamaMap(...)`, `new GamaPoint(...)`) to create instances. This hides the internal implementations behind the `gama.api` and allows GAMA to inject optimized underlying structures.
+
+**Systematic Migration Examples:**
+
+*   **Creating Lists (`IList`)**
+    ```java
+    // BEFORE
+    IList<String> list = new GamaList<>();
+    IList<IAgent> listFromSet = new GamaList<>(mySet);
+
+    // AFTER
+    IList<String> list = GamaListFactory.create(Types.STRING);
+    IList<IAgent> listFromSet = GamaListFactory.create(scope, Types.AGENT, mySet);
+    ```
+
+*   **Creating Maps (`IMap`)**
+    ```java
+    // BEFORE
+    IMap<String, Object> map = new GamaMap<>();
+
+    // AFTER
+    IMap<String, Object> map = GamaMapFactory.create(Types.STRING, Types.NO_TYPE);
+    ```
+
+*   **Creating Geometry and Points (`IShape`, `IPoint`)**
+    ```java
+    // BEFORE
+    GamaPoint pt = new GamaPoint(1.0, 2.0);
+    IShape circle = GamaGeometryType.buildCircle(10, pt);
+
+    // AFTER
+    IPoint pt = GamaPointFactory.create(1.0, 2.0);
+    IShape circle = GamaShapeFactory.buildCircle(10, pt);
+    ```
+
+*   **Creating Graphs (`IGraph`)**
+    *   Use `GamaGraphFactory` to instantiate spatial graphs, generic graphs, etc.
+
+*   **Creating Colors (`IColor`)**
+    *   Use `GamaColorFactory` instead of `new GamaColor()`.
+
+---
+
+## 4. Redesign of Populations (`IPopulation` and `AbstractPopulation`)
 
 The internal management of agent populations has been refactored to reduce code duplication and clarify the API.
 
@@ -77,7 +127,7 @@ The internal management of agent populations has been refactored to reduce code 
     *   **Renamed:** The `createAgentAt(...)` method is renamed to `createAgentAtIndex(...)`. *All existing calls must be updated.*
     *   **Added:** A default `createOneAgent(...)` method has been added.
     *   **Behavior Change:** The `fireAgentsAdded` method is no longer a default method in the interface; its implementation is delegated to concrete classes.
-    *   **Example:**
+    *   **Systematic Migration Example:**
         ```java
         // BEFORE
         myPopulation.createAgentAt(scope, index, initialValues, isRestored);
@@ -88,7 +138,7 @@ The internal management of agent populations has been refactored to reduce code 
 
 ---
 
-## 4. GAML Compiler and Parser (`gaml.compiler`)
+## 5. GAML Compiler and Parser (`gaml.compiler`)
 
 Major changes occurred in the GAML Xtext compiler.
 
@@ -105,7 +155,7 @@ Major changes occurred in the GAML Xtext compiler.
 
 ---
 
-## 5. Utilities and I/O (`gama.api.utils.*`)
+## 6. Utilities and I/O (`gama.api.utils.*`)
 
 File management and utility libraries have been streamlined and isolated within `gama.api.utils`.
 

--- a/MIGRATION_GUIDE_2026.md
+++ b/MIGRATION_GUIDE_2026.md
@@ -1,278 +1,182 @@
-# Migration Guide: GAMA Version 2026 (Eclipse 2025-12 and JDK 25)
+# Comprehensive Migration Guide: GAMA Version 2026 (Eclipse 2025-12 and JDK 25)
 
-This document describes the major API and architectural changes introduced between the previous version of GAMA (on the `main` branch) and the 2026 version (on the `Upgrade-to-Eclipse-2025-12-and-JDK-25` branch).
+This document provides a comprehensive and exhaustive reference of the API, architectural, and syntax changes introduced between the previous version of GAMA (on the `main` branch) and the 2026 version (on the `Upgrade-to-Eclipse-2025-12-and-JDK-25` branch).
 
-The goal of this massive update (over 10,000 files modified) is to modernize GAMA, improve compatibility with modern standards (JDK 25, Eclipse 2025-12), and cleanly separate implementation details from the public API by introducing a brand-new module: **`gama.api`**.
-
----
-
-## 1. Module Changes and Imports (The `gama.api` Module)
-
-The most impactful change for GAMA extension developers is the creation of the `gama.api` module. Previously, public interfaces, types, and utilities were mixed with implementation code inside `gama.core` and `gama.annotations`.
-
-**Required Action:** Most of your imports pointing to `gama.core.*` or `gama.annotations.*` will need to be systematically updated to `gama.api.*`.
-
-### Package Correspondences: Core Types and Utilities
-
-The basic GAML types and their managers have moved:
-*   `gama.core.common.interfaces.ITyped` $\rightarrow$ `gama.api.gaml.types.ITyped`
-*   `gama.gaml.types.IType` $\rightarrow$ `gama.api.gaml.types.IType`
-*   `gama.gaml.types.ITypesManager` $\rightarrow$ `gama.api.gaml.types.ITypesManager`
-
-*All the concrete GAML type definitions have been migrated.* For example:
-*   `gama.gaml.types.GamaPointType` $\rightarrow$ `gama.api.gaml.types.GamaPointType`
-*   `gama.gaml.types.GamaListType` $\rightarrow$ `gama.api.gaml.types.GamaListType`
-*   `gama.gaml.types.GamaMatrixType` $\rightarrow$ `gama.api.gaml.types.GamaMatrixType`
-*   *And similarly for GamaActionType, GamaAgentType, GamaBoolType, GamaColorType, GamaFloatType, GamaGeometryType, GamaStringType, etc.*
-
-### Package Correspondences: Data Structures
-The actual Java interfaces and classes representing GAMA structures have been grouped under `gama.api.types.*`:
-*   `gama.core.util.IList` $\rightarrow$ `gama.api.types.list.IList`
-*   `gama.core.util.GamaList` $\rightarrow$ `gama.api.types.list.GamaList`
-*   `gama.core.util.GamaMap` $\rightarrow$ `gama.api.types.map.GamaMap`
-*   `gama.core.util.graph.IGraph` $\rightarrow$ `gama.api.types.graph.IGraph`
-*   `gama.core.metamodel.topology.ITopology` $\rightarrow$ `gama.api.types.topology.ITopology`
-*   `gama.core.metamodel.shape.GamaPoint` $\rightarrow$ `gama.api.types.geometry.GamaPoint`
+The goal of this massive update is to modernize GAMA, improve compatibility with modern standards (JDK 25, Eclipse 2025-12), and cleanly separate implementation details from the public API by introducing a brand-new module: **`gama.api`**.
 
 ---
 
-## 2. Redesign of the `IAgent` Interface
+## 1. GAML Language Syntax Changes
+
+The GAML grammar and parser have been significantly updated. Below is the exhaustive list of syntax modifications. Existing models may need to be updated.
+
+### 1.1 Flattening of Arrow (`->`) Braces
+The outermost curly braces surrounding the body of `->` (arrow) expressions are now removed by the parser.
+*   **Before:** `action my_action -> { do something; };`
+*   **After:** `action my_action -> do something;`
+
+### 1.2 Deprecation of `diffuse var:` and `transition to:`
+The verbose keywords `var:` and `to:` are no longer used in `diffuse` and `transition` statements.
+*   **Before:** `diffuse var: heat`
+*   **After:** `diffuse heat`
+*   **Before:** `transition to: idle`
+*   **After:** `transition idle`
+
+### 1.3 Renaming `image` to `picture` in Displays
+To avoid keyword collisions and improve clarity, the `image` layer inside `display` blocks is renamed to `picture`.
+*   **Before:** `display my_disp { image "background.jpg"; }`
+*   **After:** `display my_disp { picture "background.jpg"; }`
+
+### 1.4 Explicit `title:` for Displays and Experiments
+Display and experiment names declared only as strings are now rewritten to separate the identifier from the human-readable title.
+*   **Before:** `display "3 Simulations"`
+*   **After:** `display _3_Simulations title: "3 Simulations"`
+
+### 1.5 Evolution of the `with:` argument list
+The `with:` syntax for parameter passing has been modernized from bracket/double-colon `[::]` to parenthesis/single-colon `(:)`.
+*   **Before:** `with: [agents::ag, values::[1,2,3]]`
+*   **After:** `with: (agents:ag, values:[1,2,3])`
+
+---
+
+## 2. Java Annotations Flattening (`gama.annotations`)
+
+The global `GamlAnnotations` class (which previously contained all the `@interface` definitions as inner classes) has been flattened. Annotations are now top-level interfaces in the `gama.annotations` package.
+
+**Exhaustive list of migrated annotations:**
+You must update your imports from `gama.annotations.precompiler.GamlAnnotations.*` to `gama.annotations.*` for the following:
+`@action`, `@arg`, `@constant`, `@display`, `@doc`, `@example`, `@experiment`, `@facet`, `@facets`, `@file`, `@getter`, `@inside`, `@listener`, `@no_test`, `@operator`, `@setter`, `@skill`, `@species`, `@symbol`, `@test`, `@type`, `@usage`, `@variable`, `@vars`, `@factory`.
+
+**Example:**
+*   **Before:** `@gama.annotations.precompiler.GamlAnnotations.operator(value = "my_operator")`
+*   **After:** `@gama.annotations.operator(value = "my_operator")`
+
+Additionally, `IKeyword` has moved from `gama.core.common.interfaces.IKeyword` to `gama.annotations.constants.IKeyword`.
+
+---
+
+## 3. Redesign of the `IAgent` Interface
 
 The root interface for agents, `IAgent`, has undergone profound structural modifications to enhance encapsulation.
 
-1.  **Package Change:**
-    *   *Before:* `gama.core.metamodel.agent.IAgent`
-    *   *After:* `gama.api.kernel.agent.IAgent`
-2.  **Inheritance and Geometry:**
-    *   `IAgent` no longer directly extends `IShape` and `IAttributed`.
-    *   It now extends **`IDelegatingShape`**, allowing a cleaner separation of concerns regarding the agent's geometry.
-3.  **Using Geometric Interfaces instead of Concrete Classes:**
-    *   Methods like `getLocation()` and `setLocation(...)` now return and accept the `IPoint` interface rather than the concrete `GamaPoint` class.
-    *   **Systematic Migration Example:**
-        ```java
-        // BEFORE (GAMA 1.9 / main)
-        GamaPoint location = agent.getLocation();
-        agent.setLocation(new GamaPoint(10, 20));
-        IShape geometry = agent.getGeometry();
-
-        // AFTER (GAMA 2026)
-        IPoint location = agent.getLocation();
-        agent.setLocation(GamaPointFactory.create(10, 20));
-        IShape geometry = agent.getGeometry(); // IShape interface is now in gama.api.types.geometry.IShape
-        ```
-4.  **Attribute Management and Containers:**
-    *   `IAgent` no longer extends `IContainer.Addressable<String, Object>`.
-    *   It now extends `IContainer.ToGet<String, Object>`. Direct attribute modification via the container interface is no longer supported; developers must use GAML variable mechanisms (`IVariable`) or `IVarAndActionSupport`.
-5.  **The `peers` Property:**
-    *   The list of peer agents (`getPeers()`) is now conceptually **read-only**.
-    *   The default implementation of the `setPeers(IList<IAgent> peers)` method in `IAgent` is now empty. Do not rely on this method to modify an agent's neighborhood.
+*   **Location:** Moved from `gama.core.metamodel.agent.IAgent` to `gama.api.kernel.agent.IAgent`.
+*   **Inheritance:** No longer extends `IShape` and `IAttributed`. It now extends `IDelegatingShape`.
+*   **Container Interface:** Changed from `IContainer.Addressable<String, Object>` to `IContainer.ToGet<String, Object>`. Direct attribute mutation via the container is forbidden.
+*   **Geometry:** Methods like `getLocation()` now return `IPoint` instead of `GamaPoint`. `getGeometry()` returns `IShape`.
+*   **Peers:** The `getPeers()` method returns a conceptually read-only list. The `setPeers()` default implementation is empty.
 
 ---
 
-## 3. Generalization of Factories for Instantiation
+## 4. Redesign of Populations (`AbstractPopulation`)
+
+*   **Base Class:** Common population logic is now centralized in `gama.core.metamodel.population.AbstractPopulation`. `GamaPopulation` extends it.
+*   **API Updates (`IPopulation`):**
+    *   `IsLiving` nested predicate: **Removed**.
+    *   `createAgentAt(...)`: **Renamed** to `createAgentAtIndex(...)`.
+    *   `createOneAgent(...)`: **Added** as a default method.
+    *   `fireAgentsAdded`: No longer a default method; delegated to implementations.
+
+---
+
+## 5. Exhaustive Package Mapping: The `gama.api` Module
+
+The creation of the `gama.api` module required the relocation of hundreds of interfaces, types, and factories. Below is the exhaustive list of the most important structural migrations.
+
+**Action:** Update imports systematically from `gama.core.*` to `gama.api.*`.
+
+### 5.1 GAML Types (`gama.api.gaml.types.*`)
+*   `IType`, `ITyped`, `ITypesManager`, `Signature`
+*   `GamaActionType`, `GamaAgentType`, `GamaBoolType`, `GamaColorType`, `GamaContainerType`, `GamaDateType`, `GamaDirectoryType`, `GamaFieldType`, `GamaFileType`, `GamaFloatType`, `GamaFontType`, `GamaGenericAgentType`, `GamaGeometryType`, `GamaGraphType`, `GamaIntegerType`, `GamaListType`, `GamaMapType`, `GamaMatrixType`, `GamaMessageType`, `GamaMetaType`, `GamaNoType`, `GamaPairType`, `GamaPathType`, `GamaPointType`, `GamaSkillType`, `GamaSpeciesType`, `GamaStringType`, `GamaTopologyType`, `GamaType`.
+
+### 5.2 Java Data Structures (`gama.api.types.*`)
+*   **Colors:** `IColor`, `GamaColor`, `GamaColorFactory`
+*   **Dates:** `IDate`, `GamaDate`, `GamaDateInterval`, `GamaDateFactory`
+*   **Files:** `IGamaFile`, `GamaFile`, `GenericFile`
+*   **Fonts:** `IFont`, `GamaFont`, `GamaFontFactory`
+*   **Geometry:** `IShape`, `IPoint`, `IDelegatingShape`, `GamaPoint`, `GamaPointFactory`, `GamaShapeFactory`, `IShapeFactory`
+*   **Graphs:** `IGraph`, `IPath`, `GraphObject`, `GamaGraphFactory`, `GamaPathFactory`
+*   **Lists:** `IList`, `GamaList`, `GamaPairList`, `GamaListFactory`
+*   **Maps:** `IMap`, `GamaMap`, `GamaMapFactory`
+*   **Matrices:** `IMatrix`, `IField`, `GamaMatrixFactory`
+*   **Messages:** `IMessage`, `GamaMessageFactory`
+*   **Pairs:** `IPair`, `GamaPairFactory`
+*   **Topology:** `ITopology`, `AmorphousTopology`, `GamaTopologyFactory`
+
+### 5.3 Expressions and AST (`gama.api.gaml.*` & `gama.api.compilation.*`)
+*   `IExpression`, `IStatement`
+*   `IDescription`, `ISymbolDescriptionFactory`, `IExpressionFactory`, `ISyntacticFactory`
+
+### 5.4 UI and Displays (`gama.api.ui.*`)
+*   `IGui`, `IDialogFactory`, `IStatusDisplayer`, `IConsoleListener`
+*   `IDisplaySurface`, `IGraphics`, `IDisplayData`, `IChart`
+*   `ILayer`, `ICameraDefinition`, `IDrawingAttributes`
+
+### 5.5 Core Utilities (`gama.api.utils.*`)
+*   `FileUtils` (Centralized file management)
+*   `GamaPreferences` (Preference store)
+*   `StringUtils`, `JavaUtils`, `MathUtils`
+*   `CsvReader`, `CsvWriter`, `IJson`, `IJsonObject`
+*   `GamaRNG`, `RandomUtils`
+
+---
+
+## 6. Generalization of Factories for Instantiation
 
 A major architectural shift in GAMA 2026 is the **generalization of the Factory pattern** for creating core data structures and geometries.
-You should no longer use direct constructors (e.g., `new GamaList(...)`, `new GamaMap(...)`, `new GamaPoint(...)`) to create instances. This hides the internal implementations behind the `gama.api` and allows GAMA to inject optimized underlying structures.
+You must no longer use direct constructors (e.g., `new GamaList(...)`, `new GamaPoint(...)`).
 
-**Systematic Migration Examples:**
+**Exhaustive Migration Examples:**
 
-*   **Creating Lists (`IList`)**
-    ```java
-    // BEFORE
-    IList<String> list = new GamaList<>();
-    IList<IAgent> listFromSet = new GamaList<>(mySet);
-
-    // AFTER
-    IList<String> list = GamaListFactory.create(Types.STRING);
-    IList<IAgent> listFromSet = GamaListFactory.create(scope, Types.AGENT, mySet);
-    ```
-
-*   **Creating Maps (`IMap`)**
-    ```java
-    // BEFORE
-    IMap<String, Object> map = new GamaMap<>();
-
-    // AFTER
-    IMap<String, Object> map = GamaMapFactory.create(Types.STRING, Types.NO_TYPE);
-    ```
-
-*   **Creating Geometry and Points (`IShape`, `IPoint`)**
-    ```java
-    // BEFORE
-    GamaPoint pt = new GamaPoint(1.0, 2.0);
-    IShape circle = GamaGeometryType.buildCircle(10, pt);
-
-    // AFTER
-    IPoint pt = GamaPointFactory.create(1.0, 2.0);
-    IShape circle = GamaShapeFactory.buildCircle(10, pt);
-    ```
-
-*   **Creating Graphs (`IGraph`)**
-    *   Use `GamaGraphFactory` to instantiate spatial graphs, generic graphs, etc.
-
-*   **Creating Colors (`IColor`)**
-    *   Use `GamaColorFactory` instead of `new GamaColor()`.
+*   **Lists (`IList`)**
+    *   *Before:* `new GamaList<>()`
+    *   *After:* `GamaListFactory.create(Types.STRING)`
+*   **Maps (`IMap`)**
+    *   *Before:* `new GamaMap<>()`
+    *   *After:* `GamaMapFactory.create(Types.STRING, Types.INT)`
+*   **Points (`IPoint`)**
+    *   *Before:* `new GamaPoint(1.0, 2.0)`
+    *   *After:* `GamaPointFactory.create(1.0, 2.0)`
+*   **Geometries (`IShape`)**
+    *   *Before:* `GamaGeometryType.buildCircle(10, pt)`
+    *   *After:* `GamaShapeFactory.buildCircle(10, pt)`
+*   **Colors (`IColor`)**
+    *   *Before:* `new GamaColor(255, 0, 0)`
+    *   *After:* `GamaColorFactory.create(255, 0, 0)`
+*   **Graphs (`IGraph`)**
+    *   *Before:* `new GamaSpatialGraph(...)`
+    *   *After:* `GamaGraphFactory.createSpatialGraph(...)`
 
 ---
 
-## 4. Redesign of Populations (`IPopulation` and `AbstractPopulation`)
+## 7. Evolution of Casting Mechanisms (The `Cast` class)
 
-The internal management of agent populations has been refactored to reduce code duplication and clarify the API.
+The central `Cast` class, previously located at `gama.core.gaml.operators.Cast`, handled almost all type conversions.
 
-1.  **Introduction of `AbstractPopulation`:**
-    *   Common logic (internal agent container, mirror management, topology, `init`, and `step`) has been extracted into a new abstract base class: `gama.core.metamodel.population.AbstractPopulation`.
-    *   `GamaPopulation` has been refactored to extend this abstract class.
-2.  **Changes in the `IPopulation` API:**
-    *   **Removed:** The nested `IsLiving` predicate has been removed.
-    *   **Renamed:** The `createAgentAt(...)` method is renamed to `createAgentAtIndex(...)`. *All existing calls must be updated.*
-    *   **Added:** A default `createOneAgent(...)` method has been added.
-    *   **Behavior Change:** The `fireAgentsAdded` method is no longer a default method in the interface; its implementation is delegated to concrete classes.
-    *   **Systematic Migration Example:**
-        ```java
-        // BEFORE
-        myPopulation.createAgentAt(scope, index, initialValues, isRestored);
+1.  **Moved to API:** Located at `gama.api.gaml.types.Cast`.
+2.  **Decreased Role:** Static cast methods specific to data structures have been removed.
+3.  **Delegation:** Type casting is now handled directly by the target `IType` implementations.
 
-        // AFTER
-        myPopulation.createAgentAtIndex(scope, index, initialValues, isRestored);
-        ```
+**Exhaustive Casting Migration Examples:**
 
----
+*   **Point (`IPoint`)**
+    *   *Before:* `Cast.asPoint(scope, obj)`
+    *   *After:* `Types.POINT.cast(scope, obj, null, false)`
+*   **List (`IList`)**
+    *   *Before:* `Cast.asList(scope, obj)`
+    *   *After:* `Types.LIST.cast(scope, obj, null, false)`
+*   **Map (`IMap`)**
+    *   *Before:* `Cast.asMap(scope, obj, copy)`
+    *   *After:* `Types.MAP.cast(scope, obj, null, copy)`
+*   **Geometry (`IShape`)**
+    *   *Before:* `Cast.asGeometry(scope, obj)`
+    *   *After:* `Types.GEOMETRY.cast(scope, obj, null, false)`
+*   **Matrix (`IMatrix`)**
+    *   *Before:* `Cast.asMatrix(scope, obj)`
+    *   *After:* `Types.MATRIX.cast(scope, obj, null, false)`
 
-## 5. GAML Compiler and Parser (`gaml.compiler`)
-
-Major changes occurred in the GAML Xtext compiler.
-
-1.  **Strictly Typed AST (Abstract Syntax Tree):**
-    *   Introduction of formal syntactic elements such as `SyntacticAttributeElement`, `SyntacticSpeciesElement`, `SyntacticModelElement`, etc., replacing generic AST node structures.
-2.  **Descriptions and Expressions:**
-    *   Factories (`DescriptionFactory`) and description objects (like `SpeciesDescription`, `ModelDescription`, `StatementDescription`) have been significantly overhauled.
-    *   *Expression Interfaces moved:*
-        *   `gama.gaml.expressions.IExpression` $\rightarrow$ `gama.api.gaml.expressions.IExpression`
-        *   `gama.gaml.statements.IStatement` $\rightarrow$ `gama.api.gaml.statements.IStatement`
-3.  **Resources and GLSL Shaders:**
-    *   GLSL shaders (used in the `gama.ui.display.opengl4` plugin) are no longer stored as String literals within the Java code.
-    *   They must be placed in dedicated `.vert` and `.frag` files within a `glsl` subfolder of the plugin and loaded dynamically using `getClass().getResourceAsStream()`.
-
----
-
-## 6. Utilities and I/O (`gama.api.utils.*`)
-
-File management and utility libraries have been streamlined and isolated within `gama.api.utils`.
-
-*   **Refactoring `FileUtils`:** I/O methods have been centralized. The use of scattered legacy utilities must be replaced by the centralized API in `gama.api.utils.files.FileUtils`.
-*   **General Tools:** Many utilities (`GamaPreferences`, `StringUtils`, `CSV` and `JSON` manipulators, and random generators like `GamaRNG`) have been moved to `gama.api.utils.*`.
-*   **Java Pattern Matching:** The use of Java's pattern matching for `instanceof` is now the standard across the platform (introduced with the JDK migration), which greatly simplifies type checking in implementations (`if (obj instanceof MyClass myVar) { ... }`).
+*Note: Primitive conversions like `asInt`, `asFloat`, `asString`, and `asAgent` remain in `gama.api.gaml.types.Cast`.*
 
 ---
 
 **Note for CI/CD developers:**
 Ensure that your local build environments (Maven Tycho) and CI pipelines use **JDK 25** (or higher) and the Eclipse 2025-12 target platform to successfully compile this new version of GAMA.
-
-## 7. Evolution of Casting Mechanisms (The `Cast` class)
-
-The central `Cast` class, which was previously a massive utility class in `gama.core.gaml.operators.Cast` handling almost all type conversions in Java, has been refactored.
-
-1.  **Moved to API:** The class is now located at `gama.api.gaml.types.Cast`.
-2.  **Decreased Role:** Its role has been significantly decreased. Many static cast methods specific to data structures (e.g., `asPoint`, `asList`, `asMap`, `asMatrix`, `asGeometry`) have been **removed** from the `Cast` class.
-3.  **Delegation to Types and Factories:** Type casting and conversions are now handled directly by the static methods within the target `IType` implementations or via the corresponding `Factory`.
-
-**Systematic Migration Examples for Casting:**
-
-*   **Casting to a Point (`IPoint`)**
-    ```java
-    // BEFORE
-    import gama.gaml.operators.Cast;
-    GamaPoint p = Cast.asPoint(scope, someObject);
-
-    // AFTER
-    import gama.api.gaml.types.Types;
-    IPoint p = Types.POINT.cast(scope, someObject, null, false);
-    ```
-
-*   **Casting to a List (`IList`)**
-    ```java
-    // BEFORE
-    IList list = Cast.asList(scope, someObject);
-
-    // AFTER
-    IList list = Types.LIST.cast(scope, someObject, null, false);
-    ```
-
-*   **Casting to a Geometry (`IShape`)**
-    ```java
-    // BEFORE
-    IShape shape = Cast.asGeometry(scope, someObject);
-
-    // AFTER
-    IShape shape = Types.GEOMETRY.cast(scope, someObject, null, false);
-    ```
-
-*Note: Some very generic casts or base type conversions (like `asInt`, `asFloat`, `asString`, `asAgent`) are still present in the new `gama.api.gaml.types.Cast` utility, but for structured types, always prefer using `Types.YOUR_TYPE.cast(...)`.*
-
-
-## 8. Flattening of GAML Annotations (`gama.annotations`)
-
-A significant syntactic change affects all GAMA extension and plugin developers: the global `GamlAnnotations` class (which previously contained all the `@interface` definitions as inner classes) has been flattened.
-
-Annotations are now top-level interfaces in the `gama.annotations` package.
-
-**Required Action:** You must update your imports and the way you declare annotations on your Java classes and methods.
-
-**Systematic Migration Examples for Annotations:**
-
-*   **Operator Definition**
-    ```java
-    // BEFORE
-    import gama.annotations.precompiler.GamlAnnotations.operator;
-    import gama.annotations.precompiler.GamlAnnotations.doc;
-
-    @operator(value = "my_operator", can_be_const = true)
-    @doc("Returns something")
-    public Object myOperator(...) { ... }
-
-    // AFTER
-    import gama.annotations.operator;
-    import gama.annotations.doc;
-
-    @operator(value = "my_operator", can_be_const = true)
-    @doc("Returns something")
-    public Object myOperator(...) { ... }
-    ```
-
-*   **Action Definition**
-    ```java
-    // BEFORE
-    import gama.annotations.precompiler.GamlAnnotations.action;
-
-    @action(name = "my_action")
-    public Object myAction(...) { ... }
-
-    // AFTER
-    import gama.annotations.action;
-
-    @action(name = "my_action")
-    public Object myAction(...) { ... }
-    ```
-
-*This applies systematically to all annotations: `@species`, `@skill`, `@getter`, `@setter`, `@variable`, `@vars`, `@type`, `@symbol`, `@display`, `@experiment`, etc.*
-
----
-
-## 9. UI and Display Interfaces Extraction (`gama.api.ui`)
-
-In alignment with the core architecture extraction, the graphical and user interface APIs have been separated from their Eclipse RCP, SWT, Java2D, or OpenGL implementations. The core interfaces now reside in the `gama.api.ui` package.
-
-If your plugin interacts with the UI, dialogs, or display surfaces, you need to update the following references:
-
-*   **General UI and Dialogs:**
-    *   `gama.core.common.interfaces.IGui` $\rightarrow$ `gama.api.ui.IGui`
-    *   `gama.api.ui.IDialogFactory` (new factory for user dialogs, file dialogs, etc.)
-*   **Displays and Graphics:**
-    *   `gama.core.outputs.display.IDisplaySurface` $\rightarrow$ `gama.api.ui.displays.IDisplaySurface`
-    *   `gama.core.common.interfaces.IGraphics` $\rightarrow$ `gama.api.ui.displays.IGraphics`
-    *   `gama.core.outputs.LayeredDisplayData` $\rightarrow$ `gama.api.ui.displays.IDisplayData`
-*   **Layers:**
-    *   `gama.core.outputs.layers.ILayer` $\rightarrow$ `gama.api.ui.layers.ILayer`
-    *   `gama.api.ui.layers.IDrawingAttributes` (used to encapsulate styling when drawing shapes).
-
----


### PR DESCRIPTION
This PR introduces a Markdown migration guide to help developers transition their code and plugins to the new GAMA Version 2026 architecture. 

It highlights:
- The move to JDK 25 and Eclipse 2025-12.
- The creation of the `gama.api` module to decouple public interfaces from implementation.
- Specific, detailed changes to the `IAgent` interface (e.g., migration to `IDelegatingShape`, use of `IPoint` over `GamaPoint`, read-only `peers`).
- The refactoring of Populations (`AbstractPopulation` base class, method renames like `createAgentAt` to `createAgentAtIndex`).
- Structural updates to the GAML compiler and utility libraries (`gama.api.utils.*`).

---
*PR created automatically by Jules for task [7934366638968357230](https://jules.google.com/task/7934366638968357230) started by @AlexisDrogoul*