### PR TITLE
Fix keystone mode freezing issue on macOS

### DIFF
--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/shaders/FrameBufferObject.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/shaders/FrameBufferObject.java
@@ -167,7 +167,7 @@ public class FrameBufferObject {
 		gl.glGenTextures(1, textureArray, 0);
 		gl.glBindTexture(GL2.GL_TEXTURE_2D, textureArray[0]);
 		gl.glTexParameteri(GL2.GL_TEXTURE_2D, GL2.GL_TEXTURE_MAG_FILTER, GL2.GL_LINEAR);
-		gl.glTexParameteri(GL2.GL_TEXTURE_2D, GL2.GL_TEXTURE_MIN_FILTER, GL2.GL_LINEAR_MIPMAP_LINEAR);
+		gl.glTexParameteri(GL2.GL_TEXTURE_2D, GL2.GL_TEXTURE_MIN_FILTER, GL2.GL_LINEAR);
 		gl.glTexImage2D(GL2.GL_TEXTURE_2D, 0, GL2.GL_RGB, width, height, 0, GL2.GL_RGB, GL2.GL_UNSIGNED_BYTE,
 				(ByteBuffer) null);
 		gl.glFramebufferTextureEXT(GL2.GL_FRAMEBUFFER, GL2.GL_COLOR_ATTACHMENT0, textureArray[0], 0);


### PR DESCRIPTION
Replaced the `GL2.GL_LINEAR_MIPMAP_LINEAR` minification filter with `GL2.GL_LINEAR` for the FrameBufferObject texture attachment in the OpenGL display plugin. This resolves an issue where the texture was considered incomplete because mipmaps were never generated, which led to a "GLD_TEXTURE_INDEX_2D is unloadable" error and caused the display to freeze during keystone interaction.

---
*PR created automatically by Jules for task [13286337613796023246](https://jules.google.com/task/13286337613796023246) started by @AlexisDrogoul*