### PR TITLE
Fix Windows display issues in OpenGL and OpenGL4 plugins

### DIFF
--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/view/GamaGLCanvas.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/view/GamaGLCanvas.java
@@ -117,7 +117,7 @@ public class GamaGLCanvas extends Composite implements GLAutoDrawable, IDelegate
 			@Override
 			public void controlResized(final ControlEvent e) {
 				/* Detached views have no title! */
-				if (SystemInfo.isMac()) {
+				if (SystemInfo.isMac() || SystemInfo.isWindows()) {
 					final var isDetached = parent.getShell().getText().length() == 0;
 					if (isDetached) {
 						if (!detached) {

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/view/OpenGLDisplayView.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/view/OpenGLDisplayView.java
@@ -101,7 +101,7 @@ public class OpenGLDisplayView extends LayeredDisplayView {
 	public void showCanvas() {
 		getGLCanvas().setVisible(true);
 		// Maybe only necessary on macOS ? Prevents JOGL views to move over Java2D views created before
-		if (SystemInfo.isMac()) { getGLCanvas().reparentWindow(); }
+		if (SystemInfo.isMac() || SystemInfo.isWindows()) { getGLCanvas().reparentWindow(); }
 	}
 
 	/**

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/view/GamaGLCanvas.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/view/GamaGLCanvas.java
@@ -117,7 +117,7 @@ public class GamaGLCanvas extends Composite implements GLAutoDrawable, IDelegate
 			@Override
 			public void controlResized(final ControlEvent e) {
 				/* Detached views have no title! */
-				if (SystemInfo.isMac()) {
+				if (SystemInfo.isMac() || SystemInfo.isWindows()) {
 					final var isDetached = parent.getShell().getText().length() == 0;
 					if (isDetached) {
 						if (!detached) {

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/view/OpenGLDisplayView.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/view/OpenGLDisplayView.java
@@ -101,7 +101,7 @@ public class OpenGLDisplayView extends LayeredDisplayView {
 	public void showCanvas() {
 		getGLCanvas().setVisible(true);
 		// Maybe only necessary on macOS ? Prevents JOGL views to move over Java2D views created before
-		if (SystemInfo.isMac()) { getGLCanvas().reparentWindow(); }
+		if (SystemInfo.isMac() || SystemInfo.isWindows()) { getGLCanvas().reparentWindow(); }
 	}
 
 	/**


### PR DESCRIPTION
This commit fixes various display problems that were identified on Windows (umbrella issue #878). 

The root cause was traced to a specific workaround involving reparenting the GLWindow to avoid it rendering improperly (or over Java2D views). Previously, this `reparentWindow()` logic in `OpenGLDisplayView.showCanvas()` and `GamaGLCanvas` resize handlers was strictly gated behind `SystemInfo.isMac()`. 

By extending this check to `SystemInfo.isMac() || SystemInfo.isWindows()`, the workaround correctly applies to Windows machines as well, resolving the display anomalies. This has been applied consistently to both the legacy `opengl` module and the new `opengl4` module.

---
*PR created automatically by Jules for task [10299653987207363922](https://jules.google.com/task/10299653987207363922) started by @AlexisDrogoul*