### PR TITLE
Separate Maps and Containers (see #1061)

### DIFF
--- a/gama.api/src/gama/api/gaml/statements/AbstractContainerStatement.java
+++ b/gama.api/src/gama/api/gaml/statements/AbstractContainerStatement.java
@@ -30,6 +30,7 @@ import gama.api.runtime.scope.IScope;
 import gama.api.types.geometry.IShape;
 import gama.api.types.graph.IGraph;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 
 /**
  * Abstract base class for statements that manipulate containers (add, remove, put).
@@ -99,6 +100,22 @@ import gama.api.types.misc.IContainer;
 @validator (ContainerValidator.class)
 @SuppressWarnings ({ "rawtypes" })
 public abstract class AbstractContainerStatement extends AbstractStatement {
+
+	/**
+	 * Returns whether a GAML type should still be handled through the runtime container APIs.
+	 *
+	 * <p>
+	 * Maps are no longer in the GAML {@code container} inheritance branch, but container statements must still accept
+	 * them through the shared runtime-container contracts for validation and execution.
+	 * </p>
+	 *
+	 * @param type
+	 *            the type to inspect
+	 * @return {@code true} for GAML containers and for maps during the transition period
+	 */
+	private static boolean isRuntimeContainerLike(final IType<?> type) {
+		return type != null && (type.isContainer() || type.getGamlType() == Types.MAP);
+	}
 
 	/**
 	 * Validator for container manipulation statements.
@@ -324,7 +341,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 				final IType<?> contentType = list.getGamlType().getContentType();
 				boolean isAll = false;
 				IType<?> valueType;
-				if (!PUT.equals(keyword) && all && item.getGamlType().isTranslatableInto(Types.CONTAINER)) {
+				if (!PUT.equals(keyword) && all && isRuntimeContainerLike(item.getGamlType())) {
 					isAll = true;
 					valueType = item.getGamlType().getContentType();
 				} else {
@@ -416,17 +433,17 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 		list = getFacet(IKeyword.TO);
 
 		asAll = all != null && IKeyword.TRUE.equals(all.literalValue());
-		asAllValues = asAll && item != null && item.getGamlType().isTranslatableInto(Types.CONTAINER);
-		asAllIndexes = asAll && index != null && index.getGamlType().isTranslatableInto(Types.CONTAINER);
+		asAllValues = asAll && item != null && isRuntimeContainerLike(item.getGamlType());
+		asAllIndexes = asAll && index != null && isRuntimeContainerLike(index.getGamlType());
 		final IType<?> t = list.getGamlType();
-		isDirect = t.isContainer();
+		isDirect = isRuntimeContainerLike(t);
 		isGraph = t.isTranslatableInto(Types.GRAPH);
 	}
 
 	@Override
 	public Object privateExecuteIn(final IScope scope) throws GamaRuntimeException {
 		// We then identify the container
-		final IContainer.Modifiable container = identifyContainer(scope);
+		final IRuntimeContainer.Modifiable container = identifyContainer(scope);
 
 		final Object position = identifyIndex(scope, container);
 		final Object object = identifyValue(scope, container);
@@ -451,7 +468,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 *            the container
 	 * @return the object
 	 */
-	protected Object identifyValue(final IScope scope, final IContainer.Modifiable container) {
+	protected Object identifyValue(final IScope scope, final IRuntimeContainer.Modifiable container) {
 		if (item == null) return null;
 		// For the moment, only graphs need to recompute their objects
 		// GamaFloatMatrix and GamaField need too, as GAML happily accepts int ...
@@ -472,7 +489,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 *            the container
 	 * @return the object
 	 */
-	protected Object identifyIndex(final IScope scope, final IContainer.Modifiable container) {
+	protected Object identifyIndex(final IScope scope, final IRuntimeContainer.Modifiable container) {
 		if (index == null) return null;
 		if (isGraph) return buildIndex(scope, (IGraph) container);
 		return index.value(scope);
@@ -488,7 +505,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 * @return the object
 	 */
 	protected Object buildValue(final IScope scope, final IGraph container) {
-		if (asAllValues) return container.buildValues(scope, (IContainer.Modifiable) this.item.value(scope));
+		if (asAllValues) return container.buildValues(scope, (IRuntimeContainer) this.item.value(scope));
 		return container.buildValue(scope, this.item.value(scope));
 	}
 
@@ -502,7 +519,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 * @return the object
 	 */
 	protected Object buildIndex(final IScope scope, final IGraph container) {
-		if (asAllIndexes) return container.buildIndexes(scope, (IContainer.Modifiable) this.index.value(scope));
+		if (asAllIndexes) return container.buildIndexes(scope, (IRuntimeContainer) this.index.value(scope));
 		return container.buildIndex(scope, this.index.value(scope));
 	}
 
@@ -510,9 +527,9 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 * @throws GamaRuntimeException
 	 * @return the container to which this command will be applied
 	 */
-	private IContainer.Modifiable identifyContainer(final IScope scope) throws GamaRuntimeException {
+	private IRuntimeContainer.Modifiable identifyContainer(final IScope scope) throws GamaRuntimeException {
 		final Object cont = list.value(scope);
-		if (isDirect) return (IContainer.Modifiable) cont;
+		if (isDirect) return (IRuntimeContainer.Modifiable) cont;
 		if (cont instanceof IShape) return ((IShape) cont).getOrCreateAttributes();
 		throw GamaRuntimeException.warning("Cannot use " + list.serializeToGaml(false) + ", of type "
 				+ list.getGamlType().toString() + ", as a container", scope);
@@ -527,7 +544,7 @@ public abstract class AbstractContainerStatement extends AbstractStatement {
 	 * @param container
 	 * @throws GamaRuntimeException
 	 */
-	protected abstract void apply(IScope scope, Object object, Object position, IContainer.Modifiable container)
+	protected abstract void apply(IScope scope, Object object, Object position, IRuntimeContainer.Modifiable container)
 			throws GamaRuntimeException;
 
 }

--- a/gama.api/src/gama/api/gaml/types/GamaContainerType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaContainerType.java
@@ -19,13 +19,18 @@ import gama.api.gaml.expressions.IExpression;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.list.IList;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 
 /**
  * Represents the generic GAML container type.
  * <p>
- * This is the super-type of all container types in GAML (list, graph, matrix, map, etc.). It provides a generic
- * framework for types that hold collections of values with keys/indices. Container types are compound types with
- * variable length and support parameterization by key type and content type.
+ * This is the super-type of the indexed/sequential container types in GAML (list, graph, matrix, etc.). It provides a
+ * generic framework for types that hold collections of values with keys/indices. Container types are compound types
+ * with variable length and support parameterization by key type and content type.
+ * </p>
+ * <p>
+ * Maps still expose most container-oriented operators in GAML, but they are intentionally kept out of the
+ * {@code container} inheritance branch of the type hierarchy.
  * </p>
  * <p>
  * When casting to a container type, if the object is already a container it is returned as-is, otherwise it is cast to
@@ -38,6 +43,7 @@ import gama.api.types.misc.IContainer;
  * @author drogoul
  * @since GAMA 1.0
  * @see IContainer
+ * @see IRuntimeContainer
  * @see IContainerType
  */
 @type (
@@ -46,8 +52,8 @@ import gama.api.types.misc.IContainer;
 		wraps = { IContainer.class },
 		kind = ISymbolKind.REGULAR,
 		concept = { IConcept.TYPE, IConcept.CONTAINER },
-		doc = @doc ("Generic super-type of all the container types (list, graph, matrix, etc.)"))
-public class GamaContainerType<T extends IContainer<?, ?>> extends GamaType<T> implements IContainerType<T> {
+		doc = @doc ("Generic super-type of indexed/sequential container types (list, graph, matrix, etc.). Maps keep the same GAML capabilities but are no longer in this inheritance branch."))
+public class GamaContainerType<T extends IRuntimeContainer<?, ?>> extends GamaType<T> implements IContainerType<T> {
 
 	/**
 	 * Constructs a new GamaContainerType.
@@ -212,7 +218,7 @@ public class GamaContainerType<T extends IContainer<?, ?>> extends GamaType<T> i
 			if (kt == Types.NO_TYPE) return this;
 			ct = getContentType();
 		}
-		return new ParametricType(typesManager, (IContainerType<IContainer<?, ?>>) this, kt, ct);
+		return new ParametricType(typesManager, (IContainerType<IRuntimeContainer<?, ?>>) this, kt, ct);
 
 	}
 
@@ -239,7 +245,7 @@ public class GamaContainerType<T extends IContainer<?, ?>> extends GamaType<T> i
 			ct = getContentType();
 		}
 		if (kt == Types.NO_TYPE) { kt = getKeyType(); }
-		return new ParametricType(typesManager, (IContainerType<IContainer<?, ?>>) this, kt, ct);
+		return new ParametricType(typesManager, (IContainerType<IRuntimeContainer<?, ?>>) this, kt, ct);
 
 	}
 

--- a/gama.api/src/gama/api/gaml/types/GamaMapType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaMapType.java
@@ -69,6 +69,10 @@ import gama.api.types.map.IMap;
  * Maps preserve insertion order, making them suitable for ordered dictionaries. They are implemented using {@link IMap}
  * interface and created via {@link GamaMapFactory}.
  * </p>
+ * <p>
+ * In the GAML type hierarchy, maps are intentionally kept separate from the {@code container} inheritance branch even
+ * though they still support the same map syntax, parametric typing, and most container-oriented operators.
+ * </p>
  *
  * @author drogoul
  * @since GAMA 1.0
@@ -84,7 +88,7 @@ import gama.api.types.map.IMap;
 		wraps = { IMap.class },
 		kind = ISymbolKind.REGULAR,
 		concept = { IConcept.TYPE, IConcept.CONTAINER, IConcept.MAP },
-		doc = @doc ("Represents lists of pairs key::value, where each key is unique in the map. Maps are ordered by the insertion order of elements"))
+		doc = @doc ("Represents lists of pairs key::value, where each key is unique in the map. Maps are ordered by the insertion order of elements and remain separate from the `container` inheritance branch while keeping the same GAML syntax and operators."))
 @SuppressWarnings ({ "unchecked", "rawtypes" })
 public class GamaMapType extends GamaContainerType<IMap> {
 

--- a/gama.api/src/gama/api/gaml/types/GamaMatrixType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaMatrixType.java
@@ -153,7 +153,7 @@ public class GamaMatrixType extends GamaContainerType<IMatrix> {
 	 * contain:
 	 * <ul>
 	 * <li>For list of lists: returns the type of elements in the inner lists</li>
-	 * <li>For containers: returns the container's content type</li>
+	 * <li>For container-like values (including maps): returns the source content type</li>
 	 * <li>Otherwise: returns the expression's type itself</li>
 	 * </ul>
 	 * </p>
@@ -178,7 +178,7 @@ public class GamaMatrixType extends GamaContainerType<IMatrix> {
 			if (array.length == 0) return Types.NO_TYPE;
 			return array[0].getGamlType().getContentType();
 		}
-		if (Types.CONTAINER.isAssignableFrom(itemType)) return itemType.getContentType();
+		if (itemType.isContainer()) return itemType.getContentType();
 		return itemType;
 	}
 

--- a/gama.api/src/gama/api/gaml/types/GamaType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaType.java
@@ -31,6 +31,7 @@ import gama.api.gaml.expressions.IExpression;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.map.IMap;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.misc.IValue;
 import gama.api.utils.GamlProperties;
 import gama.dev.DEBUG;
@@ -745,7 +746,10 @@ public abstract class GamaType<Support> implements IType<Support> {
 			IType<?> parent = type.getParent();
 			return 1 + distanceTo(parent);
 		}
-		return 1 + getParent().distanceTo(type);
+		final IType<?> parent = getParent();
+		if (parent == null || parent == Types.NO_TYPE) return Integer.MAX_VALUE;
+		final int parentDistance = parent.distanceTo(type);
+		return parentDistance == Integer.MAX_VALUE ? Integer.MAX_VALUE : 1 + parentDistance;
 	}
 
 	/**
@@ -781,7 +785,8 @@ public abstract class GamaType<Support> implements IType<Support> {
 	 * Algorithm:
 	 * <ul>
 	 * <li>If types are identical, return this type</li>
-	 * <li>If other type is NO_TYPE, return this type (or NO_TYPE if default is null)</li>
+	 * <li>If other type is NO_TYPE, return this type unless the current type is already a direct child of the root, in
+	 * which case NO_TYPE is the only remaining common supertype</li>
 	 * <li>If other type is translatable into this, return this type</li>
 	 * <li>If this is translatable into other, return other type</li>
 	 * <li>Otherwise, recursively find common supertype of parents</li>
@@ -796,7 +801,10 @@ public abstract class GamaType<Support> implements IType<Support> {
 	@Override
 	public IType<? super Support> computeFindCommonSupertypeWith(final IType<?> type) {
 		if (type == this) return this;
-		if (type == Types.NO_TYPE) return getDefault() == null ? this : (GamaNoType) type;
+		if (type == Types.NO_TYPE) {
+			if (getParent() == Types.NO_TYPE) return (GamaNoType) type;
+			return getDefault() == null ? this : (GamaNoType) type;
+		}
 		if (type.isTranslatableInto(this)) return this;
 		if (this.isTranslatableInto(type)) return (IType) type;
 		return getParent().findCommonSupertypeWith(type.getParent());
@@ -951,7 +959,7 @@ public abstract class GamaType<Support> implements IType<Support> {
 	 *            the desired content type (or NO_TYPE to use default)
 	 * @return a parametric container type with the specified key and content types
 	 */
-	public static IContainerType<?> from(final IContainerType<IContainer<?, ?>> t, final IType<?> keyType,
+	public static IContainerType<?> from(final IContainerType<IRuntimeContainer<?, ?>> t, final IType<?> keyType,
 			final IType<?> contentType) {
 		if ((keyType == null || keyType == Types.NO_TYPE) && (contentType == null || contentType == Types.NO_TYPE))
 			return t;

--- a/gama.api/src/gama/api/gaml/types/IContainerType.java
+++ b/gama.api/src/gama/api/gaml/types/IContainerType.java
@@ -14,6 +14,7 @@ import gama.annotations.constants.IKeyword;
 import gama.api.gaml.expressions.IExpression;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.utils.json.IJson;
 import gama.api.utils.json.IJsonValue;
 
@@ -40,9 +41,10 @@ import gama.api.utils.json.IJsonValue;
  * @since GAMA 1.0
  * @see IType
  * @see IContainer
+ * @see IRuntimeContainer
  * @see GamaContainerType
  */
-public interface IContainerType<T extends IContainer<?, ?>> extends IType<T> {
+public interface IContainerType<T extends IRuntimeContainer<?, ?>> extends IType<T> {
 
 	/**
 	 * Gets the GAML type representation of this container type.

--- a/gama.api/src/gama/api/gaml/types/IType.java
+++ b/gama.api/src/gama/api/gaml/types/IType.java
@@ -662,8 +662,8 @@ public interface IType<Support> extends IGamlDescription, ITyped, IJsonable {
 	 *   ├─ float
 	 *   ├─ container
 	 *   │   ├─ list
-	 *   │   ├─ map
 	 *   │   └─ matrix
+	 *   ├─ map
 	 *   └─ geometry
 	 *       └─ point
 	 * </pre>

--- a/gama.api/src/gama/api/gaml/types/ParametricFileType.java
+++ b/gama.api/src/gama/api/gaml/types/ParametricFileType.java
@@ -29,6 +29,7 @@ import gama.api.runtime.scope.IScope;
 import gama.api.types.file.GenericFile;
 import gama.api.types.file.IGamaFile;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.utils.GamlProperties;
 
 /**
@@ -439,7 +440,7 @@ public class ParametricFileType extends ParametricType {
 	 * @return the created file instance
 	 */
 	@SuppressWarnings ({ "rawtypes", "unchecked" })
-	public IGamaFile createFile(final IScope scope, final String path, final IContainer.Modifiable contents) {
+	public IGamaFile createFile(final IScope scope, final String path, final IRuntimeContainer.Modifiable contents) {
 		final IGamaFile file = builder.get(scope, path);
 		if (contents != null) {
 			file.setWritable(scope, true);

--- a/gama.api/src/gama/api/gaml/types/ParametricType.java
+++ b/gama.api/src/gama/api/gaml/types/ParametricType.java
@@ -25,6 +25,7 @@ import gama.api.gaml.expressions.IExpression;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.map.IMap;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.utils.GamlProperties;
 import gama.dev.DEBUG;
 
@@ -59,14 +60,14 @@ import gama.dev.DEBUG;
  * @see GamaContainerType
  * @see IType
  */
-public class ParametricType implements IContainerType<IContainer<?, ?>> {
+public class ParametricType implements IContainerType<IRuntimeContainer<?, ?>> {
 
 	static {
 		DEBUG.OFF();
 	}
 
 	/** The base container type (e.g., list, map, matrix). */
-	private final IContainerType<IContainer<?, ?>> type;
+	private final IContainerType<IRuntimeContainer<?, ?>> type;
 
 	/** The content/value type parameter. */
 	private final IType<?> contentsType;
@@ -99,7 +100,8 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 * @param ct
 	 *            the content type parameter
 	 */
-	protected ParametricType(final ITypesManager manager, final IContainerType<IContainer<?, ?>> t, final IType<?> kt,
+	protected ParametricType(final ITypesManager manager, final IContainerType<IRuntimeContainer<?, ?>> t,
+			final IType<?> kt,
 			final IType<?> ct) {
 		type = t;
 		contentsType = ct;
@@ -172,7 +174,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 * @see gama.api.gaml.types.ITyped#getGamlType()
 	 */
 	@Override
-	public IContainerType<IContainer<?, ?>> getGamlType() { return type; }
+	public IContainerType<IRuntimeContainer<?, ?>> getGamlType() { return type; }
 
 	/**
 	 * Method cast()
@@ -181,7 +183,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 *      gama.api.gaml.types.IType, gama.api.gaml.types.IType)
 	 */
 	@Override
-	public IContainer<?, ?> cast(final IScope scope, final Object obj, final Object param, final IType<?> kt,
+	public IRuntimeContainer<?, ?> cast(final IScope scope, final Object obj, final Object param, final IType<?> kt,
 			final IType<?> ct, final boolean copy) throws GamaRuntimeException {
 		return type.cast(scope, obj, param, keyType, contentsType, copy);
 	}
@@ -202,7 +204,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 * @see gama.api.gaml.types.IType#toClass()
 	 */
 	@Override
-	public Class<? extends IContainer<?, ?>> toClass() {
+	public Class<? extends IRuntimeContainer<?, ?>> toClass() {
 		return type.toClass();
 	}
 
@@ -212,7 +214,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 * @see gama.api.gaml.types.IType#getDefault()
 	 */
 	@Override
-	public IContainer<?, ?> getDefault() { return type.getDefault(); }
+	public IRuntimeContainer<?, ?> getDefault() { return type.getDefault(); }
 
 	/**
 	 * Method getVarKind()
@@ -350,7 +352,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 * @see gama.api.gaml.types.IType#setParent(gama.api.gaml.types.IType)
 	 */
 	@Override
-	public void setParent(final IType<? super IContainer<?, ?>> p) {}
+	public void setParent(final IType<? super IRuntimeContainer<?, ?>> p) {}
 
 	/**
 	 * Method getParent()
@@ -378,8 +380,13 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	@Override
 	public int computeDistanceTo(final IType<?> t) {
 		// Use polymorphic internal methods to avoid recursion
-		return t.getGamlType().computeDistanceTo(type) + t.getContentType().computeDistanceTo(contentsType)
-				+ t.getKeyType().computeDistanceTo(keyType);
+		final int typeDistance = t.getGamlType().computeDistanceTo(type);
+		if (typeDistance == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+		final int contentDistance = t.getContentType().computeDistanceTo(contentsType);
+		if (contentDistance == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+		final int keyDistance = t.getKeyType().computeDistanceTo(keyType);
+		if (keyDistance == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+		return typeDistance + contentDistance + keyDistance;
 	}
 
 	@Override
@@ -433,7 +440,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	 */
 	@SuppressWarnings ("unchecked")
 	@Override
-	public IType<? super IContainer<?, ?>> computeFindCommonSupertypeWith(final IType<?> iType) {
+	public IType<? super IRuntimeContainer<?, ?>> computeFindCommonSupertypeWith(final IType<?> iType) {
 		// Use polymorphic internal methods to avoid recursion
 		if (iType instanceof ParametricType) {
 			final IType<?> pType = iType;
@@ -441,19 +448,19 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 			if (cType.isContainer()) {
 				final IType<?> kt = keyType.computeFindCommonSupertypeWith(pType.getKeyType());
 				final IType<?> ct = contentsType.computeFindCommonSupertypeWith(pType.getContentType());
-				return (IType<? super IContainer<?, ?>>) GamaType.from(cType, kt, ct);
+				return (IType<? super IRuntimeContainer<?, ?>>) GamaType.from(cType, kt, ct);
 			}
-			return (IType<? super IContainer<?, ?>>) cType;
+			return (IType<? super IRuntimeContainer<?, ?>>) cType;
 		}
-		return type;
+		return (IType<? super IRuntimeContainer<?, ?>>) type.computeFindCommonSupertypeWith(iType);
 	}
 
 	@SuppressWarnings ("unchecked")
 	@Override
-	public IType<? super IContainer<?, ?>> findCommonSupertypeWith(final IType<?> iType) {
+	public IType<? super IRuntimeContainer<?, ?>> findCommonSupertypeWith(final IType<?> iType) {
 		// Use cached version if typesManager is available
 		if (typesManager != null)
-			return (IType<? super IContainer<?, ?>>) typesManager.computeCommonSupertype(this, iType);
+			return (IType<? super IRuntimeContainer<?, ?>>) typesManager.computeCommonSupertype(this, iType);
 		// Fallback to direct computation
 		return computeFindCommonSupertypeWith(iType);
 	}
@@ -462,7 +469,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	public boolean isDrawable() { return type.isDrawable(); }
 
 	@Override
-	public IContainer<?, ?> cast(final IScope scope, final Object obj, final Object param, final boolean copy)
+	public IRuntimeContainer<?, ?> cast(final IScope scope, final Object obj, final Object param, final boolean copy)
 			throws GamaRuntimeException {
 		return cast(scope, obj, param, keyType, contentsType, copy);
 	}
@@ -597,7 +604,7 @@ public class ParametricType implements IContainerType<IContainer<?, ?>> {
 	public Map<String, IArtefact.Operator> getFieldGetters() { return type.getFieldGetters(); }
 
 	@Override
-	public IContainer<?, ?> deserializeFromJson(final IScope scope, final IMap<String, Object> map2) {
+	public IRuntimeContainer<?, ?> deserializeFromJson(final IScope scope, final IMap<String, Object> map2) {
 		map2.put("requested_type", this);
 		return type.deserializeFromJson(scope, map2);
 	}

--- a/gama.api/src/gama/api/gaml/types/Signature.java
+++ b/gama.api/src/gama/api/gaml/types/Signature.java
@@ -57,6 +57,48 @@ public record Signature(IType... list) implements Iterable<IType> {
 	static IType[] EMPTY_TYPES = {};
 
 	/**
+	 * Returns whether a split GAML {@code map} type can still use a runtime operator overload declared on
+	 * {@code container}.
+	 *
+	 * <p>
+	 * Maps are no longer in the GAML {@code container} inheritance branch, but the Java runtime still exposes
+	 * {@link gama.api.types.map.IMap} as an {@link gama.api.types.misc.IContainer}. Operator resolution therefore keeps
+	 * this one compatibility path so existing container-oriented implementations remain callable for maps until the Java
+	 * interfaces are detached as well.
+	 * </p>
+	 *
+	 * @param actualType
+	 *            the type provided by the user call
+	 * @param formalType
+	 *            the operator parameter type being tested
+	 * @return {@code true} when a map argument should be accepted for a container parameter
+	 */
+	private static boolean isRuntimeContainerCompatibility(final IType actualType, final IType formalType) {
+		return actualType != null && formalType != null && actualType.getGamlType() == Types.MAP
+				&& formalType.getGamlType() == Types.CONTAINER;
+	}
+
+	/**
+	 * Computes the compatibility distance between a formal operator parameter and the actual user argument type.
+	 *
+	 * <p>
+	 * The split {@code map}/{@code container} compatibility is intentionally given a distance of {@code 1}, so an
+	 * explicit map overload still wins over a generic container overload, while the latter remains selectable when no map
+	 * overload exists.
+	 * </p>
+	 *
+	 * @param formalType
+	 *            the operator parameter type
+	 * @param actualType
+	 *            the provided argument type
+	 * @return the overload distance, or {@link Integer#MAX_VALUE} when incompatible
+	 */
+	private static int compatibilityDistance(final IType formalType, final IType actualType) {
+		if (isRuntimeContainerCompatibility(actualType, formalType)) return 1;
+		return formalType.distanceTo(actualType);
+	}
+
+	/**
 	 * Builds a var-arg signature by wrapping the common type of elements into a list type.
 	 * <p>
 	 * This is useful when an operator accepts an arbitrary number of homogeneous arguments.
@@ -236,6 +278,8 @@ public record Signature(IType... list) implements Iterable<IType> {
 			if (requestedType == Types.NO_TYPE && !localType.isNumber()) continue;
 			// Explicit unknown passed with a formal parameter that is not a number
 			if (localType == Types.NO_TYPE && !requestedType.isNumber()) continue;
+			// Transitional runtime compatibility: maps still implement IContainer at Java level
+			if (isRuntimeContainerCompatibility(localType, requestedType)) continue;
 			// Assignable types
 			if (requestedType.isAssignableFrom(localType)) continue;
 			return false;
@@ -256,6 +300,7 @@ public record Signature(IType... list) implements Iterable<IType> {
 			final IType ownType = list[i];
 			final IType desiredType = types[i];
 			if (Types.intFloatCase(ownType, desiredType) || desiredType.isAssignableFrom(ownType)
+					|| isRuntimeContainerCompatibility(ownType, desiredType)
 					|| !desiredType.isNumber() && ownType == Types.NO_TYPE) {
 				continue;
 			}
@@ -283,7 +328,11 @@ public record Signature(IType... list) implements Iterable<IType> {
 		// Modified again for the case where [string, matrix, unknown] and [string, container, unknown] return both 1
 		// for an input of [string,matrix, int] ...Now we sum the distances between types and return this.
 		int totalDistance = 0;
-		for (int i = 0; i < formalTypes.length; i++) { totalDistance += formalTypes[i].distanceTo(passedTypes[i]); }
+		for (int i = 0; i < formalTypes.length; i++) {
+			final int distance = compatibilityDistance(formalTypes[i], passedTypes[i]);
+			if (distance == Integer.MAX_VALUE) return Integer.MAX_VALUE;
+			totalDistance += distance;
+		}
 		return totalDistance;
 	}
 

--- a/gama.api/src/gama/api/gaml/types/Types.java
+++ b/gama.api/src/gama/api/gaml/types/Types.java
@@ -30,6 +30,7 @@ import gama.api.gaml.GAML;
 import gama.api.gaml.expressions.IExpression;
 import gama.api.kernel.species.IModelSpecies;
 import gama.api.runtime.scope.IScope;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.object.GamaGenericObjectType;
 import gama.dev.DEBUG;
 
@@ -47,6 +48,11 @@ public class Types {
 
 	static {
 		DEBUG.OFF();
+		addClassTypeCorrespondance(IRuntimeContainer.class, IKeyword.CONTAINER);
+		addClassTypeCorrespondance(IRuntimeContainer.Addressable.class, IKeyword.CONTAINER);
+		addClassTypeCorrespondance(IRuntimeContainer.Modifiable.class, IKeyword.CONTAINER);
+		addClassTypeCorrespondance(IRuntimeContainer.ToGet.class, IKeyword.CONTAINER);
+		addClassTypeCorrespondance(IRuntimeContainer.ToSet.class, IKeyword.CONTAINER);
 	}
 
 	/**
@@ -383,13 +389,19 @@ public class Types {
 	 *   ├─ string
 	 *   ├─ container
 	 *   │   ├─ list
-	 *   │   ├─ map
 	 *   │   ├─ matrix
 	 *   │   └─ graph
+	 *   ├─ map
 	 *   ├─ geometry
 	 *   │   └─ point
 	 *   └─ agent
 	 * </pre>
+	 *
+	 * <p>
+	 * Maps remain fully supported by GAML map syntax and operators, but they are intentionally excluded from the
+	 * {@code container} inheritance branch to avoid conflating associative maps with sequential/indexed containers in the
+	 * type hierarchy.
+	 * </p>
 	 *
 	 * <p>
 	 * This method should be called once during GAMA platform initialization, after all built-in types have been
@@ -406,7 +418,7 @@ public class Types {
 		}
 		for (IType t1 : types) {
 			for (IType t2 : types) {
-				if (t1 != t2 && t1.toClass().isAssignableFrom(t2.toClass())) {
+				if (t1 != t2 && t1.toClass().isAssignableFrom(t2.toClass()) && !shouldIgnoreHierarchyEdge(t1, t2)) {
 					outgoing.get(t1).add(t2);
 					incoming.get(t2).add(t1);
 				}
@@ -430,6 +442,25 @@ public class Types {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Indicates whether a Java-level assignability edge should be ignored when constructing the GAML type hierarchy.
+	 *
+	 * <p>
+	 * The runtime APIs still let maps participate in most container-oriented operators, but the type hierarchy must keep
+	 * {@code map} separate from {@code container} so assignability and common-supertype inference do not collapse
+	 * associative maps into sequential/indexed containers.
+	 * </p>
+	 *
+	 * @param parent
+	 *            the candidate parent type inferred from Java assignability
+	 * @param child
+	 *            the candidate child type inferred from Java assignability
+	 * @return {@code true} if this edge must be skipped in the GAML type hierarchy
+	 */
+	private static boolean shouldIgnoreHierarchyEdge(final IType<?> parent, final IType<?> child) {
+		return parent == CONTAINER && child == MAP;
 	}
 
 	/**

--- a/gama.api/src/gama/api/types/file/GamaFile.java
+++ b/gama.api/src/gama/api/types/file/GamaFile.java
@@ -34,6 +34,7 @@ import gama.api.types.list.IList;
 import gama.api.types.map.IMap;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.ui.IStatusMessage;
 import gama.api.utils.files.FileUtils;
 import gama.api.utils.geometry.IEnvelope;
@@ -59,8 +60,8 @@ import one.util.streamex.StreamEx;
  * <h2>Type Parameters</h2>
  * <ul>
  * <li>{@code Container} - The container type used to hold file contents. Must be both
- * {@link gama.api.types.misc.IContainer.Addressable} (support indexed/keyed access) and
- * {@link gama.api.types.misc.IContainer.Modifiable} (support modifications)</li>
+ * {@link gama.api.types.misc.IRuntimeContainer.Addressable} (support indexed/keyed access) and
+ * {@link gama.api.types.misc.IRuntimeContainer.Modifiable} (support modifications)</li>
  * <li>{@code Contents} - The type of individual elements stored in the container</li>
  * </ul>
  * 
@@ -173,7 +174,7 @@ import one.util.streamex.StreamEx;
  */
 
 @SuppressWarnings ({ "rawtypes", "unchecked" })
-public abstract class GamaFile<Container extends IContainer.Addressable & IContainer.Modifiable, Contents>
+public abstract class GamaFile<Container extends IRuntimeContainer.Addressable & IRuntimeContainer.Modifiable, Contents>
 		implements IGamaFile<Container, Contents> {
 
 	/** The file. */
@@ -425,7 +426,7 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	 * <p>
 	 * This method is called lazily when file contents are first accessed. Subclasses must
 	 * implement this method to read the file from disk (or other source) and populate the
-	 * buffer with appropriate data. The loaded contents should be set using {@link #setBuffer(IContainer)}.
+	 * buffer with appropriate data. The loaded contents should be set using {@link #setBuffer(IRuntimeContainer.Modifiable)}.
 	 * </p>
 	 * 
 	 * <p>
@@ -569,7 +570,7 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	// Then, methods for "all" operations
 	// Adds the values if possible, without replacing existing ones
 	@Override
-	public void addValues(final IScope scope, final Object index, final IContainer values) {
+	public void addValues(final IScope scope, final Object index, final IRuntimeContainer values) {
 		// Addition of the index (see #2985)
 		fillBuffer(scope);
 		getBuffer().addValues(scope, index, values);
@@ -596,7 +597,7 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	}
 
 	@Override
-	public void removeValues(final IScope scope, final IContainer values) {
+	public void removeValues(final IScope scope, final IRuntimeContainer values) {
 		fillBuffer(scope);
 		getBuffer().removeValues(scope, values);
 	}
@@ -608,7 +609,7 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	}
 
 	@Override
-	public void removeIndexes(final IScope scope, final IContainer indexes) {
+	public void removeIndexes(final IScope scope, final IRuntimeContainer indexes) {
 		fillBuffer(scope);
 		getBuffer().removeIndexes(scope, indexes);
 	}
@@ -803,7 +804,7 @@ public abstract class GamaFile<Container extends IContainer.Addressable & IConta
 	}
 
 	@Override
-	public IContainer<?, ?> reverse(final IScope scope) throws GamaRuntimeException {
+	public IRuntimeContainer<?, ?> reverse(final IScope scope) throws GamaRuntimeException {
 		getContents(scope);
 		return getBuffer().reverse(scope);
 		// No side effect

--- a/gama.api/src/gama/api/types/file/IGamaFile.java
+++ b/gama.api/src/gama/api/types/file/IGamaFile.java
@@ -12,10 +12,15 @@ package gama.api.types.file;
 import org.eclipse.emf.common.util.URI;
 
 import gama.annotations.doc;
+import gama.annotations.example;
 import gama.annotations.getter;
+import gama.annotations.operator;
+import gama.annotations.test;
 import gama.annotations.variable;
 import gama.annotations.vars;
 import gama.annotations.constants.IKeyword;
+import gama.annotations.support.IConcept;
+import gama.annotations.support.IOperatorCategory;
 import gama.annotations.support.ITypeProvider;
 import gama.api.exceptions.GamaRuntimeException;
 import gama.api.gaml.symbols.Facets;
@@ -24,6 +29,7 @@ import gama.api.runtime.scope.IScope;
 import gama.api.types.geometry.IShape;
 import gama.api.types.list.IList;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.ui.displays.IAsset;
 import gama.api.utils.geometry.IEnvelopeProvider;
 
@@ -32,8 +38,8 @@ import gama.api.utils.geometry.IEnvelopeProvider;
  * 
  * <p>
  * {@code IGamaFile} provides a unified abstraction for accessing and manipulating files within GAMA models.
- * It extends both {@link gama.api.types.misc.IContainer.Addressable} and
- * {@link gama.api.types.misc.IContainer.Modifiable} to enable file contents to be treated as addressable
+ * It extends both {@link gama.api.types.misc.IRuntimeContainer.Addressable} and
+ * {@link gama.api.types.misc.IRuntimeContainer.Modifiable} to enable file contents to be treated as addressable
  * and modifiable containers, allowing natural integration with GAML's container operations.
  * </p>
  * 
@@ -123,7 +129,7 @@ import gama.api.utils.geometry.IEnvelopeProvider;
  * </ul>
  * 
  * @param <C>
- *            the container type for storing file contents (must be both Addressable and Modifiable)
+ *            the runtime container type for storing file contents (must be both Addressable and Modifiable)
  * @param <Contents>
  *            the type of individual elements within the container
  * 
@@ -179,8 +185,8 @@ import gama.api.utils.geometry.IEnvelopeProvider;
 				type = IType.STRING,
 				doc = { @doc ("Returns the whole content of the receiver file as a single string") }) })
 @SuppressWarnings ({ "rawtypes" })
-public interface IGamaFile<C extends IContainer.Modifiable, Contents>
-		extends IContainer.Addressable, IContainer.Modifiable, IEnvelopeProvider, IAsset {
+public interface IGamaFile<C extends IRuntimeContainer.Modifiable, Contents>
+		extends IRuntimeContainer.Addressable, IRuntimeContainer.Modifiable, IEnvelopeProvider, IAsset {
 
 	/**
 	 * Marker interface for file types that can be rendered visually in displays.
@@ -251,7 +257,7 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 * 
 	 * <p>
 	 * This method controls whether the file can accept modifications and be saved back to disk.
-	 * Setting a file as writable enables operations like {@link #setContents(IContainer)} and
+	 * Setting a file as writable enables operations like {@link #setContents(IRuntimeContainer.Modifiable)} and
 	 * allows the file to be used as an output destination in save operations.
 	 * </p>
 	 * 
@@ -267,6 +273,24 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 *            true to mark this file as writable, false otherwise
 	 */
 	void setWritable(IScope scope, final boolean w);
+
+	/**
+	 * Returns whether the file contents contain the provided value.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param o
+	 *            the searched value
+	 * @return {@code true} if the buffered contents contain the value
+	 */
+	@operator (
+			value = { "contains", "contains_value" },
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "true if the buffered contents of the file contain the right operand, false otherwise")
+	@Override
+	boolean contains(IScope scope, Object o) throws GamaRuntimeException;
 
 	/**
 	 * Sets the contents of this file.
@@ -303,6 +327,113 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 */
 	@Override
 	IGamaFile copy(IScope scope);
+
+	/**
+	 * Returns the first value of the buffered contents.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the first buffered value, or {@code nil} when appropriate
+	 * @throws GamaRuntimeException
+	 *             if the buffered contents cannot be accessed
+	 */
+	@operator (
+			value = "first",
+			can_be_const = true,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "the first value of the buffered file contents")
+	@Override
+	Contents firstValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the last value of the buffered contents.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the last buffered value, or {@code nil} when appropriate
+	 * @throws GamaRuntimeException
+	 *             if the buffered contents cannot be accessed
+	 */
+	@operator (
+			value = "last",
+			can_be_const = true,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "the last value of the buffered file contents")
+	@Override
+	Contents lastValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the number of buffered elements in this file.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the buffered length of the file contents
+	 */
+	@operator (
+			value = "length",
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "the number of elements in the buffered file contents")
+	@Override
+	int length(IScope scope);
+
+	/**
+	 * Returns whether the buffered contents are empty.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return {@code true} if the buffered contents are empty
+	 */
+	@operator (
+			value = "empty",
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "true if the buffered file contents are empty, false otherwise")
+	@Override
+	boolean isEmpty(IScope scope);
+
+	/**
+	 * Returns a reversed view or copy of the buffered contents.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the reversed buffered contents
+	 * @throws GamaRuntimeException
+	 *             if the buffered contents cannot be reversed
+	 */
+	@operator (
+			value = "reverse",
+			can_be_const = true,
+			type = ITypeProvider.TYPE_AT_INDEX + 1,
+			content_type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "a reversed copy of the buffered contents of the file")
+	@Override
+	IRuntimeContainer<?, ?> reverse(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns one buffered value, typically chosen at random.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return one buffered value, or {@code nil} if the contents are empty
+	 */
+	@operator (
+			value = { "one_of", "any" },
+			can_be_const = false,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "one of the elements of the buffered file contents")
+	@Override
+	Contents anyValue(IScope scope);
 
 	/**
 	 * Gets the internal buffer containing the file's loaded contents.
@@ -473,10 +604,16 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 *            the o
 	 * @return true, if successful
 	 */
+	@operator (
+			value = { "contains_key" },
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.FILE },
+			concept = { IConcept.CONTAINER, IConcept.FILE })
+	@doc (value = "true if the buffered contents of the file contain the right operand as a key or index")
 	@Override
 	default boolean containsKey(final IScope scope, final Object o) {
 		final C contents = getContents(scope);
-		return contents != null && contents.contains(scope, o);
+		return contents != null && contents.containsKey(scope, o);
 	}
 
 	/**
@@ -514,7 +651,7 @@ public interface IGamaFile<C extends IContainer.Modifiable, Contents>
 	 * @return the i modifiable container
 	 * @date 4 nov. 2023
 	 */
-	default Modifiable ensureContentsIsCompatible(final Modifiable contents) {
+	default IRuntimeContainer.Modifiable ensureContentsIsCompatible(final IRuntimeContainer.Modifiable contents) {
 		return contents;
 	}
 

--- a/gama.api/src/gama/api/types/graph/IGraph.java
+++ b/gama.api/src/gama/api/types/graph/IGraph.java
@@ -29,6 +29,7 @@ import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
 import gama.api.types.misc.IContainer.Addressable;
 import gama.api.types.misc.IContainer.Modifiable;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.IPair;
 
 /**
@@ -294,7 +295,7 @@ public interface IGraph<Vertex, Edge>
 	 *            the objects
 	 * @return the i container
 	 */
-	IContainer buildValues(IScope scope, IContainer objects);
+	IContainer buildValues(IScope scope, IRuntimeContainer objects);
 
 	/**
 	 * Builds the index.
@@ -316,7 +317,7 @@ public interface IGraph<Vertex, Edge>
 	 *            the value
 	 * @return the i container
 	 */
-	IContainer<?, IPair<Vertex, Vertex>> buildIndexes(IScope scope, IContainer value);
+	IContainer<?, IPair<Vertex, Vertex>> buildIndexes(IScope scope, IRuntimeContainer value);
 
 	/**
 	 * Gets the vertex species.

--- a/gama.api/src/gama/api/types/map/GamaMap.java
+++ b/gama.api/src/gama/api/types/map/GamaMap.java
@@ -33,6 +33,7 @@ import gama.api.types.list.IList;
 import gama.api.types.matrix.GamaMatrixFactory;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.GamaPairFactory;
 import gama.api.types.pair.IPair;
 import gama.api.utils.interfaces.BiConsumerWithPruning;
@@ -316,7 +317,7 @@ public class GamaMap<K, V> extends LinkedHashMap<K, V> implements IMap<K, V> {
 	 */
 	// AD July 2020: Addition of the index (see #2985)
 	@Override
-	public void addValues(final IScope scope, final Object index, final IContainer/* <?, IPair<K, V>> */ values) {
+	public void addValues(final IScope scope, final Object index, final IRuntimeContainer/* <?, IPair<K, V>> */ values) {
 		// If an index is specified, we add only the last object
 		if (index != null) {
 			final Iterable list = values.iterable(scope);
@@ -440,7 +441,7 @@ public class GamaMap<K, V> extends LinkedHashMap<K, V> implements IMap<K, V> {
 	 * @see gama.api.types.misc.IContainer#removeAll(gama.api.runtime.scope.IScope, gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeValues(final IScope scope, final IContainer<?, ?> values) {
+	public void removeValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
 		// we suppose we have pairs
 		for (final Object o : values.iterable(scope)) { removeValue(scope, o); }
 	}
@@ -462,7 +463,7 @@ public class GamaMap<K, V> extends LinkedHashMap<K, V> implements IMap<K, V> {
 	 *      gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeIndexes(final IScope scope, final IContainer<?, ?> index) {
+	public void removeIndexes(final IScope scope, final IRuntimeContainer<?, ?> index) {
 		for (final Object key : index.iterable(scope)) { remove(key); }
 	}
 

--- a/gama.api/src/gama/api/types/map/GamaMapSimpleWrapper.java
+++ b/gama.api/src/gama/api/types/map/GamaMapSimpleWrapper.java
@@ -33,6 +33,7 @@ import gama.api.types.list.IList;
 import gama.api.types.matrix.GamaMatrixFactory;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.GamaPairFactory;
 import gama.api.types.pair.IPair;
 import gama.api.utils.interfaces.BiConsumerWithPruning;
@@ -356,7 +357,7 @@ public abstract class GamaMapSimpleWrapper<K, V> extends ForwardingMap<K, V> imp
 	 */
 	// AD July 2020: Addition of the index (see #2985)
 	@Override
-	public void addValues(final IScope scope, final Object index, final IContainer/* <?, IPair<K, V>> */ values) {
+	public void addValues(final IScope scope, final Object index, final IRuntimeContainer/* <?, IPair<K, V>> */ values) {
 		// If an index is specified, we add only the last object
 		if (index != null) {
 			final Iterable list = values.iterable(scope);
@@ -480,7 +481,7 @@ public abstract class GamaMapSimpleWrapper<K, V> extends ForwardingMap<K, V> imp
 	 * @see gama.api.types.misc.IContainer#removeAll(gama.api.runtime.scope.IScope, gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeValues(final IScope scope, final IContainer<?, ?> values) {
+	public void removeValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
 		// we suppose we have pairs
 		for (final Object o : values.iterable(scope)) { removeValue(scope, o); }
 	}
@@ -502,7 +503,7 @@ public abstract class GamaMapSimpleWrapper<K, V> extends ForwardingMap<K, V> imp
 	 *      gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeIndexes(final IScope scope, final IContainer<?, ?> index) {
+	public void removeIndexes(final IScope scope, final IRuntimeContainer<?, ?> index) {
 		for (final Object key : index.iterable(scope)) { remove(key); }
 	}
 

--- a/gama.api/src/gama/api/types/map/GamaMapWrapper.java
+++ b/gama.api/src/gama/api/types/map/GamaMapWrapper.java
@@ -33,6 +33,7 @@ import gama.api.types.list.IList;
 import gama.api.types.matrix.GamaMatrixFactory;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.GamaPairFactory;
 import gama.api.types.pair.IPair;
 import gama.api.utils.interfaces.BiConsumerWithPruning;
@@ -309,7 +310,7 @@ public class GamaMapWrapper<K, V> extends ForwardingMap<K, V> implements IMap<K,
 	 */
 	// AD July 2020: Addition of the index (see #2985)
 	@Override
-	public void addValues(final IScope scope, final Object index, final IContainer/* <?, IPair<K, V>> */ values) {
+	public void addValues(final IScope scope, final Object index, final IRuntimeContainer/* <?, IPair<K, V>> */ values) {
 		// If an index is specified, we add only the last object
 		if (index != null) {
 			final Iterable list = values.iterable(scope);
@@ -433,7 +434,7 @@ public class GamaMapWrapper<K, V> extends ForwardingMap<K, V> implements IMap<K,
 	 * @see gama.api.types.misc.IContainer#removeAll(gama.api.runtime.scope.IScope, gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeValues(final IScope scope, final IContainer<?, ?> values) {
+	public void removeValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
 		// we suppose we have pairs
 		for (final Object o : values.iterable(scope)) { removeValue(scope, o); }
 	}
@@ -455,7 +456,7 @@ public class GamaMapWrapper<K, V> extends ForwardingMap<K, V> implements IMap<K,
 	 *      gama.api.types.misc.IContainer)
 	 */
 	@Override
-	public void removeIndexes(final IScope scope, final IContainer<?, ?> index) {
+	public void removeIndexes(final IScope scope, final IRuntimeContainer<?, ?> index) {
 		for (final Object key : index.iterable(scope)) { remove(key); }
 	}
 

--- a/gama.api/src/gama/api/types/map/IMap.java
+++ b/gama.api/src/gama/api/types/map/IMap.java
@@ -27,6 +27,7 @@ import gama.api.gaml.types.IType;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.list.IList;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.IPair;
 import gama.api.utils.interfaces.BiConsumerWithPruning;
 import gama.api.utils.interfaces.ConsumerWithPruning;
@@ -35,7 +36,17 @@ import gama.api.utils.interfaces.ConsumerWithPruning;
  * The main interface for type-safe, key-value maps in the GAMA modeling platform.
  *
  * <p>
- * {@code IMap} extends Java's {@link Map} interface while integrating with GAMA's type system and runtime capabilities.
+ * {@code IMap} extends Java's {@link Map} interface while integrating with GAMA's type system and runtime
+ * capabilities.
+ * </p>
+ *
+ * <p>
+ * In the GAML type hierarchy, {@code map} is now distinct from {@code container}. At the Java level, {@code IMap}
+ * now depends on the extracted runtime contracts in {@link IRuntimeContainer} rather than inheriting the legacy
+ * {@link IContainer} capability branch directly.
+ * </p>
+ *
+ * <p>
  * It provides:
  * </p>
  * <ul>
@@ -128,7 +139,8 @@ import gama.api.utils.interfaces.ConsumerWithPruning;
  *
  * <h2>Usage in GAML</h2>
  * <p>
- * Maps are fundamental container types in GAML:
+ * Maps are fundamental associative collection types in GAML. They still support many container-like operators, but
+ * they no longer belong to the {@code container} inheritance branch of the GAML type hierarchy:
  * </p>
  *
  * <pre>
@@ -150,12 +162,12 @@ import gama.api.utils.interfaces.ConsumerWithPruning;
  *
  * <h2>IPairList Interface</h2>
  * <p>
- * Nested interface that combines {@link Set} and {@link IList} for entry pairs:
+ * Nested interface representing the ordered list view returned by {@link #getPairs()}:
  * </p>
  * <ul>
  * <li>Returned by {@link #getPairs()}</li>
- * <li>Implements both Set&lt;Map.Entry&gt; and IList&lt;Map.Entry&gt;</li>
- * <li>Preserves order (in ordered maps)</li>
+ * <li>Contains {@link IPair} elements exposing both key and value</li>
+ * <li>Preserves insertion order when the underlying map is ordered</li>
  * </ul>
  *
  * <h2>Default Implementations</h2>
@@ -196,7 +208,8 @@ import gama.api.utils.interfaces.ConsumerWithPruning;
  *
  * @see GamaMapFactory for creating IMap instances
  * @see GamaMap for the primary implementation
- * @see IContainer for parent container interfaces
+ * @see IRuntimeContainer for the extracted shared Java-level runtime contract
+ * @see IContainer for the legacy container API from which maps are now detached
  * @see Map for Java Map interface
  *
  * @author drogoul
@@ -218,10 +231,16 @@ import gama.api.utils.interfaces.ConsumerWithPruning;
 				doc = { @doc ("Returns the list of pairs (key, value) that compose this map") }) })
 @SuppressWarnings ("unchecked")
 
-public interface IMap<K, V> extends Map<K, V>, IContainer.Modifiable<K, V, K, V>, IContainer.Addressable<K, V, K, V> {
+public interface IMap<K, V> extends Map<K, V>, IRuntimeContainer.Modifiable<K, V, K, V>,
+		IRuntimeContainer.Addressable<K, V, K, V> {
 
 	/**
-	 * The Interface IPairList.
+	 * Ordered list view of the pairs contained in a map.
+	 *
+	 * <p>
+	 * This view is primarily used by the {@link #getPairs()} getter and by operators that need stable traversal of map
+	 * entries as {@link IPair} values.
+	 * </p>
 	 *
 	 * @param <K>
 	 *            the key type
@@ -242,28 +261,42 @@ public interface IMap<K, V> extends Map<K, V>, IContainer.Modifiable<K, V, K, V>
 
 	}
 
-	/** The keys. */
+	/** Name of the pseudo-variable exposing the list of keys. */
 	String KEYS = "keys";
 
-	/** The values. */
+	/** Name of the pseudo-variable exposing the list of values. */
 	String VALUES = "values";
 
-	/** The pairs. */
+	/** Name of the pseudo-variable exposing the list of key/value pairs. */
 	String PAIRS = "pairs";
 
 	/**
+	 * Returns the value located at the specified iteration position.
 	 *
-	 *
-	 * /** Value at.
+	 * <p>
+	 * The index refers to the traversal order of the map values, which is stable only when {@link #isOrdered()} is
+	 * {@code true}.
+	 * </p>
 	 *
 	 * @param index
-	 *            the index
-	 * @return the v
+	 *            the zero-based position of the value in iteration order
+	 * @return the value at that position
 	 */
 	V valueAt(final int index);
 
 	/**
-	 * Method buildValue()
+	 * Casts or normalizes a value so it matches this map content type.
+	 *
+	 * <p>
+	 * Implementations honor the map type and the current runtime casting policy before the value is inserted or
+	 * replaced.
+	 * </p>
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param object
+	 *            the candidate value to adapt
+	 * @return the value converted to the map content type
 	 *
 	 * @see gama.api.types.misc.IContainer.ToSet#buildValue(gama.api.runtime.scope.IScope, java.lang.Object,
 	 *      gama.gaml.types.IContainerType)
@@ -271,12 +304,163 @@ public interface IMap<K, V> extends Map<K, V>, IContainer.Modifiable<K, V, K, V>
 	V buildValue(final IScope scope, final Object object);
 
 	/**
-	 * Method buildIndex()
+	 * Casts or normalizes a key so it matches this map key type.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param object
+	 *            the candidate key to adapt
+	 * @return the key converted to the map key type
 	 *
 	 * @see gama.api.types.misc.IContainer.ToSet#buildIndex(gama.api.runtime.scope.IScope, java.lang.Object,
 	 *      gama.gaml.types.IContainerType)
 	 */
 	K buildIndex(final IScope scope, final Object object);
+
+	/**
+	 * Returns whether this map contains the provided value.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param o
+	 *            the searched value
+	 * @return {@code true} if the value is present in the map
+	 * @throws GamaRuntimeException
+	 *             if the test cannot be evaluated
+	 */
+	@operator (
+			value = { "contains", "contains_value" },
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "true if the map contains the right operand as one of its values, false otherwise",
+			examples = { @example (
+					value = "[1::2, 3::4, 5::6] contains 4",
+					equals = "true"),
+				@example (
+						value = "[1::2, 3::4, 5::6] contains 3",
+						equals = "false") },
+			see = { "contains_key" })
+	@Override
+	boolean contains(IScope scope, Object o) throws GamaRuntimeException;
+
+	/**
+	 * Returns whether this map contains the provided key.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param o
+	 *            the searched key
+	 * @return {@code true} if the key is present in the map
+	 * @throws GamaRuntimeException
+	 *             if the test cannot be evaluated
+	 */
+	@operator (
+			value = { "contains_key" },
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "true if the map contains the right operand as one of its keys, false otherwise",
+			examples = { @example (
+					value = "[1::2, 3::4, 5::6] contains_key 3",
+					equals = "true"),
+				@example (
+						value = "[1::2, 3::4, 5::6] contains_key 4",
+						equals = "false") },
+			see = { "contains" })
+	@Override
+	boolean containsKey(IScope scope, Object o) throws GamaRuntimeException;
+
+	/**
+	 * Returns the first value of this map in iteration order.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the first mapped value, or {@code nil} if the map is empty
+	 * @throws GamaRuntimeException
+	 *             if the value cannot be retrieved
+	 */
+	@operator (
+			value = "first",
+			can_be_const = true,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "the first value of the first pair of the map in iteration order",
+			examples = { @example (
+					value = "first([1::2, 3::4])",
+					equals = "2") },
+			see = { "last" })
+	@Override
+	V firstValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the last value of this map in iteration order.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the last mapped value, or {@code nil} if the map is empty
+	 * @throws GamaRuntimeException
+	 *             if the value cannot be retrieved
+	 */
+	@operator (
+			value = "last",
+			can_be_const = true,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "the last value of the last pair of the map in iteration order",
+			examples = { @example (
+					value = "last([1::2, 3::4])",
+					equals = "4") },
+			see = { "first" })
+	@Override
+	V lastValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the number of key/value pairs stored in this map.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the map size
+	 */
+	@operator (
+			value = "length",
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "the number of key-value mappings contained in the map",
+			examples = { @example (
+					value = "length([1::2, 3::4])",
+					equals = "2") })
+	@Override
+	int length(IScope scope);
+
+	/**
+	 * Returns whether this map is empty.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return {@code true} if the map contains no pair
+	 */
+	@operator (
+			value = "empty",
+			can_be_const = true,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "true if the map contains no key-value mappings, false otherwise",
+			examples = { @example (
+					value = "empty([] as_map (each::each))",
+					equals = "true",
+					test = false) })
+	@Override
+	boolean isEmpty(IScope scope);
 
 	/**
 	 * Reverse.
@@ -291,8 +475,8 @@ public interface IMap<K, V> extends Map<K, V>, IContainer.Modifiable<K, V, K, V>
 			type = IType.MAP,
 			content_type = ITypeProvider.KEY_TYPE_AT_INDEX + 1,
 			index_type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
-			category = { IOperatorCategory.CONTAINER },
-			concept = { IConcept.CONTAINER })
+			category = { IOperatorCategory.MAP },
+			concept = { IConcept.MAP })
 	@doc (
 			value = "Specialization of the reverse operator for maps. Reverses keys and values",
 			comment = "",
@@ -306,71 +490,94 @@ public interface IMap<K, V> extends Map<K, V>, IContainer.Modifiable<K, V, K, V>
 	IMap reverse(final IScope scope);
 
 	/**
-	 * Gets the keys.
+	 * Returns one mapped value, typically chosen at random.
 	 *
-	 * @return the keys
+	 * @param scope
+	 *            the current execution scope
+	 * @return one of the map values, or {@code nil} if the map is empty
+	 */
+	@operator (
+			value = { "one_of", "any" },
+			can_be_const = false,
+			type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 1,
+			category = { IOperatorCategory.CONTAINER, IOperatorCategory.MAP },
+			concept = { IConcept.CONTAINER, IConcept.MAP })
+	@doc (
+			value = "one of the values stored in the map, chosen from a random key",
+			examples = { @example (
+					value = "int x <- one_of([1::2, 3::4]);",
+					equals = "2 or 4",
+					test = false) },
+			see = { "contains" })
+	@Override
+	V anyValue(IScope scope);
+
+	/**
+	 * Returns the keys of this map as a list.
+	 *
+	 * @return the keys in map iteration order
 	 */
 	@getter ("keys")
 	IList<K> getKeys();
 
 	/**
-	 * Gets the values.
+	 * Returns the values of this map as a list.
 	 *
-	 * @return the values
+	 * @return the values in map iteration order
 	 */
 	@getter ("values")
 	IList<V> getValues();
 
 	/**
-	 * Gets the pairs.
+	 * Returns the pairs of this map as an ordered list view.
 	 *
-	 * @return the pairs
+	 * @return the map entries exposed as {@link IPair} values
 	 */
 	@getter (PAIRS)
-	IPairList getPairs();
+	IPairList<K, V> getPairs();
 
 	/**
-	 * For each pair.
+	 * Visits each key/value pair until the visitor requests pruning.
 	 *
 	 * @param visitor
-	 *            the visitor
-	 * @return true, if successful
+	 *            the visitor invoked on each pair
+	 * @return {@code true} if the whole traversal completed, {@code false} if it was pruned early
 	 */
 	boolean forEachPair(final BiConsumerWithPruning<K, V> visitor);
 
 	/**
-	 * Checks if is ordered.
+	 * Indicates whether this map preserves a stable iteration order.
 	 *
-	 * @return true, if is ordered
+	 * @return {@code true} if iteration order is stable and meaningful
 	 */
 	boolean isOrdered();
 
 	/**
-	 * For each value.
+	 * Visits each value until the visitor requests pruning.
 	 *
 	 * @param visitor
-	 *            the visitor
-	 * @return true, if successful
+	 *            the visitor invoked on each value
+	 * @return {@code true} if the whole traversal completed, {@code false} if it was pruned early
 	 */
 	boolean forEachValue(final ConsumerWithPruning<? super V> visitor);
 
 	/**
-	 * For each key.
+	 * Visits each key until the visitor requests pruning.
 	 *
 	 * @param visitor
-	 *            the visitor
-	 * @return true, if successful
+	 *            the visitor invoked on each key
+	 * @return {@code true} if the whole traversal completed, {@code false} if it was pruned early
 	 */
 	boolean forEachKey(final ConsumerWithPruning<K> visitor);
 
 	/**
-	 * Copy.
+	 * Returns a copy of this map.
 	 *
 	 * @param scope
-	 *            the scope
-	 * @return the i map
+	 *            the current execution scope
+	 * @return a map containing the same entries
 	 * @throws GamaRuntimeException
-	 *             the gama runtime exception
+	 *             if the copy cannot be produced
 	 */
 	@Override
 	IMap<K, V> copy(IScope scope) throws GamaRuntimeException;

--- a/gama.api/src/gama/api/types/misc/IContainer.java
+++ b/gama.api/src/gama/api/types/misc/IContainer.java
@@ -33,12 +33,13 @@ import gama.api.types.matrix.IMatrix;
 import one.util.streamex.StreamEx;
 
 /**
- * The fundamental interface for all collection-like structures in GAMA.
+ * The fundamental interface for indexed and sequential container structures in GAMA.
  * 
  * <p>
- * IContainer provides a unified abstraction over diverse collection types including lists, maps, matrices, graphs,
- * populations (species), files, and pairs. This uniformity allows GAML operators to work consistently across different
- * container types.
+ * IContainer provides the GAML {@code container} branch abstraction over indexed and sequential structures such as
+ * lists, matrices, graphs, populations (species), files, and pairs. Maps now remain outside this inheritance branch in
+ * the GAML type system, while still sharing the extracted Java-level runtime contract defined by
+ * {@link IRuntimeContainer}.
  * </p>
  * 
  * <h2>Type Parameters</h2>
@@ -78,7 +79,8 @@ import one.util.streamex.StreamEx;
  * </p>
  * <ul>
  * <li><strong>Lists:</strong> KeyType=Integer, ordered sequences indexed from 0</li>
- * <li><strong>Maps:</strong> KeyType=any, unordered key-value associations</li>
+ * <li><strong>Maps:</strong> now handled through {@link IRuntimeContainer} and {@code map}, not through the GAML
+ * {@code container} inheritance branch</li>
  * <li><strong>Matrices:</strong> KeyType=IPoint, 2D grids indexed by {column, row}</li>
  * <li><strong>Graphs:</strong> KeyType=node, ValueType=edge (or vice versa)</li>
  * <li><strong>Populations:</strong> KeyType=Integer/String, ValueType=IAgent</li>
@@ -146,7 +148,7 @@ import one.util.streamex.StreamEx;
  * @author drogoul
  * @since GAMA 1.0
  */
-public interface IContainer<KeyType, ValueType> extends IValue {
+public interface IContainer<KeyType, ValueType> extends IRuntimeContainer<KeyType, ValueType> {
 
 	/**
 	 * Returns a copy of this container.
@@ -354,49 +356,7 @@ public interface IContainer<KeyType, ValueType> extends IValue {
 	 * @param <ValueType>
 	 *            the type of elements returned
 	 */
-	public interface ToGet<KeyType, ValueType> {
-
-		/**
-		 * Gets the element at the specified key/index.
-		 * 
-		 * <p>
-		 * The behavior depends on the container type:
-		 * </p>
-		 * <ul>
-		 * <li><strong>Lists:</strong> index must be an integer in [0, length)</li>
-		 * <li><strong>Maps:</strong> index is a key in the map</li>
-		 * <li><strong>Matrices:</strong> index is a point {col, row}</li>
-		 * </ul>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            the key or index of the element to retrieve
-		 * @return the element at the specified index, or null if not found
-		 * @throws GamaRuntimeException
-		 *             if the index is invalid or out of bounds
-		 */
-		ValueType get(IScope scope, KeyType index) throws GamaRuntimeException;
-
-		/**
-		 * Gets multiple elements using a list of keys/indices.
-		 * 
-		 * <p>
-		 * This method is called from GAML when accessing a container with a list of indices. The container is
-		 * responsible for extracting each index and returning the corresponding value.
-		 * </p>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param indices
-		 *            the list of keys/indices to retrieve
-		 * @return the value(s) at those indices (semantics depend on implementation)
-		 * @throws GamaRuntimeException
-		 *             if any index is invalid
-		 */
-		ValueType getFromIndicesList(IScope scope, IList<KeyType> indices) throws GamaRuntimeException;
-
-	}
+	public interface ToGet<KeyType, ValueType> extends IRuntimeContainer.ToGet<KeyType, ValueType> {}
 
 	/**
 	 * Interface combining IContainer with read capabilities.
@@ -416,7 +376,8 @@ public interface IContainer<KeyType, ValueType> extends IValue {
 	 *            the type returned by addressing (may differ from Value)
 	 */
 	public interface Addressable<Key, Value, AddressableKey, AddressableValue>
-			extends IContainer<Key, Value>, IContainer.ToGet<AddressableKey, AddressableValue> {}
+			extends IContainer<Key, Value>, IRuntimeContainer.Addressable<Key, Value, AddressableKey, AddressableValue>,
+				IContainer.ToGet<AddressableKey, AddressableValue> {}
 
 	/**
 	 * Interface combining IContainer with write capabilities.
@@ -437,9 +398,8 @@ public interface IContainer<KeyType, ValueType> extends IValue {
 	 *            the type of values to add/set (may differ from V)
 	 */
 	public interface Modifiable<K, V, KeyToAdd, ValueToAdd>
-			extends IContainer<K, V>, IContainer.ToSet<KeyToAdd, ValueToAdd> {
-
-	}
+			extends IContainer<K, V>, IRuntimeContainer.Modifiable<K, V, KeyToAdd, ValueToAdd>,
+				IContainer.ToSet<KeyToAdd, ValueToAdd> {}
 
 	/**
 	 * Interface for containers that support element modification and removal.
@@ -454,163 +414,40 @@ public interface IContainer<KeyType, ValueType> extends IValue {
 	 * @param <ValueType>
 	 *            the type of elements to add/set
 	 */
-	public interface ToSet<KeyType, ValueType> {
+	public interface ToSet<KeyType, ValueType> extends IRuntimeContainer.ToSet<KeyType, ValueType> {
 
-		/**
-		 * Adds a value to the container.
-		 * 
-		 * <p>
-		 * The exact behavior depends on the container type:
-		 * </p>
-		 * <ul>
-		 * <li><strong>Lists:</strong> appends to the end</li>
-		 * <li><strong>Sets:</strong> adds if not present</li>
-		 * <li><strong>Maps:</strong> requires a key (see addValueAtIndex)</li>
-		 * </ul>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param value
-		 *            the value to add
-		 */
-		void addValue(IScope scope, final ValueType value);
-
-		/**
-		 * Adds a value at a specific index/key.
-		 * 
-		 * <p>
-		 * The behavior depends on the container type:
-		 * </p>
-		 * <ul>
-		 * <li><strong>Lists:</strong> inserts at the index, shifting subsequent elements</li>
-		 * <li><strong>Maps:</strong> adds a new key-value pair (or replaces if key exists)</li>
-		 * <li><strong>Matrices:</strong> sets the cell at the point index</li>
-		 * </ul>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            the index/key where to add the value
-		 * @param value
-		 *            the value to add
-		 */
-		void addValueAtIndex(IScope scope, final Object index, final ValueType value);
-
-		/**
-		 * Sets the value at a specific index/key.
-		 * 
-		 * <p>
-		 * Unlike {@link #addValueAtIndex(IScope, Object, Object)}, this typically requires that the index already
-		 * exists (for lists) or replaces an existing value (for maps/matrices).
-		 * </p>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            the index/key to set
-		 * @param value
-		 *            the new value
-		 */
-		void setValueAtIndex(IScope scope, final Object index, final ValueType value);
-
-		/**
-		 * Adds all values from another container.
-		 * 
-		 * <p>
-		 * This method adds elements without replacing existing ones. For lists, elements are appended. For maps, new
-		 * pairs are added.
-		 * </p>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            optional index/key hint for where to add (may be null)
-		 * @param values
-		 *            the container of values to add
-		 */
 		void addValues(IScope scope, Object index, IContainer<?, ?> values);
 
-		/**
-		 * Adds all values from another container (convenience method without index).
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param values
-		 *            the container of values to add
-		 */
 		default void addValues(final IScope scope, final IContainer<?, ?> values) {
 			addValues(scope, null, values);
 		}
 
-		/**
-		 * Sets all elements in the container to a single value.
-		 * 
-		 * <p>
-		 * For matrices and grids, this fills all cells. For lists, this may replace all elements or set a default
-		 * value.
-		 * </p>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param value
-		 *            the value to set everywhere
-		 */
-		void setAllValues(IScope scope, ValueType value);
+		@Override
+		default void addValues(final IScope scope, final Object index, final IRuntimeContainer<?, ?> values) {
+			addValues(scope, index,
+					values instanceof IContainer<?, ?> c ? c : values.listValue(scope, Types.NO_TYPE, false));
+		}
 
-		/**
-		 * Removes the first occurrence of a value from the container.
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param value
-		 *            the value to remove
-		 */
-		void removeValue(IScope scope, Object value);
+		@Override
+		default void addValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
+			addValues(scope, null, values);
+		}
 
-		/**
-		 * Removes the element at a specific index/key.
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            the index/key to remove
-		 */
-		void removeIndex(IScope scope, Object index);
-
-		/**
-		 * Removes all elements at the specified indices/keys.
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param index
-		 *            container of indices/keys to remove
-		 */
 		void removeIndexes(IScope scope, IContainer<?, ?> index);
 
-		/**
-		 * Removes all elements matching values in the provided container.
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param values
-		 *            container of values to remove
-		 */
+		@Override
+		default void removeIndexes(final IScope scope, final IRuntimeContainer<?, ?> index) {
+			removeIndexes(scope,
+					index instanceof IContainer<?, ?> c ? c : index.listValue(scope, Types.NO_TYPE, false));
+		}
+
 		void removeValues(IScope scope, IContainer<?, ?> values);
 
-		/**
-		 * Removes all occurrences of a specific value.
-		 * 
-		 * <p>
-		 * Unlike {@link #removeValue(IScope, Object)} which removes only the first occurrence, this removes all
-		 * occurrences.
-		 * </p>
-		 *
-		 * @param scope
-		 *            the current GAMA execution scope
-		 * @param value
-		 *            the value to remove completely
-		 */
-		void removeAllOccurrencesOfValue(IScope scope, Object value);
+		@Override
+		default void removeValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
+			removeValues(scope,
+					values instanceof IContainer<?, ?> c ? c : values.listValue(scope, Types.NO_TYPE, false));
+		}
 
 	}
 

--- a/gama.api/src/gama/api/types/misc/IRuntimeContainer.java
+++ b/gama.api/src/gama/api/types/misc/IRuntimeContainer.java
@@ -1,0 +1,461 @@
+/*******************************************************************************************************
+ *
+ * IRuntimeContainer.java, in gama.api, is part of the source code of the GAMA modeling and simulation platform
+ * (v.2025-03).
+ *
+ * (c) 2007-2026 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
+ *
+ * Visit https://github.com/gama-platform/gama for license information and contacts.
+ *
+ ********************************************************************************************************/
+package gama.api.types.misc;
+
+import java.util.Collection;
+
+import gama.api.exceptions.GamaRuntimeException;
+import gama.api.gaml.types.IContainerType;
+import gama.api.gaml.types.IType;
+import gama.api.gaml.types.Types;
+import gama.api.runtime.GamaExecutorService;
+import gama.api.runtime.scope.IScope;
+import gama.api.types.geometry.IPoint;
+import gama.api.types.list.IList;
+import gama.api.types.map.IMap;
+import gama.api.types.matrix.IMatrix;
+import one.util.streamex.StreamEx;
+
+/**
+ * Shared runtime contract for collection-like values in GAMA.
+ *
+ * <p>
+ * This interface captures the common Java-level API currently shared by true {@link IContainer} implementations and
+ * by {@link gama.api.types.map.IMap maps}. It exists to progressively separate the runtime contract from the GAML
+ * {@code container} inheritance branch.
+ * </p>
+ *
+ * <p>
+ * At this stage, {@link IContainer} still refines this interface and remains the main home of operator metadata. This
+ * extracted contract is intended to host the methods that maps and indexed/sequential containers genuinely share at
+ * runtime.
+ * </p>
+ *
+ * @param <KeyType>
+ *            the type used to address elements
+ * @param <ValueType>
+ *            the type of stored values
+ *
+ * @author drogoul
+ * @since GAMA 2026-05
+ *
+ * @see IContainer
+ * @see gama.api.types.map.IMap
+ */
+public interface IRuntimeContainer<KeyType, ValueType> extends IValue {
+
+	/**
+	 * Returns a copy of this runtime container.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return a copy preserving the runtime semantics of the receiver
+	 * @throws GamaRuntimeException
+	 *             if the copy cannot be produced
+	 */
+	@Override
+	IRuntimeContainer<KeyType, ValueType> copy(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the GAML type describing this runtime container.
+	 *
+	 * @return the associated parametric container type
+	 */
+	@Override
+	IContainerType<?> getGamlType();
+
+	/**
+	 * Converts this runtime container to a list view or copy.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param contentType
+	 *            the desired content type of the produced list
+	 * @param copy
+	 *            whether a copy should be forced
+	 * @return a list representation of the receiver
+	 */
+	IList<ValueType> listValue(IScope scope, IType<?> contentType, boolean copy);
+
+	/**
+	 * Converts this runtime container to a matrix.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param contentType
+	 *            the desired matrix content type
+	 * @param copy
+	 *            whether a copy should be forced
+	 * @return a matrix representation of the receiver
+	 */
+	IMatrix<?> matrixValue(IScope scope, IType<?> contentType, boolean copy);
+
+	/**
+	 * Converts this runtime container to a matrix with the specified size.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param contentType
+	 *            the desired matrix content type
+	 * @param size
+	 *            the preferred dimensions of the resulting matrix
+	 * @param copy
+	 *            whether a copy should be forced
+	 * @return a matrix representation of the receiver
+	 */
+	IMatrix<?> matrixValue(IScope scope, IType<?> contentType, IPoint size, boolean copy);
+
+	/**
+	 * Converts this runtime container to a map.
+	 *
+	 * @param <D>
+	 *            the desired value type
+	 * @param <C>
+	 *            the desired key type
+	 * @param scope
+	 *            the current execution scope
+	 * @param keyType
+	 *            the desired key type
+	 * @param contentType
+	 *            the desired value type
+	 * @param copy
+	 *            whether a copy should be forced
+	 * @return a map representation of the receiver
+	 */
+	<D, C> IMap<C, D> mapValue(IScope scope, IType<C> keyType, IType<D> contentType, boolean copy);
+
+	/**
+	 * Returns an iterable over the values stored in this runtime container.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return an iterable over the receiver values
+	 */
+	java.lang.Iterable<? extends ValueType> iterable(IScope scope);
+
+	/**
+	 * Returns a sequential stream over the stored values.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return a sequential stream over the values
+	 */
+	@SuppressWarnings ("unchecked")
+	default StreamEx<ValueType> stream(final IScope scope) {
+		if (this instanceof Collection) return StreamEx.of(((Collection<ValueType>) this).stream());
+		return StreamEx.of(listValue(scope, Types.NO_TYPE, false));
+	}
+
+	/**
+	 * Returns a parallel stream over the stored values.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return a parallel stream over the values
+	 */
+	default StreamEx<ValueType> parallelStream(final IScope scope) {
+		return stream(scope).parallel(GamaExecutorService.AGENT_PARALLEL_EXECUTOR);
+	}
+
+	/**
+	 * Returns whether the receiver contains the provided value.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param o
+	 *            the searched value
+	 * @return {@code true} if the value is present
+	 * @throws GamaRuntimeException
+	 *             if containment cannot be evaluated
+	 */
+	boolean contains(IScope scope, Object o) throws GamaRuntimeException;
+
+	/**
+	 * Returns whether the receiver contains the provided key or index.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @param o
+	 *            the searched key or index
+	 * @return {@code true} if the key or index is valid
+	 * @throws GamaRuntimeException
+	 *             if the test cannot be evaluated
+	 */
+	boolean containsKey(IScope scope, Object o) throws GamaRuntimeException;
+
+	/**
+	 * Returns the first accessible value of the receiver.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the first value, or {@code null} when appropriate
+	 * @throws GamaRuntimeException
+	 *             if the value cannot be retrieved
+	 */
+	ValueType firstValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the last accessible value of the receiver.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the last value, or {@code null} when appropriate
+	 * @throws GamaRuntimeException
+	 *             if the value cannot be retrieved
+	 */
+	ValueType lastValue(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns the number of accessible values in the receiver.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the runtime length of the receiver
+	 */
+	int length(IScope scope);
+
+	/**
+	 * Returns the integer representation of this runtime container.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return the length of the receiver
+	 */
+	@Override
+	default int intValue(final IScope scope) {
+		return length(scope);
+	}
+
+	/**
+	 * Returns whether the receiver is empty.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return {@code true} if the receiver has no accessible value
+	 */
+	boolean isEmpty(IScope scope);
+
+	/**
+	 * Returns a reversed or structurally inverted copy of the receiver.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return a reversed copy matching the runtime kind of the receiver
+	 * @throws GamaRuntimeException
+	 *             if the reversed representation cannot be produced
+	 */
+	IRuntimeContainer<?, ?> reverse(IScope scope) throws GamaRuntimeException;
+
+	/**
+	 * Returns one accessible value of the receiver, typically chosen at random.
+	 *
+	 * @param scope
+	 *            the current execution scope
+	 * @return one accessible value, or {@code null} when appropriate
+	 */
+	ValueType anyValue(IScope scope);
+
+	/**
+	 * Read capability for runtime containers that can retrieve values through keys or indices.
+	 *
+	 * @param <KeyType>
+	 *            the addressing type
+	 * @param <ValueType>
+	 *            the retrieved value type
+	 */
+	interface ToGet<KeyType, ValueType> {
+
+		/**
+		 * Returns the value stored at the specified key or index.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            the key or index to resolve
+		 * @return the resolved value
+		 * @throws GamaRuntimeException
+		 *             if access fails
+		 */
+		ValueType get(IScope scope, KeyType index) throws GamaRuntimeException;
+
+		/**
+		 * Returns the value resolved from a list of keys or indices.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param indices
+		 *            the indices to resolve
+		 * @return the resolved value or values, depending on the implementation
+		 * @throws GamaRuntimeException
+		 *             if access fails
+		 */
+		ValueType getFromIndicesList(IScope scope, IList<KeyType> indices) throws GamaRuntimeException;
+	}
+
+	/**
+	 * Write capability for runtime containers that support insertion, replacement, and removal.
+	 *
+	 * @param <KeyType>
+	 *            the key or index type used by write operations
+	 * @param <ValueType>
+	 *            the value type used by write operations
+	 */
+	interface ToSet<KeyType, ValueType> {
+
+		/**
+		 * Adds a value to the receiver.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param value
+		 *            the value to add
+		 */
+		void addValue(IScope scope, ValueType value);
+
+		/**
+		 * Adds a value at the specified key or index.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            the key or index at which to add the value
+		 * @param value
+		 *            the value to add
+		 */
+		void addValueAtIndex(IScope scope, Object index, ValueType value);
+
+		/**
+		 * Replaces the value stored at the specified key or index.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            the key or index to update
+		 * @param value
+		 *            the new value
+		 */
+		void setValueAtIndex(IScope scope, Object index, ValueType value);
+
+		/**
+		 * Adds all values from another runtime container.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            an optional key or index hint
+		 * @param values
+		 *            the runtime container supplying the values
+		 */
+		void addValues(IScope scope, Object index, IRuntimeContainer<?, ?> values);
+
+		/**
+		 * Adds all values from another runtime container without an explicit index.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param values
+		 *            the runtime container supplying the values
+		 */
+		default void addValues(final IScope scope, final IRuntimeContainer<?, ?> values) {
+			addValues(scope, null, values);
+		}
+
+		/**
+		 * Replaces all values of the receiver with the provided value when supported.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param value
+		 *            the replacement value
+		 */
+		void setAllValues(IScope scope, ValueType value);
+
+		/**
+		 * Removes one occurrence of the provided value.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param value
+		 *            the value to remove
+		 */
+		void removeValue(IScope scope, Object value);
+
+		/**
+		 * Removes the value stored at the specified key or index.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            the key or index to remove
+		 */
+		void removeIndex(IScope scope, Object index);
+
+		/**
+		 * Removes all values referenced by the specified keys or indices.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param index
+		 *            the runtime container supplying the keys or indices to remove
+		 */
+		void removeIndexes(IScope scope, IRuntimeContainer<?, ?> index);
+
+		/**
+		 * Removes all values matching those supplied by another runtime container.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param values
+		 *            the runtime container supplying the values to remove
+		 */
+		void removeValues(IScope scope, IRuntimeContainer<?, ?> values);
+
+		/**
+		 * Removes all occurrences of the provided value.
+		 *
+		 * @param scope
+		 *            the current execution scope
+		 * @param value
+		 *            the value to remove everywhere it occurs
+		 */
+		void removeAllOccurrencesOfValue(IScope scope, Object value);
+	}
+
+	/**
+	 * Shared readable runtime container capability.
+	 *
+	 * @param <Key>
+	 *            the container key type
+	 * @param <Value>
+	 *            the container value type
+	 * @param <AddressableKey>
+	 *            the read key type
+	 * @param <AddressableValue>
+	 *            the read value type
+	 */
+	interface Addressable<Key, Value, AddressableKey, AddressableValue>
+			extends IRuntimeContainer<Key, Value>, ToGet<AddressableKey, AddressableValue> {}
+
+	/**
+	 * Shared writable runtime container capability.
+	 *
+	 * @param <K>
+	 *            the container key type
+	 * @param <V>
+	 *            the container value type
+	 * @param <KeyToAdd>
+	 *            the write key type
+	 * @param <ValueToAdd>
+	 *            the write value type
+	 */
+	interface Modifiable<K, V, KeyToAdd, ValueToAdd>
+			extends IRuntimeContainer<K, V>, ToSet<KeyToAdd, ValueToAdd> {}
+}

--- a/gama.core/src/gama/core/util/file/GamaJsonFile.java
+++ b/gama.core/src/gama/core/util/file/GamaJsonFile.java
@@ -27,6 +27,7 @@ import gama.api.gaml.symbols.Facets;
 import gama.api.gaml.types.IType;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.file.GamaFile;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.map.GamaMapFactory;
 import gama.api.types.map.IMap;
 import gama.api.utils.geometry.IEnvelope;
@@ -134,7 +135,7 @@ public class GamaJsonFile extends GamaFile<IMap<String, Object>, Object> {
 	}
 
 	@Override
-	public Modifiable ensureContentsIsCompatible(final Modifiable contents) {
+	public IRuntimeContainer.Modifiable ensureContentsIsCompatible(final IRuntimeContainer.Modifiable contents) {
 		if (contents instanceof IMap) return contents;
 		IMap map = GamaMapFactory.create();
 		map.put(IJson.Labels.CONTENTS_WITH_REFERENCES_LABEL, contents);

--- a/gama.core/src/gama/core/util/graph/GamaGraph.java
+++ b/gama.core/src/gama/core/util/graph/GamaGraph.java
@@ -65,6 +65,7 @@ import gama.api.types.map.IMap;
 import gama.api.types.matrix.GamaMatrixFactory;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.GamaPairFactory;
 import gama.api.types.pair.IPair;
 import gama.api.utils.StringUtils;
@@ -1408,7 +1409,7 @@ public class GamaGraph<V, E> implements IGraph<V, E> {
 	 *      gama.api.types.misc.IContainer, gama.api.gaml.types.IContainerType)
 	 */
 	@Override
-	public IContainer<?, GraphObjectToAdd> buildValues(final IScope scope, final IContainer objects) {
+	public IContainer<?, GraphObjectToAdd> buildValues(final IScope scope, final IRuntimeContainer objects) {
 		try (final Collector.AsList list = Collector.getList()) {
 			if (!(objects instanceof gama.core.util.graph.NodesToAdd)) {
 				for (final Object o : objects.iterable(scope)) { list.add(buildValue(scope, o)); }
@@ -1431,7 +1432,7 @@ public class GamaGraph<V, E> implements IGraph<V, E> {
 	}
 
 	@Override
-	public IContainer<?, IPair<V, V>> buildIndexes(final IScope scope, final IContainer value) {
+	public IContainer<?, IPair<V, V>> buildIndexes(final IScope scope, final IRuntimeContainer value) {
 		final IList<IPair<V, V>> result = GamaListFactory.create(Types.PAIR);
 		for (final Object o : value.iterable(scope)) { result.add(buildIndex(scope, o)); }
 		return result;

--- a/gama.core/src/gama/gaml/operators/Containers.java
+++ b/gama.core/src/gama/gaml/operators/Containers.java
@@ -74,6 +74,7 @@ import gama.api.types.matrix.GamaMatrixFactory;
 import gama.api.types.matrix.IField;
 import gama.api.types.matrix.IMatrix;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.GamaPairFactory;
 import gama.api.types.pair.IPair;
 import gama.api.types.topology.ITopology;
@@ -85,8 +86,9 @@ import one.util.streamex.StreamEx;
  * Written by drogoul Modified on 31 juil. 2010
  *
  * <p>
- * Provides GAML operators for all container types: {@code list}, {@code map}, {@code matrix}, {@code graph}, species
- * populations, and any other {@link IContainer} implementors.
+ * Provides GAML operators for collection-like runtime types used in GAMA: sequential/indexed containers
+ * ({@code list}, {@code matrix}, {@code graph}, species populations, etc.) as well as {@code map}, whose GAML type
+ * hierarchy is now distinct even though the Java runtime still shares part of the container API.
  * </p>
  *
  * <h3>Operator Families</h3>
@@ -194,8 +196,8 @@ public class Containers {
 		 */
 		public InterleavingIterator(final IScope scope, final Object... objects) {
 			for (final Object object : objects) {
-				if (object instanceof IContainer) {
-					queue.add(((IContainer) object).iterable(scope).iterator());
+				if (object instanceof IRuntimeContainer) {
+					queue.add(((IRuntimeContainer) object).iterable(scope).iterator());
 				} else if (object instanceof Iterator) {
 					queue.add((Iterator) object);
 				} else if (object instanceof Iterable) {
@@ -269,8 +271,8 @@ public class Containers {
 	 *            the l
 	 * @return the predicate
 	 */
-	public static <T> Predicate<T> inContainer(final IScope scope, final IContainer l) {
-		final IContainer c = notNull(scope, l);
+	public static <T> Predicate<T> inContainer(final IScope scope, final IRuntimeContainer l) {
+		final IRuntimeContainer c = notNull(scope, l);
 		return t -> c.contains(scope, t);
 	}
 
@@ -287,7 +289,7 @@ public class Containers {
 	 *            the c
 	 * @return the stream ex
 	 */
-	public static StreamEx stream(final IScope scope, final IContainer c) {
+	public static StreamEx stream(final IScope scope, final IRuntimeContainer c) {
 		return notNull(scope, c).stream(scope);
 	}
 
@@ -309,7 +311,7 @@ public class Containers {
 	 *            the c
 	 * @return the supplier
 	 */
-	public static Supplier<IList> listLike(final IContainer c) {
+	public static Supplier<IList> listLike(final IRuntimeContainer c) {
 		return GamaListFactory.getSupplier(c == null ? Types.NO_TYPE : c.getGamlType().getContentType());
 	}
 
@@ -322,7 +324,7 @@ public class Containers {
 	 *            the c 1
 	 * @return the supplier
 	 */
-	public static Supplier<IList> listLike(final IContainer c, final IContainer c1) {
+	public static Supplier<IList> listLike(final IRuntimeContainer c, final IRuntimeContainer c1) {
 		return listOf(c.getGamlType().getContentType().findCommonSupertypeWith(c1.getGamlType().getContentType()));
 	}
 
@@ -1047,10 +1049,11 @@ public class Containers {
 			see = { IKeyword.AT })
 	@no_test
 	@validator (InternalAtValidator.class)
-	public static Object internal_at(final IScope scope, final IContainer container, final IList indices)
+	public static Object internal_at(final IScope scope, final IRuntimeContainer container,
+			final IList indices)
 			throws GamaRuntimeException {
-		if (container instanceof IContainer.ToGet)
-			return ((IContainer.ToGet) container).getFromIndicesList(scope, indices);
+		if (container instanceof IRuntimeContainer.ToGet)
+			return ((IRuntimeContainer.ToGet) container).getFromIndicesList(scope, indices);
 		throw GamaRuntimeException.error("" + container + " cannot be accessed using " + indices, scope);
 	}
 
@@ -1100,8 +1103,8 @@ public class Containers {
 	@validator (AtValidator.class)
 	@test ("list<int> l <- [10,20,30]; l at 0 = 10")
 	@test ("list<int> l2 <- [10,20,30]; l at 2 = 30")
-	public static Object at(final IScope scope, final IContainer container, final Object key) {
-		if (container instanceof IContainer.ToGet) return ((IContainer.ToGet) container).get(scope, key);
+	public static Object at(final IScope scope, final IRuntimeContainer container, final Object key) {
+		if (container instanceof IRuntimeContainer.ToGet) return ((IRuntimeContainer.ToGet) container).get(scope, key);
 		throw GamaRuntimeException.error("" + container + " cannot be accessed using " + key, scope);
 	}
 
@@ -1303,7 +1306,7 @@ public class Containers {
 	@test ("remove_duplicates([3,2,5,1,2,3,5,5,5]) = [3,2,5,1]")
 	@test ("distinct([1,2,1,3]) = [1,2,3]")
 	@test ("distinct([]) = []")
-	public static IList remove_duplicates(final IScope scope, final IContainer c) {
+	public static IList remove_duplicates(final IScope scope, final IRuntimeContainer c) {
 		return (IList) stream(scope, c).distinct().toCollection(listLike(c));
 	}
 
@@ -1343,7 +1346,7 @@ public class Containers {
 	@test ("[1,2,3,4,5,6] contains_all [2,8] = false")
 	@test ("[1::2, 3::4, 5::6] contains_all [1,3] = false")
 	@test ("[1::2, 3::4, 5::6] contains_all [2,4] = true")
-	public static Boolean contains_all(final IScope scope, final IContainer c, final IContainer c2) {
+	public static Boolean contains_all(final IScope scope, final IRuntimeContainer c, final IRuntimeContainer c2) {
 		return stream(scope, c2).allMatch(inContainer(scope, c));
 	}
 
@@ -1383,7 +1386,7 @@ public class Containers {
 	@test ("[1,2,3,4,5,6] contains_any [2,4] = true")
 	@test ("[1,2,3,4,5,6] contains_any [2,8] = true")
 	@test ("[1::2, 3::4, 5::6] contains_any [2,4] = true")
-	public static Boolean contains_any(final IScope scope, final IContainer c, final IContainer c1) {
+	public static Boolean contains_any(final IScope scope, final IRuntimeContainer c, final IRuntimeContainer c1) {
 		return stream(scope, c1).anyMatch(inContainer(scope, c));
 	}
 
@@ -1415,7 +1418,7 @@ public class Containers {
 	@test ("first_of(0,[1,2,3,4,5,6]) = []")
 	@test ("first([1,2,3]) = 1")
 	@test ("first([]) = nil")
-	public static IList first(final IScope scope, final Integer number, final IContainer c) {
+	public static IList first(final IScope scope, final Integer number, final IRuntimeContainer c) {
 		return (IList) stream(scope, c).limit(number < 0 ? 0 : number).toCollection(listLike(c));
 	}
 
@@ -1446,7 +1449,7 @@ public class Containers {
 	@test ("last(10,[1::2, 3::4]) is list")
 	@test ("last([1,2,3]) = 3")
 	@test ("last([]) = nil")
-	public static IList last(final IScope scope, final Integer number, final IContainer c) {
+	public static IList last(final IScope scope, final Integer number, final IRuntimeContainer c) {
 		int n = number < 0 ? 0 : number;
 		return (IList) stream(scope, c).skip(Math.max(0, c.length(scope) - n)).toCollection(listLike(c));
 	}
@@ -1488,7 +1491,7 @@ public class Containers {
 	@test ("2 in [1,2,3,4,5,6] = true")
 	@test ("3 in [1::2, 3::4, 5::6] = false")
 
-	public static Boolean in(final IScope scope, final Object o, final IContainer c) throws GamaRuntimeException {
+	public static Boolean in(final IScope scope, final Object o, final IRuntimeContainer c) throws GamaRuntimeException {
 		return notNull(scope, c).contains(scope, o);
 	}
 
@@ -1763,7 +1766,7 @@ public class Containers {
 	@doc (
 			value = "the index of the last occurence of the right operand in the left operand container",
 			usages = @usage (
-					value = "if the left operand is a map, last_index_of returns the index as an int (the key of the pair)",
+					value = "if the left operand is a map, last_index_of returns the last key mapped to that value",
 					examples = { @example (
 							value = "[1::2, 3::4, 5::4] last_index_of 4",
 							equals = "5") }))
@@ -1818,7 +1821,7 @@ public class Containers {
 							equals = "[]") },
 			see = { "remove_duplicates" })
 	@test ("[1,2,3,4,5,6] inter [0,8] = []")
-	public static IList inter(final IScope scope, final IContainer c, final IContainer c1) {
+	public static IList inter(final IScope scope, final IRuntimeContainer c, final IRuntimeContainer c1) {
 		return (IList) stream(scope, c).filter(inContainer(scope, c1)).distinct().toCollection(listLike(c, c1));
 	}
 
@@ -2208,7 +2211,7 @@ public class Containers {
 							equals = "[1,3,2,4,5,6,8,0]") },
 			see = { "inter", IKeyword.PLUS })
 	@test ("[1,2,3,4,5,6] union [2,4,9] = [1,2,3,4,5,6,9]")
-	public static IList union(final IScope scope, final IContainer c, final IContainer c1) {
+	public static IList union(final IScope scope, final IRuntimeContainer c, final IRuntimeContainer c1) {
 		return (IList) stream(scope, c).append(stream(scope, c1)).distinct().toCollection(listLike(c, c1));
 	}
 
@@ -2256,7 +2259,8 @@ public class Containers {
 			see = { "first_with", "last_with", "where" })
 	@test ("[1,2,3,4,5,6,7,8] group_by (each > 3) = [false::[1, 2, 3], true::[4, 5, 6, 7, 8]]")
 	@test ("[1::2, 3::4, 5::6] group_by (each > 4) = [false::[2, 4], true::[6]]")
-	public static IMap group_by(final IScope scope, final String eachName, final IContainer c, final IExpression e) {
+	public static IMap group_by(final IScope scope, final String eachName, final IRuntimeContainer c,
+			final IExpression e) {
 		final IType ct = notNull(scope, c).getGamlType().getContentType();
 		return (IMap) stream(scope, c).groupingTo(buildFunctionWithEach(scope, eachName, e),
 				asMapOf(e.getGamlType(), Types.LIST.of(ct)), listOf(ct));
@@ -2309,7 +2313,7 @@ public class Containers {
 							isExecutable = false) },
 			see = { "group_by", "first_with", "where" })
 	@test ("[1,2,3,4,5,6,7,8] last_with (each > 3) = 8")
-	public static Object last_with(final IScope scope, final String eachName, final IContainer c,
+	public static Object last_with(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		return stream(scope, c).filter(buildPredicateWithEach(scope, eachName, filter)).reduce((a, b) -> b)
 				.orElse(null);
@@ -2364,7 +2368,7 @@ public class Containers {
 							isExecutable = false) },
 			see = { "group_by", "last_with", "where" })
 	@test ("[1,2,3,4,5,6,7,8] first_with (each > 3) = 4")
-	public static Object first_with(final IScope scope, final String eachName, final IContainer c,
+	public static Object first_with(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		return stream(scope, c).findFirst(buildPredicateWithEach(scope, eachName, filter)).orElse(null);
 	}
@@ -2422,7 +2426,7 @@ public class Containers {
 	@test ("sum([{1.0,3.0},{3.0,5.0},{9.0,1.0},{7.0,8.0}]) = {20.0,17.0}")
 	@test ("sum ([12,10,3]) = 25")
 	@test ("sum([1,2,3]) = 6")
-	public static Object sum(final IScope scope, final IContainer l) {
+	public static Object sum(final IScope scope, final IRuntimeContainer l) {
 		return sum_of(scope, IKeyword.EACH, l, null);
 	}
 
@@ -2509,7 +2513,7 @@ public class Containers {
 					equals = "300") },
 			see = { "min_of", "max_of", "product_of", "mean_of" })
 	@test ("[1,2] sum_of (each * 100 ) = 300")
-	public static Object sum_of(final IScope scope, final String eachName, final IContainer container,
+	public static Object sum_of(final IScope scope, final String eachName, final IRuntimeContainer container,
 			final IExpression filter) {
 		Stream s = stream(scope, container);
 		IType t;
@@ -2574,7 +2578,7 @@ public class Containers {
 							equals = "2 or 4",
 							test = false) })
 	@no_test
-	public static IList among(final IScope scope, final Integer number, final IContainer c)
+	public static IList among(final IScope scope, final Integer number, final IRuntimeContainer c)
 			throws GamaRuntimeException {
 		if (number <= 0) {
 			if (number < 0) {
@@ -2656,7 +2660,8 @@ public class Containers {
 			see = { "group_by" })
 	@test ("[1,2,4,3,5,7,6,8] sort_by (each) = [1,2,3,4,5,6,7,8]")
 	@validator (ComparableValidator.class)
-	public static IList sort(final IScope scope, final String eachName, final IContainer c, final IExpression filter) {
+	public static IList sort(final IScope scope, final String eachName, final IRuntimeContainer c,
+			final IExpression filter) {
 		try {
 			return (IList) stream(scope, c).sortedBy(buildFunctionWithEach(scope, eachName, filter))
 					.toCollection(listLike(c));
@@ -2719,7 +2724,8 @@ public class Containers {
 			see = { "first_with", "last_with" })
 	@test ("[1,2,3,4,5,6,7,8] where (each > 3) = [4, 5, 6, 7, 8] ")
 	@test ("matrix([1, 2, 3], [4, 5, 6]) where (each > 2) = [4, 5, 3, 6] ")
-	public static IList where(final IScope scope, final String eachName, final IContainer c, final IExpression filter) {
+	public static IList where(final IScope scope, final String eachName, final IRuntimeContainer c,
+			final IExpression filter) {
 		return (IList) stream(scope, c).filter(buildPredicateWithEach(scope, eachName, filter))
 				.toCollection(listLike(c));
 	}
@@ -2841,7 +2847,7 @@ public class Containers {
 			see = { "where", "with_min_of" })
 	@test ("[1,2,3,4,5,6,7,8] with_max_of (each ) = 8")
 	@validator (ComparableValidator.class)
-	public static Object with_max_of(final IScope scope, final String eachName, final IContainer c,
+	public static Object with_max_of(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		return stream(scope, c).maxBy(buildFunctionWithEach(scope, eachName, filter)).orElse(null);
 	}
@@ -2888,7 +2894,7 @@ public class Containers {
 			see = { "where", "with_max_of" })
 	@test ("[1,2,3,4,5,6,7,8] with_min_of (each )  = 1")
 	@validator (ComparableValidator.class)
-	public static Object with_min_of(final IScope scope, final String eachName, final IContainer c,
+	public static Object with_min_of(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		return stream(scope, c).minBy(buildFunctionWithEach(scope, eachName, filter)).orElse(null);
 	}
@@ -2928,7 +2934,7 @@ public class Containers {
 							equals = "[2,4,8]") },
 			see = { "collect" })
 	@test ("[1,2,4] accumulate ([2,4]) = [2,4,2,4,2,4]")
-	public static IList accumulate(final IScope scope, final String eachName, final IContainer c,
+	public static IList accumulate(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		// WARNING TODO The resulting type is not computed
 		final IType type = filter.getGamlType();
@@ -3049,7 +3055,7 @@ public class Containers {
 	@test ("[1,2,4] collect ([2,4]) = [[2,4],[2,4],[2,4]]")
 	@test ("[1,2,3] collect (i: i+1) = [2,3,4]")
 	@test ("[1,2] collect (i: ([1,2,3] collect (j: i+j))) = [[2,3,4],[3,4,5]]")
-	public static IList collect(final IScope scope, final String eachName, final IContainer c,
+	public static IList collect(final IScope scope, final String eachName, final IRuntimeContainer c,
 			final IExpression filter) {
 		return (IList) stream(scope, c).map(buildFunctionWithEach(scope, eachName, filter))
 				.toCollection(listOf(filter.getGamlType()));
@@ -3078,7 +3084,7 @@ public class Containers {
 					@example (
 							value = "interleave([['e11','e12','e13'],['e21','e22','e23'],['e31','e32','e33']])",
 							equals = "['e11','e21','e31','e12','e22','e32','e13','e23','e33']") })
-	public static IList interleave(final IScope scope, final IContainer cc) {
+	public static IList interleave(final IScope scope, final IRuntimeContainer cc) {
 		final Iterable iterable = notNull(scope, cc).iterable(scope);
 		IType type = cc.getGamlType().getContentType();
 		if (type.isContainer()) { type = type.getContentType(); }
@@ -3127,7 +3133,7 @@ public class Containers {
 							value = "[1::2, 3::4, 5::6] count (each > 4)",
 							equals = "1") },
 			see = { "group_by" })
-	public static Integer count(final IScope scope, final String eachName, final IContainer original,
+	public static Integer count(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression filter) {
 		return (int) notNull(scope, original).stream(scope).filter(buildPredicateWithEach(scope, eachName, filter))
 				.count();
@@ -3161,7 +3167,7 @@ public class Containers {
 							value = "[1::2, 3::4, 5::6] one_matches (each > 4)",
 							equals = "true") },
 			see = { "none_matches", "all_match", "count" })
-	public static Boolean one_matches(final IScope scope, final String eachName, final IContainer original,
+	public static Boolean one_matches(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression filter) {
 		return notNull(scope, original).stream(scope).anyMatch(buildPredicateWithEach(scope, eachName, filter));
 	}
@@ -3195,7 +3201,7 @@ public class Containers {
 							value = "[1::2, 3::4, 5::6] none_matches (each > 4)",
 							equals = "false") },
 			see = { "one_matches", "all_match", "count" })
-	public static Boolean none_matches(final IScope scope, final String eachName, final IContainer original,
+	public static Boolean none_matches(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression filter) {
 		return notNull(scope, original).stream(scope).noneMatch(buildPredicateWithEach(scope, eachName, filter));
 	}
@@ -3229,7 +3235,7 @@ public class Containers {
 							value = "[1::2, 3::4, 5::6] all_match (each > 4)",
 							equals = "false") },
 			see = { "none_matches", "one_matches", "count" })
-	public static Boolean all_match(final IScope scope, final String eachName, final IContainer original,
+	public static Boolean all_match(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression filter) {
 		return notNull(scope, original).stream(scope).allMatch(buildPredicateWithEach(scope, eachName, filter));
 	}
@@ -3250,8 +3256,8 @@ public class Containers {
 			iterator = true,
 			content_type = ITypeProvider.CONTENT_TYPE_AT_INDEX + 2,
 			index_type = ITypeProvider.TYPE_AT_INDEX + 3,
-			category = IOperatorCategory.CONTAINER,
-			concept = { IConcept.CONTAINER })
+			category = IOperatorCategory.MAP,
+			concept = { IConcept.CONTAINER, IConcept.MAP })
 	@doc (
 			value = "produces a new map from the evaluation of the right-hand operand for each element of the left-hand operand",
 			usages = {
@@ -3260,7 +3266,7 @@ public class Containers {
 					value = "[1,2,3,4,5,6,7,8] index_by (each - 1)",
 					equals = "[0::1, 1::2, 2::3, 3::4, 4::5, 5::6, 6::7, 7::8]") },
 			see = {})
-	public static IMap index_by(final IScope scope, final String eachName, final IContainer original,
+	public static IMap index_by(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression keyProvider) {
 
 		final StreamEx s = original.stream(scope);
@@ -3301,7 +3307,7 @@ public class Containers {
 							returnType = "map<int,int>",
 							equals = "[2::4, 4::8, 6::12] ") },
 			see = {})
-	public static IMap as_map(final IScope scope, final String eachName, final IContainer original,
+	public static IMap as_map(final IScope scope, final String eachName, final IRuntimeContainer original,
 			final IExpression filter) {
 		if (!(filter instanceof IOperator pair) || !"::".equals(pair.getName()))
 			throw GamaRuntimeException.error("'as_map' expects a pair as second argument", scope);
@@ -3375,8 +3381,8 @@ public class Containers {
 			can_be_const = true,
 			type = ITypeProvider.BOTH,
 			content_type = ITypeProvider.BOTH,
-			category = IOperatorCategory.CONTAINER,
-			concept = { IConcept.CONTAINER })
+			category = IOperatorCategory.MAP,
+			concept = { IConcept.MAP })
 	@doc (
 			value = "returns a new map containing all the elements of both operands",
 			examples = { @example (
@@ -3409,8 +3415,8 @@ public class Containers {
 			can_be_const = true,
 			type = ITypeProvider.TYPE_AT_INDEX + 1,
 			content_type = ITypeProvider.BOTH,
-			category = IOperatorCategory.CONTAINER,
-			concept = { IConcept.CONTAINER })
+			category = IOperatorCategory.MAP,
+			concept = { IConcept.MAP })
 	@doc (
 			value = "returns a new map containing all the elements of both operands",
 			examples = { @example (
@@ -3443,8 +3449,8 @@ public class Containers {
 			can_be_const = true,
 			type = ITypeProvider.BOTH,
 			content_type = ITypeProvider.BOTH,
-			category = IOperatorCategory.CONTAINER,
-			concept = {})
+			category = IOperatorCategory.MAP,
+			concept = { IConcept.MAP })
 	@doc (
 			value = "returns a new map containing all the elements of the first operand not present in the second operand",
 			examples = { @example (
@@ -3476,8 +3482,8 @@ public class Containers {
 			can_be_const = true,
 			type = ITypeProvider.TYPE_AT_INDEX + 1,
 			content_type = ITypeProvider.BOTH,
-			category = IOperatorCategory.CONTAINER,
-			concept = {})
+			category = IOperatorCategory.MAP,
+			concept = { IConcept.MAP })
 	@doc (
 			value = "returns a new map containing all the elements of the first operand without the one of the second operand",
 			examples = { @example (
@@ -3524,7 +3530,7 @@ public class Containers {
 			see = { "sum" })
 	@test ("mean ([4.5, 3.5, 5.5, 7.0]) with_precision 3 = 5.125")
 	@test ("mean([1,2,3]) = 2.0")
-	public static Object opMean(final IScope scope, final IContainer l) throws GamaRuntimeException {
+	public static Object opMean(final IScope scope, final IRuntimeContainer l) throws GamaRuntimeException {
 
 		final Object s = sum(scope, l);
 		int size = l.length(scope);

--- a/gama.core/src/gama/gaml/operators/Files.java
+++ b/gama.core/src/gama/gaml/operators/Files.java
@@ -51,47 +51,46 @@ import gama.api.utils.files.FileUtils;
 /**
  * Provides GAML file I/O operators for the GAMA modeling and simulation platform.
  *
- * <p>This class is the primary host for file-related operators that GAML models can use to
- * interact with the filesystem at runtime. All path arguments that are relative are resolved
- * against the simulation workspace root via
+ * <p>
+ * This class is the primary host for file-related operators that GAML models can use to interact with the filesystem at
+ * runtime. All path arguments that are relative are resolved against the simulation workspace root via
  * {@link gama.api.utils.files.FileUtils#constructAbsoluteFilePath(IScope, String, boolean)}.
  *
- * <p><strong>Operator families provided:</strong>
+ * <p>
+ * <strong>Operator families provided:</strong>
  * <ul>
- *   <li><strong>File existence:</strong> {@code file_exists}, {@code folder_exists} /
- *       {@code directory_exists} — test whether a path refers to an existing file or directory.</li>
- *   <li><strong>File access:</strong> {@code read} / {@code get} — read an attribute from an
- *       agent, geometry, or the current GIS feature stream.</li>
- *   <li><strong>File path manipulation:</strong> {@code to_absolute_path} — converts a
- *       relative path to an absolute one using the simulation workspace root.</li>
- *   <li><strong>File creation / writing:</strong> {@code save} and {@code write} are
- *       implemented in other classes (see {@code SaveStatements}); cross-reference them when
- *       documenting output workflows.</li>
- *   <li><strong>Compression:</strong> {@code zip} — compresses a list of files/folders into a
- *       standard ZIP archive; {@code unzip} — extracts a ZIP archive to a destination folder.</li>
- *   <li><strong>Directory operations:</strong> {@code directory} / {@code folder} — opens an
- *       existing directory as a {@link gama.api.types.file.GamaFolderFile};
- *       {@code new_folder} — creates a directory if it does not yet exist.</li>
- *   <li><strong>File management:</strong> {@code copy_file}, {@code rename_file},
- *       {@code delete_file} — manipulate files and directories on the filesystem.</li>
- *   <li><strong>Writable flag:</strong> {@code writable} — changes the read/write mode of an
- *       open {@link gama.api.types.file.IGamaFile}.</li>
- *   <li><strong>Buffered I/O:</strong> {@code flush_all_files} — flushes all pending buffered
- *       save operations for the current simulation.</li>
+ * <li><strong>File existence:</strong> {@code file_exists}, {@code folder_exists} / {@code directory_exists} — test
+ * whether a path refers to an existing file or directory.</li>
+ * <li><strong>File access:</strong> {@code read} / {@code get} — read an attribute from an agent, geometry, or the
+ * current GIS feature stream.</li>
+ * <li><strong>File path manipulation:</strong> {@code to_absolute_path} — converts a relative path to an absolute one
+ * using the simulation workspace root.</li>
+ * <li><strong>File creation / writing:</strong> {@code save} and {@code write} are implemented in other classes (see
+ * {@code SaveStatements}); cross-reference them when documenting output workflows.</li>
+ * <li><strong>Compression:</strong> {@code zip} — compresses a list of files/folders into a standard ZIP archive;
+ * {@code unzip} — extracts a ZIP archive to a destination folder.</li>
+ * <li><strong>Directory operations:</strong> {@code directory} / {@code folder} — opens an existing directory as a
+ * {@link gama.api.types.file.GamaFolderFile}; {@code new_folder} — creates a directory if it does not yet exist.</li>
+ * <li><strong>File management:</strong> {@code copy_file}, {@code rename_file}, {@code delete_file} — manipulate files
+ * and directories on the filesystem.</li>
+ * <li><strong>Writable flag:</strong> {@code writable} — changes the read/write mode of an open
+ * {@link gama.api.types.file.IGamaFile}.</li>
+ * <li><strong>Buffered I/O:</strong> {@code flush_all_files} — flushes all pending buffered save operations for the
+ * current simulation.</li>
  * </ul>
  *
- * <p><strong>Path resolution:</strong> Relative paths are resolved against the simulation
- * workspace root via
- * {@link gama.api.utils.files.FileUtils#constructAbsoluteFilePath(IScope, String, boolean)}.
- * The resulting absolute path uses the OS path separator.
+ * <p>
+ * <strong>Path resolution:</strong> Relative paths are resolved against the simulation workspace root via
+ * {@link gama.api.utils.files.FileUtils#constructAbsoluteFilePath(IScope, String, boolean)}. The resulting absolute
+ * path uses the OS path separator.
  *
- * <p><strong>Testing:</strong> Most operators in this class are marked {@code @no_test} because
- * their results depend on the filesystem and execution context and cannot be verified with static
- * inline assertions.
+ * <p>
+ * <strong>Testing:</strong> Most operators in this class are marked {@code @no_test} because their results depend on
+ * the filesystem and execution context and cannot be verified with static inline assertions.
  *
- * <p><strong>ZIP support:</strong> The {@code zip} and {@code unzip} operators create and read
- * standard ZIP archives (as defined by {@link java.util.zip.ZipOutputStream} /
- * {@link java.util.zip.ZipFile}).
+ * <p>
+ * <strong>ZIP support:</strong> The {@code zip} and {@code unzip} operators create and read standard ZIP archives (as
+ * defined by {@link java.util.zip.ZipOutputStream} / {@link java.util.zip.ZipFile}).
  *
  * @author Alexis Drogoul (original author, 20 Dec 2010)
  * @see gama.api.utils.files.FileUtils
@@ -154,8 +153,7 @@ public class Files {
 	@doc (
 			value = "Test whether the parameter is the path to an existing file. False if it does not exist or if it is a folder",
 			returns = "a {@code bool}: {@code true} if the file exists on the filesystem and is not a directory.",
-			special_cases = {
-					"An empty or null path returns false without raising an error.",
+			special_cases = { "An empty or null path returns false without raising an error.",
 					"Paths are resolved relative to the simulation workspace root via FileUtils.constructAbsoluteFilePath.",
 					"Returns false for directories; use folder_exists to check directories." },
 			examples = { @example (
@@ -196,8 +194,7 @@ public class Files {
 	@doc (
 			value = "Transforms a relative path into an absolute path. If the path is already absolute doesn't transform it.",
 			returns = "a {@code string} containing the absolute path resolved against the simulation workspace root.",
-			special_cases = {
-					"An empty string '' is resolved to the simulation root path itself.",
+			special_cases = { "An empty string '' is resolved to the simulation root path itself.",
 					"If the path is already absolute it is returned unchanged.",
 					"The returned path uses the OS-specific path separator." })
 	@no_test

--- a/gama.core/src/gama/gaml/skills/MovingSkill.java
+++ b/gama.core/src/gama/gaml/skills/MovingSkill.java
@@ -53,7 +53,7 @@ import gama.api.types.list.GamaListFactory;
 import gama.api.types.list.IList;
 import gama.api.types.map.GamaMapFactory;
 import gama.api.types.map.IMap;
-import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.topology.GamaTopologyFactory;
 import gama.api.types.topology.ITopology;
 import gama.api.utils.collections.Collector;
@@ -882,7 +882,7 @@ public class MovingSkill extends Skill {
 		IShape goal = computeTarget(scope, agent);
 		final Boolean returnPath =
 				scope.hasArg("return_path") ? (Boolean) scope.getArg("return_path", IType.NONE) : false;
-		IContainer on = null;
+		IRuntimeContainer<?, ?> on = null;
 
 		Object onV = scope.getArg("on", IType.NONE);
 		Object rt;

--- a/gama.core/src/gama/gaml/statements/AddStatement.java
+++ b/gama.core/src/gama/gaml/statements/AddStatement.java
@@ -32,6 +32,7 @@ import gama.api.gaml.types.IType;
 import gama.api.gaml.types.Types;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.gaml.statements.AddStatement.AddSerializer;
 import gama.gaml.statements.AddStatement.AddValidator;
 
@@ -45,7 +46,7 @@ import gama.gaml.statements.AddStatement.AddValidator;
 @facets (
 		value = { @facet (
 				name = IKeyword.TO,
-				type = { IType.CONTAINER, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
+				type = { IType.CONTAINER, IType.MAP, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
 				optional = false,
 				doc = { @doc ("the left member of the addition assignment ('cont << expr;') is an expression cont that evaluates to a container (list, map, matrix, graph) ") }),
 				@facet (
@@ -308,7 +309,7 @@ public class AddStatement extends AbstractContainerStatement {
 
 	@Override
 	protected void apply(final IScope scope, final Object object, final Object position,
-			final IContainer.Modifiable container) throws GamaRuntimeException {
+			final IRuntimeContainer.Modifiable container) throws GamaRuntimeException {
 		// if (position != null && !container.checkBounds(scope, position, true)) {
 		// throw GamaRuntimeException.warning("Index " + position + " out of bounds of " + list.serialize(false),
 		// scope);
@@ -319,9 +320,9 @@ public class AddStatement extends AbstractContainerStatement {
 			} else {
 				container.addValueAtIndex(scope, position, object);
 			}
-		} else if (object instanceof IContainer) {
+		} else if (object instanceof IRuntimeContainer) {
 			// AD July 2020: Addition of the position (see #2985)
-			container.addValues(scope, position, (IContainer<?, ?>) object);
+			container.addValues(scope, position, (IRuntimeContainer<?, ?>) object);
 		}
 	}
 

--- a/gama.core/src/gama/gaml/statements/PutStatement.java
+++ b/gama.core/src/gama/gaml/statements/PutStatement.java
@@ -30,7 +30,7 @@ import gama.api.gaml.types.IType;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.graph.IGraph;
 import gama.api.types.list.IList;
-import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.api.types.pair.IPair;
 import gama.gaml.statements.PutStatement.PutSerializer;
 import gama.gaml.statements.PutStatement.PutValidator;
@@ -65,7 +65,7 @@ import gama.gaml.statements.PutStatement.PutValidator;
 						doc = @doc ("the right member of the put assignment ('cont[index] <- expr;') is an expression expr that evaluates to the element(s) to be put in the container")),
 				@facet (
 						name = IKeyword.IN,
-						type = { IType.CONTAINER, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
+												type = { IType.CONTAINER, IType.MAP, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
 						optional = false,
 						doc = @doc ("the left member of the put assignment ('cont[index] <- expr;') is an expression cont that evaluates to a container (list, map, matrix). It makes no sense for graphs ")) },
 		omissible = IKeyword.ITEM)
@@ -206,7 +206,7 @@ public class PutStatement extends AddStatement {
 
 	@Override
 	protected void apply(final IScope scope, final Object object, final Object position,
-			final IContainer.Modifiable container) throws GamaRuntimeException {
+			final IRuntimeContainer.Modifiable container) throws GamaRuntimeException {
 		if (!asAll) {
 			if (container instanceof IList && position instanceof IPair) {
 				((IList<Object>) container).replaceRange(scope, (IPair) position, object);

--- a/gama.core/src/gama/gaml/statements/RemoveStatement.java
+++ b/gama.core/src/gama/gaml/statements/RemoveStatement.java
@@ -31,7 +31,7 @@ import gama.api.gaml.statements.AbstractContainerStatement.ContainerValidator;
 import gama.api.gaml.types.IType;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.graph.IGraph;
-import gama.api.types.misc.IContainer;
+import gama.api.types.misc.IRuntimeContainer;
 import gama.gaml.statements.RemoveStatement.RemoveSerializer;
 
 /**
@@ -49,7 +49,7 @@ import gama.gaml.statements.RemoveStatement.RemoveSerializer;
 				doc = @doc ("the right member of the removal assignment ('cont >> expr;') is an expression expr that evaluates to the element(s) to be removed from the container")),
 				@facet (
 						name = IKeyword.FROM,
-						type = { IType.CONTAINER, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
+												type = { IType.CONTAINER, IType.MAP, IType.SPECIES, IType.AGENT, IType.GEOMETRY },
 						optional = false,
 						doc = { @doc ("the left member of the removal assignment ('cont >> expr;') is an expression cont that evaluates to a container (list, map, graph) ") }),
 				@facet (
@@ -246,7 +246,7 @@ public class RemoveStatement extends AbstractContainerStatement {
 	@SuppressWarnings ("rawtypes")
 	@Override
 	protected void apply(final IScope scope, final Object object, final Object position,
-			final IContainer.Modifiable container) throws GamaRuntimeException {
+			final IRuntimeContainer.Modifiable container) throws GamaRuntimeException {
 
 		if (position == null) {
 			// If key/at/index/node is not mentioned
@@ -254,7 +254,7 @@ public class RemoveStatement extends AbstractContainerStatement {
 				// if we "remove all"
 				if (asAllValues) {
 					// if a container is passed
-					container.removeValues(scope, (IContainer) object);
+					container.removeValues(scope, (IRuntimeContainer) object);
 				} else {
 					// otherwise if it is a simple value
 					container.removeAllOccurrencesOfValue(scope, object);
@@ -264,7 +264,7 @@ public class RemoveStatement extends AbstractContainerStatement {
 				container.removeValue(scope, object);
 			}
 		} else if (asAllIndexes) {
-			container.removeIndexes(scope, (IContainer) position);
+			container.removeIndexes(scope, (IRuntimeContainer) position);
 		} else {
 			// If a key/index/at/node is mentioned
 			// simply remove the index.

--- a/gama.ui.display.java2d/src/gama/ui/display/java2d/AWTDisplayView.java
+++ b/gama.ui.display.java2d/src/gama/ui/display/java2d/AWTDisplayView.java
@@ -29,40 +29,6 @@ public class AWTDisplayView extends LayeredDisplayView {
 		DEBUG.OFF();
 	}
 
-	// static IPartListener MyPartListener = new IPartListener() {
-	// @Override
-	// public void partActivated(IWorkbenchPart part) {
-	// DEBUG.OUT("Part activated: " + part.getTitle());
-	// // if (PlatformHelper.isWindows()) {
-	// // if (part instanceof AWTDisplayView av) {
-	// //
-	// // WorkbenchHelper.runInUI("", 20, m -> av.setFocus());
-	// //
-	// // }
-	// // }
-	// }
-	//
-	// @Override
-	// public void partBroughtToTop(IWorkbenchPart part) {
-	// DEBUG.OUT("Part brought to top: " + part.getTitle());
-	// }
-	//
-	// @Override
-	// public void partClosed(IWorkbenchPart part) {
-	// DEBUG.OUT("Part closed: " + part.getTitle());
-	// }
-	//
-	// @Override
-	// public void partDeactivated(IWorkbenchPart part) {
-	// DEBUG.OUT("Part deactivated: " + part.getTitle());
-	// }
-	//
-	// @Override
-	// public void partOpened(IWorkbenchPart part) {
-	// DEBUG.OUT("Part opened: " + part.getTitle());
-	// }
-	// };
-
 	@Override
 	protected Composite createSurfaceComposite(final Composite parent) {
 		// WorkbenchHelper.getPage().addPartListener(MyPartListener);


### PR DESCRIPTION
Introduce a new IRuntimeContainer interface and migrate runtime container APIs to use it. Maps are intentionally kept out of the GAML `container` inheritance branch but retain runtime compatibility so existing container-oriented operators still accept maps during the transition. Adjustments include: updating AbstractContainerStatement to use IRuntimeContainer, adding compatibility logic in Signature and Types (skip CONTAINER<-MAP edge and compute compatibility distance), changing various parametric/container types and IGamaFile/GamaFile APIs to IRuntimeContainer, and adapting map implementations and graph APIs to the runtime container contracts. This keeps associative maps separate in the type hierarchy while preserving existing runtime behavior. Addresses #1061 