### PR TITLE
perf: cache compiled regex in hot string operators

### DIFF
--- a/gama.core/src/gama/gaml/operators/Strings.java
+++ b/gama.core/src/gama/gaml/operators/Strings.java
@@ -10,6 +10,9 @@
 package gama.gaml.operators;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.regex.MatchResult;
@@ -80,6 +83,38 @@ import gama.api.utils.files.CompressionUtils;
  */
 @SuppressWarnings ({ "rawtypes" })
 public class Strings {
+
+	/** Upper bound for cached compiled regex patterns used by string operators. */
+	private static final int REGEX_CACHE_SIZE = 256;
+
+	/** Small LRU cache to avoid recompiling frequently reused regex patterns. */
+	private static final Map<String, Pattern> REGEX_CACHE =
+			Collections.synchronizedMap(new LinkedHashMap<>(REGEX_CACHE_SIZE, 0.75f, true) {
+
+				@Override
+				protected boolean removeEldestEntry(final Map.Entry<String, Pattern> eldest) {
+					return size() > REGEX_CACHE_SIZE;
+				}
+			});
+
+	/**
+	 * Returns a compiled regex pattern from cache or compiles and stores it if missing.
+	 *
+	 * @param pattern
+	 *            the regex source
+	 * @return the compiled {@link Pattern}
+	 * @throws PatternSyntaxException
+	 *             if the regex is invalid
+	 */
+	private static Pattern getCachedPattern(final String pattern) {
+		synchronized (REGEX_CACHE) {
+			final Pattern cached = REGEX_CACHE.get(pattern);
+			if (cached != null) { return cached; }
+			final Pattern compiled = Pattern.compile(pattern);
+			REGEX_CACHE.put(pattern, compiled);
+			return compiled;
+		}
+	}
 
 	/**
 	 * Op plus.
@@ -729,7 +764,7 @@ public class Strings {
 	public static IList opTokenizeRegex(final IScope scope, final String target, final String pattern) {
 		if (target == null) return GamaListFactory.create();
 		if (pattern == null || pattern.isEmpty()) return GamaListFactory.create(scope, Types.STRING, target);
-		return GamaListFactory.create(scope, Types.STRING, target.split(pattern));
+		return GamaListFactory.create(scope, Types.STRING, getCachedPattern(pattern).split(target));
 	}
 
 
@@ -809,7 +844,7 @@ public class Strings {
 			see = { "replace" })
 	public static String opReplaceRegex(final String target, final String pattern, final String replacement) {
 		// DEBUG.OUT("String pattern = " + pattern);
-		return target.replaceAll(pattern, replacement);
+		return getCachedPattern(pattern).matcher(target).replaceAll(replacement);
 	}
 
 	/**
@@ -847,7 +882,7 @@ public class Strings {
 		if (pattern == null || pattern.isEmpty()) return GamaListFactory.create();
 		Pattern p;
 		try {
-			p = Pattern.compile(pattern);
+			p = getCachedPattern(pattern);
 		} catch (PatternSyntaxException e) {
 			return target.contains(pattern) ? GamaListFactory.createWithoutCasting(Types.STRING, pattern)
 					: GamaListFactory.create();


### PR DESCRIPTION
## What this PR changes

Implements the highest-impact, lowest-effort improvement from the performance review: **regex compilation caching in hot string operators**.

### Implemented optimization
- Added a small bounded LRU cache (`REGEX_CACHE_SIZE = 256`) for compiled `Pattern` objects in `gama.core/src/gama/gaml/operators/Strings.java`.
- Reused cached patterns in:
  - `tokenize_regex`
  - `replace_regex`
  - `regex_matches`

This removes repeated `Pattern.compile(...)` calls on repeated regex usage, reducing CPU overhead in frequently evaluated string expressions while keeping behavior unchanged (including `PatternSyntaxException` handling paths).

## 10 identified performance improvements

1. **Cache compiled regex in string operators** (implemented)  
   `gama.core/src/gama/gaml/operators/Strings.java` (`opTokenizeRegex`, `opReplaceRegex`, `opRegexMatches`)
2. **Fast-path literal split in `split_with(..., true)`** using `Pattern.quote` or manual index split to avoid regex engine for plain delimiters  
   `gama.core/src/gama/gaml/operators/Strings.java:696-700`
3. **Memoize dynamic regex patterns in switch `match`** (small bounded cache for non-constant patterns)  
   `gama.core/src/gama/gaml/statements/MatchStatement.java:243-256`
4. **Precompile documentation regexes once** instead of per-line compilation  
   `gama.headless/src/gama/headless/batch/documentation/Utils.java:105-112`
5. **Precompile metadata extraction regexes once** instead of per-call compilation  
   `gama.headless/src/gama/headless/batch/documentation/MetadataStructure.java:168-176`
6. **Replace repeated `split("\\s+")` in OBJ/MTL parsing loop** with a reusable tokenizer/manual scanner  
   `gama.core/src/gama/core/util/file/MtlLoader.java:192-213`
7. **Avoid regex `split(" ")` in ASC parsing hot path**; use whitespace scanner/manual parsing to reduce allocations  
   `gama.core/src/gama/core/util/file/GamaGridFile.java:292-312,398-413`
8. **Replace repeated `replaceFirst(" ", "")` loops** with `stripLeading()` for linear-time trimming without regex  
   `gama.core/src/gama/core/util/file/MtlLoader.java:215-230`
9. **Reduce repeated lowercase conversion per line** in grid reader by using case-insensitive checks where possible  
   `gama.core/src/gama/core/util/file/GamaGridFile.java:338-372`
10. **Reuse date formatter in concept export path** to avoid repeated formatter instantiation  
   `gama.headless/src/gama/headless/batch/documentation/ConceptManager.java:270`

## Notes
- `mvn` is not available in this environment, so module build/test execution could not be run here.
