### PR TITLE
Add `text` property to files

### DIFF
--- a/gama.api/src/gama/api/types/file/GamaFile.java
+++ b/gama.api/src/gama/api/types/file/GamaFile.java
@@ -695,6 +695,15 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	}
 
 	@Override
+	public String getText(final IScope scope) throws GamaRuntimeException {
+		try {
+			return java.nio.file.Files.readString(java.nio.file.Paths.get(getPath(scope)));
+		} catch (java.io.IOException e) {
+			throw GamaRuntimeException.create(e, scope);
+		}
+	}
+
+	@Override
 	public Container getContents(final IScope scope) throws GamaRuntimeException {
 		if (buffer == null && !exists(scope))
 			throw GamaRuntimeException.error("File " + getFile(scope).getAbsolutePath() + " does not exist", scope);

--- a/gama.api/src/gama/api/types/file/IGamaFile.java
+++ b/gama.api/src/gama/api/types/file/IGamaFile.java
@@ -173,7 +173,11 @@ import gama.api.utils.geometry.IEnvelopeProvider;
 				type = ITypeProvider.WRAPPED,
 				of = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
 				index = ITypeProvider.KEY_TYPE_AT_INDEX + 1,
-				doc = { @doc ("Returns the contents of the receiver file in the form of a container") }) })
+				doc = { @doc ("Returns the contents of the receiver file in the form of a container") }),
+		@variable (
+				name = IKeyword.TEXT,
+				type = IType.STRING,
+				doc = { @doc ("Returns the whole content of the receiver file as a single string") }) })
 @SuppressWarnings ({ "rawtypes" })
 public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 		extends IContainer.Addressable, IContainer.Modifiable, IEnvelopeProvider, IAsset {
@@ -376,6 +380,18 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 */
 	@getter (IKeyword.CONTENTS)
 	C getContents(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Gets the text.
+	 *
+	 * @param scope
+	 *            the scope
+	 * @return the text
+	 * @throws GamaRuntimeException
+	 *             the gama runtime exception
+	 */
+	@getter (IKeyword.TEXT)
+	String getText(IScope scope) throws GamaRuntimeException;
 
 	/**
 	 * Gets the attributes.


### PR DESCRIPTION
This pull request adds a `text` property to `IGamaFile` and implements it in `GamaFile` to easily extract a file's raw content as a single string. This addresses feature request #763.

---
*PR created automatically by Jules for task [16190323734763905781](https://jules.google.com/task/16190323734763905781) started by @AlexisDrogoul*