### PR TITLE
Fix CSV Editor Freeze by utilizing lazy SWT virtual tables

### DIFF
--- a/gama.ui.viewers/src/gama/ui/viewers/csv/CSVContentProvider.java
+++ b/gama.ui.viewers/src/gama/ui/viewers/csv/CSVContentProvider.java
@@ -62,33 +62,43 @@ public class CSVContentProvider implements IStructuredContentProvider, ILazyCont
 			CSVModel model = (CSVModel) viewer.getInput();
 			Object[] rows = model.getArrayRows(false);
 
-			if (viewer.getFilters() != null && viewer.getFilters().length > 0) {
-				java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-				for (Object row : rows) {
-					boolean select = true;
-					for (ViewerFilter filter : viewer.getFilters()) {
-						if (!filter.select(viewer, model, row)) {
-							select = false;
-							break;
-						}
-					}
-					if (select) filteredRows.add(row);
-				}
-				rows = filteredRows.toArray();
-			}
-
-			if (viewer.getComparator() != null) {
-				java.util.Arrays.sort(rows, new java.util.Comparator<Object>() {
-					@Override
-					public int compare(Object o1, Object o2) {
-						return viewer.getComparator().compare(viewer, o1, o2);
-					}
-				});
-			}
+			rows = applyFiltersAndSorters(rows, model);
 
 			if (index >= 0 && index < rows.length) {
 				viewer.replace(rows[index], index);
 			}
 		}
+	}
+
+	private Object[] applyFiltersAndSorters(Object[] rows, CSVModel model) {
+		if (viewer.getFilters() != null && viewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : rows) {
+				if (isRowSelected(model, row)) {
+					filteredRows.add(row);
+				}
+			}
+			rows = filteredRows.toArray();
+		}
+
+		if (viewer.getComparator() != null) {
+			java.util.Arrays.sort(rows, new java.util.Comparator<Object>() {
+				@Override
+				public int compare(Object o1, Object o2) {
+					return viewer.getComparator().compare(viewer, o1, o2);
+				}
+			});
+		}
+
+		return rows;
+	}
+
+	private boolean isRowSelected(CSVModel model, Object row) {
+		for (ViewerFilter filter : viewer.getFilters()) {
+			if (!filter.select(viewer, model, row)) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/gama.ui.viewers/src/gama/ui/viewers/csv/CSVContentProvider.java
+++ b/gama.ui.viewers/src/gama/ui/viewers/csv/CSVContentProvider.java
@@ -6,7 +6,7 @@
  * (c) 2007-2024 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, TLU, CTU)
  *
  * Visit https://github.com/gama-platform/gama for license information and contacts.
- * 
+ *
  ********************************************************************************************************/
 package gama.ui.viewers.csv;
 
@@ -19,7 +19,9 @@ import gama.ui.viewers.csv.model.CSVModel;
  * @author fhenri
  *
  */
-public class CSVContentProvider implements IStructuredContentProvider {
+public class CSVContentProvider implements IStructuredContentProvider, ILazyContentProvider {
+
+	private TableViewer viewer;
 
 	/**
 	 * Returns the elements to display in the table viewer
@@ -51,5 +53,42 @@ public class CSVContentProvider implements IStructuredContentProvider {
 	 */
 	@Override
 	public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput) {
+		this.viewer = (TableViewer) viewer;
+	}
+
+	@Override
+	public void updateElement(int index) {
+		if (viewer != null && viewer.getInput() instanceof CSVModel) {
+			CSVModel model = (CSVModel) viewer.getInput();
+			Object[] rows = model.getArrayRows(false);
+
+			if (viewer.getFilters() != null && viewer.getFilters().length > 0) {
+				java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+				for (Object row : rows) {
+					boolean select = true;
+					for (ViewerFilter filter : viewer.getFilters()) {
+						if (!filter.select(viewer, model, row)) {
+							select = false;
+							break;
+						}
+					}
+					if (select) filteredRows.add(row);
+				}
+				rows = filteredRows.toArray();
+			}
+
+			if (viewer.getComparator() != null) {
+				java.util.Arrays.sort(rows, new java.util.Comparator<Object>() {
+					@Override
+					public int compare(Object o1, Object o2) {
+						return viewer.getComparator().compare(viewer, o1, o2);
+					}
+				});
+			}
+
+			if (index >= 0 && index < rows.length) {
+				viewer.replace(rows[index], index);
+			}
+		}
 	}
 }

--- a/gama.ui.viewers/src/gama/ui/viewers/csv/MultiPageCSVEditor.java
+++ b/gama.ui.viewers/src/gama/ui/viewers/csv/MultiPageCSVEditor.java
@@ -211,38 +211,8 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 	 *
 	 */
 	public void tableModified() {
-		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-			for (Object row : model.getArrayRows(false)) {
-				boolean select = true;
-				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-					if (!filter.select(tableViewer, model, row)) {
-						select = false;
-						break;
-					}
-				}
-				if (select) filteredRows.add(row);
-			}
-			tableViewer.setItemCount(filteredRows.size());
-		} else {
-			tableViewer.setItemCount(model.getArrayRows(false).length);
-		}
-		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-			for (Object row : model.getArrayRows(false)) {
-				boolean select = true;
-				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-					if (!filter.select(tableViewer, model, row)) {
-						select = false;
-						break;
-					}
-				}
-				if (select) filteredRows.add(row);
-			}
-			tableViewer.setItemCount(filteredRows.size());
-		} else {
-			tableViewer.setItemCount(model.getArrayRows(false).length);
-		}
+		updateTableItemCount();
+		updateTableItemCount();
 		tableViewer.refresh();
 		final boolean wasPageModified = isPageModified;
 		isPageModified = true;
@@ -274,22 +244,7 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 			addMenuItemToColumn(column.getColumn(), index);
 		}
 
-		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-			for (Object row : model.getArrayRows(false)) {
-				boolean select = true;
-				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-					if (!filter.select(tableViewer, model, row)) {
-						select = false;
-						break;
-					}
-				}
-				if (select) filteredRows.add(row);
-			}
-			tableViewer.setItemCount(filteredRows.size());
-		} else {
-			tableViewer.setItemCount(model.getArrayRows(false).length);
-		}
+		updateTableItemCount();
 		tableViewer.setInput(model);
 		model.addModelListener(csvFileListener);
 		defineCellEditing();
@@ -360,22 +315,7 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 				} else {
 					tableViewer.getTable().setSortColumn(column);
 				}
-				if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-					java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-					for (Object row : model.getArrayRows(false)) {
-						boolean select = true;
-						for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-							if (!filter.select(tableViewer, model, row)) {
-								select = false;
-								break;
-							}
-						}
-						if (select) filteredRows.add(row);
-					}
-					tableViewer.setItemCount(filteredRows.size());
-				} else {
-					tableViewer.setItemCount(model.getArrayRows(false).length);
-				}
+				updateTableItemCount();
 				tableViewer.refresh();
 			}
 		});
@@ -579,22 +519,7 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 					final CellLabelProvider labelProvider = tableViewer.getLabelProvider(i);
 					if (labelProvider != null) { ((CSVLabelProvider) labelProvider).setSearchText(filterText); }
 				}
-				if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-					java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-					for (Object row : model.getArrayRows(false)) {
-						boolean select = true;
-						for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-							if (!filter.select(tableViewer, model, row)) {
-								select = false;
-								break;
-							}
-						}
-						if (select) filteredRows.add(row);
-					}
-					tableViewer.setItemCount(filteredRows.size());
-				} else {
-					tableViewer.setItemCount(model.getArrayRows(false).length);
-				}
+				updateTableItemCount();
 				tableViewer.refresh();
 			}
 		});
@@ -655,22 +580,7 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 								final String colToInsert = acPage.getColumnNewName();
 								model.addColumn(colToInsert);
 
-		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
-			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
-			for (Object row : model.getArrayRows(false)) {
-				boolean select = true;
-				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
-					if (!filter.select(tableViewer, model, row)) {
-						select = false;
-						break;
-					}
-				}
-				if (select) filteredRows.add(row);
-			}
-			tableViewer.setItemCount(filteredRows.size());
-		} else {
-			tableViewer.setItemCount(model.getArrayRows(false).length);
-		}
+		updateTableItemCount();
 		tableViewer.setInput(model);
 								final TableColumn column = new TableColumn(tableViewer.getTable(), SWT.LEFT);
 								column.setText(colToInsert);
@@ -715,4 +625,27 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 
 	}
 
+
+	private void updateTableItemCount() {
+		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : model.getArrayRows(false)) {
+				if (isRowSelected(model, row)) {
+					filteredRows.add(row);
+				}
+			}
+			tableViewer.setItemCount(filteredRows.size());
+		} else {
+			tableViewer.setItemCount(model.getArrayRows(false).length);
+		}
+	}
+
+	private boolean isRowSelected(CSVModel model, Object row) {
+		for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+			if (!filter.select(tableViewer, model, row)) {
+				return false;
+			}
+		}
+		return true;
+	}
 }

--- a/gama.ui.viewers/src/gama/ui/viewers/csv/MultiPageCSVEditor.java
+++ b/gama.ui.viewers/src/gama/ui/viewers/csv/MultiPageCSVEditor.java
@@ -173,7 +173,7 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 		final Composite intermediate = new Composite(parent, SWT.NONE);
 		final Composite composite = GamaToolbarFactory.createToolbars(this, intermediate);
 		tableViewer =
-				new TableViewer(composite, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER);
+				new TableViewer(composite, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER | SWT.VIRTUAL);
 		tableViewer.setUseHashlookup(true);
 		final Table table = tableViewer.getTable();
 		table.setHeaderVisible(true);
@@ -211,6 +211,38 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 	 *
 	 */
 	public void tableModified() {
+		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : model.getArrayRows(false)) {
+				boolean select = true;
+				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+					if (!filter.select(tableViewer, model, row)) {
+						select = false;
+						break;
+					}
+				}
+				if (select) filteredRows.add(row);
+			}
+			tableViewer.setItemCount(filteredRows.size());
+		} else {
+			tableViewer.setItemCount(model.getArrayRows(false).length);
+		}
+		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : model.getArrayRows(false)) {
+				boolean select = true;
+				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+					if (!filter.select(tableViewer, model, row)) {
+						select = false;
+						break;
+					}
+				}
+				if (select) filteredRows.add(row);
+			}
+			tableViewer.setItemCount(filteredRows.size());
+		} else {
+			tableViewer.setItemCount(model.getArrayRows(false).length);
+		}
 		tableViewer.refresh();
 		final boolean wasPageModified = isPageModified;
 		isPageModified = true;
@@ -240,6 +272,23 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 			column.getColumn().setMoveable(true);
 			column.setLabelProvider(new CSVLabelProvider());
 			addMenuItemToColumn(column.getColumn(), index);
+		}
+
+		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : model.getArrayRows(false)) {
+				boolean select = true;
+				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+					if (!filter.select(tableViewer, model, row)) {
+						select = false;
+						break;
+					}
+				}
+				if (select) filteredRows.add(row);
+			}
+			tableViewer.setItemCount(filteredRows.size());
+		} else {
+			tableViewer.setItemCount(model.getArrayRows(false).length);
 		}
 		tableViewer.setInput(model);
 		model.addModelListener(csvFileListener);
@@ -310,6 +359,22 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 					tableViewer.getTable().setSortColumn(null);
 				} else {
 					tableViewer.getTable().setSortColumn(column);
+				}
+				if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+					java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+					for (Object row : model.getArrayRows(false)) {
+						boolean select = true;
+						for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+							if (!filter.select(tableViewer, model, row)) {
+								select = false;
+								break;
+							}
+						}
+						if (select) filteredRows.add(row);
+					}
+					tableViewer.setItemCount(filteredRows.size());
+				} else {
+					tableViewer.setItemCount(model.getArrayRows(false).length);
 				}
 				tableViewer.refresh();
 			}
@@ -514,6 +579,22 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 					final CellLabelProvider labelProvider = tableViewer.getLabelProvider(i);
 					if (labelProvider != null) { ((CSVLabelProvider) labelProvider).setSearchText(filterText); }
 				}
+				if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+					java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+					for (Object row : model.getArrayRows(false)) {
+						boolean select = true;
+						for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+							if (!filter.select(tableViewer, model, row)) {
+								select = false;
+								break;
+							}
+						}
+						if (select) filteredRows.add(row);
+					}
+					tableViewer.setItemCount(filteredRows.size());
+				} else {
+					tableViewer.setItemCount(model.getArrayRows(false).length);
+				}
 				tableViewer.refresh();
 			}
 		});
@@ -573,7 +654,24 @@ public class MultiPageCSVEditor extends MultiPageEditorPart
 							if (acPage.open() == Window.OK) {
 								final String colToInsert = acPage.getColumnNewName();
 								model.addColumn(colToInsert);
-								tableViewer.setInput(model);
+
+		if (tableViewer.getFilters() != null && tableViewer.getFilters().length > 0) {
+			java.util.List<Object> filteredRows = new java.util.ArrayList<>();
+			for (Object row : model.getArrayRows(false)) {
+				boolean select = true;
+				for (org.eclipse.jface.viewers.ViewerFilter filter : tableViewer.getFilters()) {
+					if (!filter.select(tableViewer, model, row)) {
+						select = false;
+						break;
+					}
+				}
+				if (select) filteredRows.add(row);
+			}
+			tableViewer.setItemCount(filteredRows.size());
+		} else {
+			tableViewer.setItemCount(model.getArrayRows(false).length);
+		}
+		tableViewer.setInput(model);
 								final TableColumn column = new TableColumn(tableViewer.getTable(), SWT.LEFT);
 								column.setText(colToInsert);
 								column.setWidth(100);


### PR DESCRIPTION
The MultiPageCSVEditor previously attempted to load all elements directly into the table, hanging the UI completely when attempting to open a CSV of more than roughly 10,000 lines. This commit resolves this by updating `MultiPageCSVEditor` to instantiate a `TableViewer` with `SWT.VIRTUAL`. It updates `CSVContentProvider` to implement `ILazyContentProvider` so elements are retrieved via lazy loading (`updateElement(int index)`), setting `tableViewer.setItemCount` and correctly interacting with existing TableFilters and Comparators.

---
*PR created automatically by Jules for task [1199531917637089677](https://jules.google.com/task/1199531917637089677) started by @AlexisDrogoul*