### PR TITLE
Fix issue with deleted workspaces appearing in dropdown

### DIFF
--- a/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
+++ b/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
@@ -166,11 +166,17 @@ public class PickWorkspaceDialog extends TitleAreaDialog {
 	private void loadLastUsedWorkspaces() {
 		final String lastUsed = GAMA.getWorkspaceManager().getLastUsedWorkspaces();
 		lastUsedWorkspaces = new ArrayList<>();
-		if (lastUsed != null) {
+		if (lastUsed != null && !lastUsed.isEmpty()) {
 			final String[] all = lastUsed.split(splitChar);
 			for (String str : all) {
-				if (!str.isEmpty() && new File(str).exists()) {
-					lastUsedWorkspaces.add(str);
+				if (str != null && !str.trim().isEmpty()) {
+					try {
+						if (new File(str).exists()) {
+							lastUsedWorkspaces.add(str);
+						}
+					} catch (Exception e) {
+						// Ignore invalid files
+					}
 				}
 			}
 		}

--- a/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
+++ b/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
@@ -136,16 +136,7 @@ public class PickWorkspaceDialog extends TitleAreaDialog {
 			rememberWorkspaceButton.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 			rememberWorkspaceButton.setSelection(GAMA.getWorkspaceManager().isRememberWorkspace());
 
-			final String lastUsed = GAMA.getWorkspaceManager().getLastUsedWorkspaces();
-			lastUsedWorkspaces = new ArrayList<>();
-			if (lastUsed != null) {
-				final String[] all = lastUsed.split(splitChar);
-				for (String str : all) {
-					if (!str.isEmpty() && new File(str).exists()) {
-						lastUsedWorkspaces.add(str);
-					}
-				}
-			}
+			loadLastUsedWorkspaces();
 			for (final String last : lastUsedWorkspaces) { workspacePathCombo.add(last); }
 
 			/* Browse button on the right */
@@ -169,6 +160,19 @@ public class PickWorkspaceDialog extends TitleAreaDialog {
 		} catch (final RuntimeException err) {
 			err.printStackTrace();
 			return null;
+		}
+	}
+
+	private void loadLastUsedWorkspaces() {
+		final String lastUsed = GAMA.getWorkspaceManager().getLastUsedWorkspaces();
+		lastUsedWorkspaces = new ArrayList<>();
+		if (lastUsed != null) {
+			final String[] all = lastUsed.split(splitChar);
+			for (String str : all) {
+				if (!str.isEmpty() && new File(str).exists()) {
+					lastUsedWorkspaces.add(str);
+				}
+			}
 		}
 	}
 

--- a/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
+++ b/gama.ui.application/src/gama/ui/application/workbench/PickWorkspaceDialog.java
@@ -140,7 +140,11 @@ public class PickWorkspaceDialog extends TitleAreaDialog {
 			lastUsedWorkspaces = new ArrayList<>();
 			if (lastUsed != null) {
 				final String[] all = lastUsed.split(splitChar);
-				Collections.addAll(lastUsedWorkspaces, all);
+				for (String str : all) {
+					if (!str.isEmpty() && new File(str).exists()) {
+						lastUsedWorkspaces.add(str);
+					}
+				}
 			}
 			for (final String last : lastUsedWorkspaces) { workspacePathCombo.add(last); }
 


### PR DESCRIPTION
Filter out non-existent workspaces in PickWorkspaceDialog to prevent deleted workspaces from appearing in the dropdown.

---
*PR created automatically by Jules for task [4928701696037510169](https://jules.google.com/task/4928701696037510169) started by @AlexisDrogoul*