### PR TITLE
Optimize MTL parser regex hot path

### DIFF
--- a/gama.core/src/gama/core/util/file/MtlLoader.java
+++ b/gama.core/src/gama/core/util/file/MtlLoader.java
@@ -13,6 +13,7 @@ package gama.core.util.file;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 import gama.dev.DEBUG;
 
@@ -21,6 +22,9 @@ import gama.dev.DEBUG;
  */
 @SuppressWarnings ({ "rawtypes", "unchecked" })
 public class MtlLoader {
+
+	/** Reused whitespace splitter for all parsed lines. */
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
 	/** The Materials. */
 	protected ArrayList materials = new ArrayList<>();
@@ -189,46 +193,34 @@ public class MtlLoader {
 							materials.add(matset);
 							matset = new Mtl();
 						}
-						final String[] coordstext = newline.split("\\s+");
+						final String[] coordstext = WHITESPACE.split(newline);
 						matset.name = coordstext[1];
 						matset.mtlNum = mtlcounter;
 						mtlcounter++;
 					} else if (newline.charAt(0) == 'K' && newline.charAt(1) == 'a') {
-						final String[] coordstext = newline.split("\\s+");
+						final String[] coordstext = WHITESPACE.split(newline);
 						for (int i = 1; i < coordstext.length; i++) {
 							matset.Ka[i - 1] = Float.parseFloat(coordstext[i]);
 						}
 					} else if (newline.charAt(0) == 'K' && newline.charAt(1) == 'd') {
-						final String[] coordstext = newline.split("\\s+");
+						final String[] coordstext = WHITESPACE.split(newline);
 						for (int i = 1; i < coordstext.length; i++) {
 							matset.Kd[i - 1] = Float.parseFloat(coordstext[i]);
 						}
 					} else if (newline.charAt(0) == 'K' && newline.charAt(1) == 's') {
-						final String[] coordstext = newline.split("\\s+");
+						final String[] coordstext = WHITESPACE.split(newline);
 						for (int i = 1; i < coordstext.length; i++) {
 							matset.Ks[i - 1] = Float.parseFloat(coordstext[i]);
 						}
 					} else if (newline.charAt(0) == 'd') {
-						final String[] coordstext = newline.split("\\s+");
+						final String[] coordstext = WHITESPACE.split(newline);
 						matset.d = Float.parseFloat(coordstext[1]);
 					} else if (newline.contains("map_Ka")) {
-						String texture = newline.replace("map_Ka ", "");
-						while (texture.startsWith(" ")) {
-							texture = texture.replaceFirst(" ", "");
-						}
-						matset.map_Ka = texture;
+						matset.map_Ka = newline.replace("map_Ka ", "").stripLeading();
 					} else if (newline.contains("map_Kd")) {
-						String texture = newline.replace("map_Kd ", "");
-						while (texture.startsWith(" ")) {
-							texture = texture.replaceFirst(" ", "");
-						}
-						matset.map_Kd = texture;
+						matset.map_Kd = newline.replace("map_Kd ", "").stripLeading();
 					} else if (newline.contains("map_d")) {
-						String texture = newline.replace("map_d ", "");
-						while (texture.startsWith(" ")) {
-							texture = texture.replaceFirst(" ", "");
-						}
-						matset.map_d = texture;
+						matset.map_d = newline.replace("map_d ", "").stripLeading();
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
Identified 10 concrete performance opportunities and implemented the highest-impact, lowest-effort one.

### Implemented in this PR
- **`gama.core/src/gama/core/util/file/MtlLoader.java`**
  - Reused a single compiled `Pattern` for whitespace splitting (`\s+`) instead of recompiling regex per parsed line.
  - Replaced repeated `replaceFirst` loops with `stripLeading()` for `map_Ka`, `map_Kd`, and `map_d` parsing.

This targets the OBJ/MTL import hot path where these branches are executed once per relevant line.

## 10 identified performance improvements
1. **MtlLoader regex hot path** (`gama.core/src/gama/core/util/file/MtlLoader.java`) — precompile whitespace regex and remove iterative `replaceFirst` loops. **(Implemented)**
2. **OBJ parser split hot path** (`gama.core/src/gama/core/util/file/GamaObjFile.java`) — replace per-line `split("\\s+")` with reusable splitter/tokenizer.
3. **Regex operator caching** (`gama.core/src/gama/gaml/operators/Strings.java`, `opRegexMatches`) — cache compiled regex for repeated patterns.
4. **replace_regex compilation cost** (`gama.core/src/gama/gaml/operators/Strings.java`, `opReplaceRegex`) — avoid per-call regex compilation for stable patterns.
5. **Dynamic match regex caching** (`gama.core/src/gama/gaml/statements/MatchStatement.java`) — bounded cache for dynamic patterns in switch matching.
6. **CSV clean() regex chain** (`gama.core/src/gama/gaml/statements/create/CreateFromCSVDelegate.java`) — precompile cleanup patterns used repeatedly in imports.
7. **Grid header parsing allocations** (`gama.core/src/gama/core/util/file/GamaGridFile.java`) — avoid repeated `split()` in `intVal/doubleVal` via index scanning/tokenizer.
8. **Unnecessary list copy after sort** (`gama.core/src/gama/gaml/operators/spatial/SpatialTransformations.java`) — avoid `new ArrayList<>(stream().sorted().toList())` double allocation.
9. **JSON names list allocation** (`gama.core/src/gama/core/util/json/JsonAbstractObject.java`) — avoid creating a new list via stream on each `names()` call.
10. **Reflection cache key collisions** (`gama.api/src/gama/api/utils/JavaUtils.java`) — replace additive hash key with a composite key object to reduce collision-driven recomputation.

## Notes
I could not run the project Maven build in this environment because `mvn` is not installed (`mvn: command not found`).