### PR TITLE
Fix Java2D rendering on Linux Wayland

### DIFF
--- a/gama.ui.display.java2d/src/gama/ui/display/java2d/swing/SwingControlLinux.java
+++ b/gama.ui.display.java2d/src/gama/ui/display/java2d/swing/SwingControlLinux.java
@@ -109,4 +109,27 @@ public class SwingControlLinux extends SwingControl {
 	}
     }
 
+
+
+    @Override
+    protected void privateSetDimensions(final int width, final int height) {
+	WorkbenchHelper.asyncRun(() -> {
+	    if (isDisposed()) {
+		return;
+	    }
+	    org.eclipse.swt.graphics.Rectangle r = this.getBounds();
+	    int w = r.width;
+	    int h = r.height;
+	    if (!this.isDisposed() && (surface.getWidth() != w || surface.getHeight() != h)) {
+		this.requestLayout();
+	    }
+	    try {
+		EventQueue.invokeAndWait(() -> {
+		    surface.setBounds(0, 0, w, h);
+		});
+	    } catch (java.lang.reflect.InvocationTargetException | InterruptedException e) {
+		e.printStackTrace();
+	    }
+	});
+    }
 }


### PR DESCRIPTION
Fixes an issue where 2D displays using Java2D do not render under Wayland on Linux.

---
*PR created automatically by Jules for task [11295742480854017614](https://jules.google.com/task/11295742480854017614) started by @RoiArthurB*