### PR TITLE
ci: updated the zip with jdk script

### DIFF
--- a/travis/zip_withjdk.sh
+++ b/travis/zip_withjdk.sh
@@ -1,119 +1,199 @@
 #!/bin/bash
-
-#
-#	Prepare utils variables
-#
-
 set -e
-archivePath="$GITHUB_WORKSPACE/gama.application"
+
+##########################
+# building download URLs #
+##########################
+
+# the JDK_EMBEDDED_VERSION variable has to be defined before running this script
+# the format must either fit "25.0.3+9" or "25.0.3_9"
+
+JDK_EMBEDDED_VERSION=$(echo $JDK_EMBEDDED_VERSION | tr "+" "_") # replace '+' with '_'
+JDK_EMBEDDED_VERSION_URL=$(echo $JDK_EMBEDDED_VERSION | sed "s;_;%2B;g") # replace '_' with '%2B'
 JDK_MAJOR=$(echo $JDK_EMBEDDED_VERSION | cut -d '.' -f 1)
 
-#
-#	Download latest JDK
-#
+RELEASE_URL_PREFIX="https://github.com/adoptium/temurin${JDK_MAJOR}-binaries/releases/download/jdk-${JDK_EMBEDDED_VERSION_URL}"
 
-echo "=== Download latest JDK"
-echo "Downloading from https://api.github.com/repos/adoptium/temurin$JDK_MAJOR-binaries/releases/tags/jdk-$JDK_EMBEDDED_VERSION"
+######################
+# defining constants #
+######################
 
-RELEASE_JSON=$(curl -f https://api.github.com/repos/adoptium/temurin$JDK_MAJOR-binaries/releases/tags/jdk-$JDK_EMBEDDED_VERSION)
+OS_LINUX="linux"
+OS_MACOS="mac"
+OS_WINDOWS="windows"
 
-function download_and_verify() {
-    local pattern="$1"
-    local output="$2"
-    wget -q $(echo "$RELEASE_JSON" | grep "${pattern}\"" | cut -d ':' -f 2,3 | tr -d \") -O "$output"
-    local checksum_url=$(echo "$RELEASE_JSON" | grep "${pattern}.sha256.sum\"" | cut -d ':' -f 2,3 | tr -d \")
-    if [ -n "$checksum_url" ]; then
-        wget -q "$checksum_url" -O "$output.sha256"
-        echo "$(cat $output.sha256)  $output" | sha256sum -c -
+ARCH_x64="x64"
+ARCH_AARCH64="aarch64"
+
+TARGET_PLATFORMS=("linux.gtk.x86_64" "win32.win32.x86_64" "macosx.cocoa.x86_64" "macosx.cocoa.aarch64")
+
+archivePath="$GITHUB_WORKSPACE/gama.application"
+
+function download_and_prepare() {
+    local os="$1"
+    local arch="$2"
+    local output_folder="jdk_${os}_${arch}"
+
+    # infering archive_type from os
+    local archive_type=""
+    if [ $os == $OS_WINDOWS ]; then 
+        archive_type="zip"
     else
-        echo "[W] No SHA-256 checksum found for $output — skipping verification"
+        archive_type="tar.gz"
     fi
+
+    # building archive_file name from os, arch and archive type
+    local archive_file="${output_folder}.${archive_type}"
+
+    # building the release and sha256 URLs, references are here : https://github.com/adoptium/temurin25-binaries/releases
+    local RELEASE_URL="${RELEASE_URL_PREFIX}/OpenJDK${JDK_MAJOR}U-jdk_${arch}_${os}_hotspot_${JDK_EMBEDDED_VERSION}.${archive_type}"
+    local SHA256_URL="${RELEASE_URL}.sha256.txt"
+
+    echo "== Downloading jdk-$JDK_EMBEDDED_VERSION for $os $arch"
+
+    # actual downloading
+    wget -q $RELEASE_URL -O $archive_file || (echo $archive_file cannot download $archive_file - aborting the script && exit 1)
+    wget -q $SHA256_URL -O "${archive_file}.sha256.txt" || (echo $archive_file cannot download the sha256sum of $archive_file - aborting the script && exit 1)
+
+    # comparing hashes, logging and aborting if hashes are not equals
+    # the sed command removes the file's name at the end of the sha256 file
+    echo Checking the hash of the downloaded archive
+    echo "$(cat $archive_file.sha256.txt | sed "s; .*;;g")  $archive_file" | sha256sum -c - || (echo $archive_file checksum does not match - aborting the script && exit 1)
+
+    echo Unziping the archive
+    mkdir $output_folder
+
+    if [ $archive_type == "zip" ]; then
+	    unzip -q $archive_file -d $output_folder
+    elif [ $archive_type == "tar.gz" ]; then
+        tar -zxf $archive_file -C $output_folder
+    else
+        echo Unknown archive type && exit 1
+    fi
+
+    mv $output_folder/jdk-* "$output_folder/jdk"
 }
 
-download_and_verify "/OpenJDK${JDK_MAJOR}U-jdk_x64_linux.*.gz"     "jdk_linux-21.tar.gz"
-download_and_verify "/OpenJDK${JDK_MAJOR}U-jdk_x64_window.*.zip"   "jdk_win32-21.zip"
-download_and_verify "/OpenJDK${JDK_MAJOR}U-jdk_x64_mac.*.gz"       "jdk_macosx-21.tar.gz"
-download_and_verify "/OpenJDK${JDK_MAJOR}U-jdk_aarch64_mac.*.gz"   "jdk_macosx_aarch-21.tar.gz"
+echo "=== Downloading latest JDK from $(echo $RELEASE_URL_PREFIX | sed 's;download/;tag/;g')"
 
-#
-#	Prepare downloaded JDK
-#
-echo "=== Prepare downloaded JDK"
-for os in "linux" "macosx" "macosx_aarch" "win32"; do
-	mkdir jdk_$os
+download_and_prepare $OS_LINUX $ARCH_x64
+download_and_prepare $OS_WINDOWS $ARCH_x64
+download_and_prepare $OS_MACOS $ARCH_x64
+download_and_prepare $OS_MACOS $ARCH_AARCH64
 
-	echo "unzip jdk $os"
-    if [[ -f "jdk_$os-21.tar.gz" ]]; then
-    tar -zxf jdk_$os-21.tar.gz -C jdk_$os/
-	else
-		unzip -q jdk_$os-21.zip -d jdk_$os
-	fi
+######################################
+# Modify .ini file to use proper JDK #
+######################################
 
-	mv jdk_$os/jdk-* jdk_$os/jdk
-done
-
-
-#
-# Modify .ini file to use custom JDK
-#
 echo "=== Creating zip archive of release using custom JDK"
-for targetPlatform in "linux.gtk.x86_64" "win32.win32.x86_64" "macosx.cocoa.x86_64" "macosx.cocoa.aarch64"; do
+for targetPlatform in ${TARGET_PLATFORMS[@]}; do
 
-	#
-	# Get OS (first attribute in the path)
-	# + Add suffix if build for ARM64 system
-	os="$(echo $targetPlatform | cut -d '.' -f 1)$(if [[ "$targetPlatform" == *'aarch64'* ]]; then echo '_aarch'; fi )"
+	##########################################
+	# Get OS (first attribute in the path),  #
+	# arch (last attribute in the path)      #
+    # and archive type on the file system    #
+    ##########################################
 
-	echo "Add custom JDK for $os"
+	os="$(echo $targetPlatform | cut -d '.' -f 1)"
+    arch="$(echo $targetPlatform | cut -d '.' -f 3)"
+    archive_type=$(find -name "gama.application-${targetPlatform}*" | sed "s;.*${targetPlatform}\.\(.*\);\1;g")
 
-	unzip -q $archivePath-$targetPlatform.zip -d $RUNNER_TMP
+    ################################
+    # normalizing arch and os name #
+    ################################
 
-	#
-	# Specific sub-path for Eclipse in MacOS
+    if [ $arch == "x86_64" ]; then arch=$ARCH_x64; fi
+
+    case "$os" in
+        "win32")
+            os=$OS_WINDOWS;;
+        "macosx")
+            os=$OS_MACOS;;
+        "linux")
+            :;; # do nothing because os name is already normalized
+        *)
+            echo "Unknown artifact $os" && exit 1;;
+    esac
+
+    ###################################
+    # Unzip the build in a tmp folder # 
+    ###################################
+
+	echo "== Adding custom JDK for $os $arch"
+    echo "Unziping the build"
+
+    if [ $archive_type == "zip" ]; then
+	    unzip -q $archivePath-$targetPlatform.zip -d $RUNNER_TMP
+    elif [ $archive_type == "tar.gz" ]; then
+        tar -zxf $archivePath-$targetPlatform.tar.gz -C $RUNNER_TMP
+    else
+        echo Unknown archive type && exit 1
+    fi
+
+	##################################################
+	# Specific sub-path for JDK and Eclipse in MacOS #
+    ##################################################
+
 	jdkLocation=$RUNNER_TMP
-	if [[ "$os" == "macosx"* ]]; then
+	folderEclipse=$jdkLocation
+
+	if [ $os == $OS_MACOS ]; then
 		jdkLocation=$RUNNER_TMP/Gama.app/Contents
 		# Create symlink of jdk next to GAMA's executable
 		# Fix #229
 		ln -sf ../jdk $RUNNER_TMP/Gama.app/Contents/MacOS/jdk
+        folderEclipse=$jdkLocation/Eclipse
 	fi
 
-	#
-	# Add JDK to build
-	sudo cp -R jdk_$os/jdk $jdkLocation
-	#
-	# Add custom jar signing certificate in custom JDK
+	#########################
+	# Copy JDK inside build #
+    #########################
+
+    echo Copying the jdk inside the build
+	sudo cp -R jdk_${os}_${arch}/jdk $jdkLocation
+
+	####################################################
+	# Add custom jar signing certificate in custom JDK #
+	####################################################
+
 	if [[ -f "$GITHUB_WORKSPACE/sign.maven" ]]; then
 		keytool -export -alias gama-platform -file ~/GamaPlatform.cer -keystore ~/gama.keystore -storepass "$GAMA_KEYSTORE_STOREPASS"
 		# Using default 'changeit' JDK storepass
 		sudo find $RUNNER_TMP -name "cacerts" -exec keytool -importcert -noprompt -file ~/GamaPlatform.cer -keystore {} -alias gama-platform -storepass "changeit" \;
 	fi
 
+	##############################
+	# Make GAMA use embedded JDK #
+    # by editing .ini file       #
+    ##############################
 
-	#
-	# Specific sub-path for Eclipse in MacOS
-	folderEclipse=$jdkLocation
-	if [[ "$os" == "macosx"* ]]; then
-		folderEclipse=$jdkLocation/Eclipse
-	fi
-	#
-	# Make GAMA use embedded JDK
+    echo Editing Gama.ini
+
 	sed -i '1s/^/-vm\n/' $folderEclipse/Gama.ini
-	if [[ "$os" == "macosx"* ]]; then
+
+	if [ $os == $OS_MACOS ]; then
 		sed -i '2s/^/.\/jdk\/Contents\/Home\/bin\/java\n/' $folderEclipse/Gama.ini
-	elif [[ "$os" == "win32"* ]]; then
+
+	elif [ $os == $OS_WINDOWS ]; then
 		sed -i '2s/^/.\/jdk\/bin\/javaw\n/' $folderEclipse/Gama.ini
+        
 	else
 		sed -i '2s/^/.\/jdk\/bin\/java\n/' $folderEclipse/Gama.ini
 	fi
 
-	#
-	# Create final zip archives
+	############################
+	# Create final zip archive #
+    ############################
+
+    # zip
+    echo "Ziping build with JDK"
 	cd $RUNNER_TMP
 	sudo zip -9 -qyr "${archivePath}-${targetPlatform}_withJDK.zip" . && echo "Successfully compressed ${archivePath}-${targetPlatform}_withJDK.zip" || echo "Failed compressing ${archivePath}-${targetPlatform}_withJDK.zip"
 
-	cd $GITHUB_WORKSPACE && sudo rm -fr "${RUNNER_TMP:?}"
-
+    # clean the tmp folder
+	cd $GITHUB_WORKSPACE
+    sudo rm -Rf "${RUNNER_TMP:?}"/*
+    
 done
 
 echo DONE


### PR DESCRIPTION
Improved the modularity and readability of the `zip_withjdk.sh` script.

Some tasks have been factorized and the overall script should be more synthetic.

Availability of the downloaded JDKs checksum is now mandatory and not fetching the checksums will fail the job.

The `JDK_EMBEDDED_VERSION` variable can accept both formats : `X.Y.Z+W` or `X.Y.Z_W`

The script has been tested on a github runner.

The logging has been enhanced to be able to trace the exact stage where an error may occur.
```
=== Downloading latest JDK from https://github.com/adoptium/temurin25-binaries/releases/tag/jdk-25.0.3%2B9
== Downloading jdk-25.0.3_9 for linux x64
Checking the hash of the downloaded archive
jdk_linux_x64.tar.gz: OK
Unziping the archive
== Downloading jdk-25.0.3_9 for windows x64
Checking the hash of the downloaded archive
jdk_windows_x64.zip: OK
Unziping the archive
== Downloading jdk-25.0.3_9 for mac x64
Checking the hash of the downloaded archive
jdk_mac_x64.tar.gz: OK
Unziping the archive
== Downloading jdk-25.0.3_9 for mac aarch64
Checking the hash of the downloaded archive
jdk_mac_aarch64.tar.gz: OK
Unziping the archive
=== Creating zip archive of release using custom JDK
== Adding custom JDK for linux x64
Unziping the build
Copying the jdk inside the build
Editing Gama.ini
Ziping build with JDK
Successfully compressed /home/runner/work/zgama/zgama/gama.application-linux.gtk.x86_64_withJDK.zip
== Adding custom JDK for windows x64
Unziping the build
Copying the jdk inside the build
Editing Gama.ini
Ziping build with JDK
Successfully compressed /home/runner/work/zgama/zgama/gama.application-win32.win32.x86_64_withJDK.zip
== Adding custom JDK for mac x64
Unziping the build
Copying the jdk inside the build
Editing Gama.ini
Ziping build with JDK
Successfully compressed /home/runner/work/zgama/zgama/gama.application-macosx.cocoa.x86_64_withJDK.zip
== Adding custom JDK for mac aarch64
Unziping the build
Copying the jdk inside the build
Editing Gama.ini
Ziping build with JDK
Successfully compressed /home/runner/work/zgama/zgama/gama.application-macosx.cocoa.aarch64_withJDK.zip
DONE
```