### PR TITLE
fix(ci): fixes macos presign, what2sign.sh

### DIFF
--- a/.github/workflows/travis-packaging-macos.yaml
+++ b/.github/workflows/travis-packaging-macos.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Calculate what Jar to sign
         run: |
           bash what2sign.sh
-          echo "\nPrint `needToSign.txt` :"
+          echo "\nPrint 'needToSign.txt' :"
           cat needToSign.txt
 
       - uses: actions/upload-artifact@v6

--- a/travis/what2sign.sh
+++ b/travis/what2sign.sh
@@ -18,7 +18,7 @@ alreadySawJar=()
 # Add a jar to the list of jars to sign
 function addJarInFile(){
 	if [[ $(tail -n 1 $NEED_TO_SIGN_FILENAME) != "$1" ]]; then
-		echo $1 >> $NEED_TO_SIGN_FILENAME
+		echo "$1" >> $NEED_TO_SIGN_FILENAME
 	fi
 
 	if (( $# != 1 )); then
@@ -34,7 +34,7 @@ function getJarToCheck(){
 	currentAppJar=($(find "$target_directory" -name "*.jar"))
 
 	# Remove already checked lines
-	currentAppJar=($(grep -v -x -f <(printf "%s\n" "${alreadySawJar[@]}") <(printf "%s\n" "${currentAppJar[@]}")))
+	currentAppJar=($(grep -v -x -f <(printf "%s\n" "${alreadySawJar[@]}") <(printf "%s\n" "${currentAppJar[@]}") || true))
 	
 	alreadySawJar=("${alreadySawJar[@]}" "${currentAppJar[@]}")
 }


### PR DESCRIPTION
The issue was grep returning 1 when no match.

I also replaced the back quotes by single quotes in the `travis-packaging-macos.yaml` workflow file, which should fix a minor logging issue.