### PR TITLE
ci: maven dependency cache

### DIFF
--- a/.github/actions/maven-dependency-cache/action.yaml
+++ b/.github/actions/maven-dependency-cache/action.yaml
@@ -12,7 +12,7 @@ inputs:
   cachePath:
     required: true
     type: string
-    default: "~/.m2/repository"
+    default: "/home/runner/.m2/repository"
   cacheTag:
     required: true
     type: string
@@ -26,7 +26,7 @@ runs:
   steps:
 
   - name: Remove Old Maven Dependency Cache
-    if: "${{inputs.action == 'save'}} || ( ${{ github.ref_name }} == 'main' )"
+    if: "${{inputs.action == 'save'}}"
     run: "gh cache delete maven-dependency-cache-${CACHE_TAG} --ref ${REF}  --repo ${REPO}"
     continue-on-error: true
     shell: bash
@@ -37,7 +37,7 @@ runs:
       REPO: ${{ github.repository }}
 
   - uses: actions/cache/save@v5
-    if: "${{inputs.action == 'save'}} || ( ${{ github.ref_name }} == 'main' )"
+    if: "${{inputs.action == 'save'}}"
     name: Save Maven Dependency Cache
     with:
       path: ${{ inputs.cachePath }}

--- a/.github/actions/maven-dependency-cache/action.yaml
+++ b/.github/actions/maven-dependency-cache/action.yaml
@@ -1,0 +1,60 @@
+name: Maven Dependency Cache
+description: Upload or retrieve maven cached dependencies data
+
+inputs:
+  action:
+    required: true
+    type: choice
+    description: save/restore cache
+    options:
+    - save
+    - restore
+  cachePath:
+    required: true
+    type: string
+    default: "~/.m2/repository"
+  cacheTag:
+    required: true
+    type: string
+    default: "default"
+  GH_TOKEN:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Remove Old Maven Dependency Cache
+    if: "${{inputs.action == 'save'}} || ( ${{ github.ref_name }} == 'main' )"
+    run: "gh cache delete maven-dependency-cache-${CACHE_TAG} --ref ${REF}  --repo ${REPO}"
+    continue-on-error: true
+    shell: bash
+    env:
+      GH_TOKEN: ${{ inputs.GH_TOKEN }}
+      CACHE_TAG: ${{ inputs.cacheTag }}
+      REF: ${{ github.ref }}
+      REPO: ${{ github.repository }}
+
+  - uses: actions/cache/save@v5
+    if: "${{inputs.action == 'save'}} || ( ${{ github.ref_name }} == 'main' )"
+    name: Save Maven Dependency Cache
+    with:
+      path: ${{ inputs.cachePath }}
+      key: "maven-dependency-cache-${{ inputs.cacheTag }}"
+
+  - uses: actions/cache/restore@v5
+    if: "${{ inputs.action == 'restore' }}"
+    name: Restore Maven Dependency Cache
+    with:
+      path: ${{ inputs.cachePath }}
+      key: "maven-dependency-cache-${{ inputs.cacheTag }}"
+
+  - name: Compute Maven Dependency Cache Hash
+    if: "${{ inputs.action == 'restore' }}"
+    shell: bash
+    run: ./travis/compute_hash.sh
+    env:
+      MAVEN_CACHE_PATH: ${{ inputs.cachePath }}
+    
+  

--- a/.github/workflows/travis-build.yaml
+++ b/.github/workflows/travis-build.yaml
@@ -42,6 +42,9 @@ on:
       GITHUB_ONLY:
         type: boolean
         default: false
+      USE_DEPENDENCY_CACHE:
+        type: boolean
+        default: true
     secrets:
       GAMA_KEYSTORE_BASE64:
         required: false
@@ -122,8 +125,21 @@ jobs:
           sed -i 's/-Denable_logging=true/-Denable_logging=false/g' ./gama.product/*product
           sed -i 's/-Denable_debug=true/-Denable_debug=false/g' ./gama.product/*product
 
+      - uses: ./.github/actions/maven-dependency-cache
+        name: Restore Maven Dependency Cache
+        if: "${{ inputs.USE_DEPENDENCY_CACHE }}"
+        with:
+          action: restore
+
       - name: Compiling gama
         run: bash $GITHUB_WORKSPACE/travis/build.sh -e -B -T 4 ${{ inputs.mvn_extra_arguments }}
+
+      - uses: ./.github/actions/maven-dependency-cache
+        name: Save Maven Dependency Cache
+        if: "${{ inputs.USE_DEPENDENCY_CACHE && (github.ref_name == 'main') }}"
+        with:
+          action: save
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       # Spotbugs
       - name: Running SpotBugs

--- a/.github/workflows/trigger-compilation.yaml
+++ b/.github/workflows/trigger-compilation.yaml
@@ -11,6 +11,10 @@ on:
       - 'travis/**'
 
   workflow_dispatch: # For manual trigger
+    inputs:
+      USE_DEPENDENCY_CACHE:
+        type: boolean
+        default: true
 
 jobs:
 
@@ -39,6 +43,7 @@ jobs:
     with:
       get_testing_compiled_archives: true
       get_all_archives_for_release: false
+      USE_DEPENDENCY_CACHE: ${{ inputs.USE_DEPENDENCY_CACHE || github.event_name == 'push' }}
 
   testing-gama:
     name: Testing built GAMA

--- a/.github/workflows/trigger-doc-regeneration.yaml
+++ b/.github/workflows/trigger-doc-regeneration.yaml
@@ -29,8 +29,20 @@ jobs:
         run: |
           echo "MAVEN_OPTS='-Xmx15g'" >> ~/.mavenrc
 
+      - uses: ./.github/actions/maven-dependency-cache
+        name: Restore Maven Dependency Cache
+        with:
+          action: restore
+
       - name: Compiling GAMA
         run: bash travis/build.sh -B -T 4
+
+      - uses: ./.github/actions/maven-dependency-cache
+        name: Save Maven Dependency Cache
+        if: "${{ github.ref_name }} == 'main'"
+        with:
+          action: save
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Generate documentation
         run: |

--- a/.github/workflows/trigger-gama-release.yaml
+++ b/.github/workflows/trigger-gama-release.yaml
@@ -28,6 +28,10 @@ on:
         type: boolean
         required: true
         default: false
+      USE_DEPENDENCY_CACHE:
+        type: boolean
+        required: true
+        default: false
 
 run-name: Building GAMA release
 
@@ -42,6 +46,7 @@ jobs:
       jdk_embedded_version: ${{ inputs.jdk }}
       IS_STABLE_RELEASE: ${{ inputs.IS_STABLE_RELEASE }}
       GITHUB_ONLY: ${{ inputs.releaseGithubOnly }}
+      USE_DEPENDENCY_CACHE: ${{ inputs.USE_DEPENDENCY_CACHE }}
     secrets:
       GAMA_KEYSTORE_BASE64: ${{ secrets.GAMA_KEYSTORE_BASE64 }}
       GAMA_KEYSTORE_STOREPASS: ${{ secrets.GAMA_KEYSTORE_STOREPASS }}

--- a/.github/workflows/trigger-pr.yaml
+++ b/.github/workflows/trigger-pr.yaml
@@ -7,6 +7,10 @@ on:
   # Triggers the workflow on pull request events
   pull_request:
   workflow_dispatch: # For manual trigger
+    inputs:
+      USE_DEPENDENCY_CACHE:
+        type: boolean
+        default: true
 
 jobs:
   compiling-gama-base:
@@ -19,6 +23,7 @@ jobs:
       RUN_SPOTBUGS: true
       SPOTBUGS_OUTPUT_ARTIFACT_NAME: "result-spotbugs-base"
       CHECKOUT_BRANCH: "main"
+      USE_DEPENDENCY_CACHE: ${{ inputs.USE_DEPENDENCY_CACHE }}
 
   compiling-gama-pr:
     if: "! github.event.pull_request.draft || github.event_name == 'workflow_dispatch'"
@@ -29,6 +34,7 @@ jobs:
       get_all_archives_for_release: false
       RUN_SPOTBUGS: true
       SPOTBUGS_OUTPUT_ARTIFACT_NAME: "result-spotbugs-pr"
+      USE_DEPENDENCY_CACHE: ${{ inputs.USE_DEPENDENCY_CACHE }}
 
   testing-gama-pr:
     name: Testing built GAMA

--- a/travis/compute_hash.sh
+++ b/travis/compute_hash.sh
@@ -1,0 +1,29 @@
+# this variable has to be set -> MAVEN_CACHE_PATH=~/.m2/repository (default)
+
+set -e
+
+# 1. hash every pom.xml, build.properties, and MANIFEST.MF
+# 2. hash the resulting file "hash - filename"
+# 3. compare the resulting hash with what's stored in the cache
+# 4. if it doesn't match, remove the cache because it might lead 
+# to build inconsistencies throughout builds and machines
+# 5. update the hash stored in the cache with the new one
+
+current_hash=$(find . -type f \
+     \( -name pom.xml -o -name MANIFEST.MF -o -name build.properties \) \
+     -not -path "*/target/*" \
+     -exec sha256sum {} \; | sha256sum | sed 's/\s.*//')
+
+stored_hash=$(cat ${MAVEN_CACHE_PATH}/cachehash.sha256sum || echo "no cache found") 
+
+echo -e "computed hash \t: $current_hash"
+echo -e "stored hash \t: $stored_hash"
+
+if ! [ $current_hash == $stored_hash ]; then
+    echo "cache miss, cleaning the current cache"
+    rm -Rf ${MAVEN_CACHE_PATH}/*
+    else
+        echo cache hit
+fi
+
+echo "$current_hash" > ${MAVEN_CACHE_PATH}/cachehash.sha256sum

--- a/travis/compute_hash.sh
+++ b/travis/compute_hash.sh
@@ -26,4 +26,9 @@ if ! [ $current_hash == $stored_hash ]; then
         echo cache hit
 fi
 
+# if no pre-existing cache, create one
+if ! [ -d ${MAVEN_CACHE_PATH} ]; then
+    mkdir -p ${MAVEN_CACHE_PATH}
+fi
+
 echo "$current_hash" > ${MAVEN_CACHE_PATH}/cachehash.sha256sum


### PR DESCRIPTION
# How the dependency cache works

Only the `main` branch has a dependency cache. Every child branch can retrieve it, but only the `main` branch can update it. All the branches having their own cache would be too expensive in storage.

The criteria for a project build to use cached dependency data, is to have the `sha256sum` of all its module's `pom.xml`, `MANIFEST.MF` and `build.properties` files, identical the ones in the cache. The purpose of this strict cache hit strategy is ensure that the project's datas produce deterministic builds, by preventing decorelations between dependencies in the **github cache** and the dependencies that are actually declared in the project's files.

In other words, only changes that are not affecting the dependency tree or project structure will benefit from the cache.

## Table of contents

* [Usage in github workflows](#usage-in-github-workflows)
    * [Using the same cache throughout multiple runs](#using-the-same-cache-throughout-multiple-runs)
    * [Action inputs](#action-inputs)
    * [Usage - Restore](#usage---restore)
    * [Usage - Save](#usage---save)
* [Troubleshoot](#troubleshoot)


## Usage in github workflows

### Using the same cache throughout multiple runs

The coherence of the cache throughout runs is handled by a custom composite action. <br/>
This action uses the github `action/cache` action to store all the maven cache inside a global github cache with the key `maven-dependency-cache-default` (what is considered as a `key` for `action/cache` is used as an id). When retrieving the cache, `action/cache` always hit if the `main` branch has already been built once. Once the maven cached data are retrieved, the `sha256sum` of every `pom.xml`, `MANIFEST.MF` and `build.properties` files will be calculated and compared with the one stored in cached data, in the file named `cachehash.sha256sum`. If it doesn't match, the cached data is removed. This task is handled by the `compute_hash.sh` script: 

```bash
# this variable has to be set -> MAVEN_CACHE_PATH=/home/runner/.m2/repository (default)

set -e

# 1. hash every pom.xml, build.properties, and MANIFEST.MF
# 2. hash the resulting file "hash - filename"
# 3. compare the resulting hash with what's stored in the cache
# 4. if it doesn't match, remove the cache because it might lead 
# to build inconsistencies throughout builds and machines
# 5. update the hash stored in the cache with the new one

current_hash=$(find . -type f \
     \( -name pom.xml -o -name MANIFEST.MF -o -name build.properties \) \
     -not -path "*/target/*" \
     -exec sha256sum {} \; | sha256sum | sed 's/\s.*//')

stored_hash=$(cat ${MAVEN_CACHE_PATH}/cachehash.sha256sum || echo "no cache found") 

echo -e "computed hash \t: $current_hash"
echo -e "stored hash \t: $stored_hash"

if ! [ $current_hash == $stored_hash ]; then
    echo "cache miss, cleaning the current cache"
    rm -Rf ${MAVEN_CACHE_PATH}/*
    else
        echo cache hit
fi

echo "$current_hash" > ${MAVEN_CACHE_PATH}/cachehash.sha256sum
```

To prevent cache saving under the same key from crashing the workflow if the cache already exists, the given cache is deleted beforehand, using github cli. It requires a **github token** with authorization at the repo scope. The default workflow run token `secrets.GITHUB_TOKEN` does the job.

https://cli.github.com/manual/gh_cache_delete <br/>

#### Action inputs
```yaml
inputs:
  action:
    required: true
    type: choice
    description: save/restore cache
    options:
    - save
    - restore
  cachePath:
    required: true
    type: string
    default: "/home/runner/.m2/repository"
  cacheTag:
    required: true
    type: string
    default: "default"
  GH_TOKEN:
    required: true
    type: string
```

#### Usage - Restore
```yaml
    steps:
      - uses: ./.github/actions/maven-dependency-cache
        name: Restore Maven Dependency Cache
        with:
          action: restore
```

#### Usage - Save
```yaml
    steps:
      - uses: ./.github/actions/maven-cache
        name: Save Maven Dependency Cache
        with:
          action: save
          GH_TOKEN: ${{secrets.GH_TOKEN}}
```