### PR TITLE
Add Web streaming display && ability to add Server commands from plugin

### DIFF
--- a/gama.api/plugin.xml
+++ b/gama.api/plugin.xml
@@ -11,6 +11,7 @@
    <extension-point id="gama.experiment" name="Implementations of IExperimentAgent" schema="schema/gama.experiment.exsd"/>
    <extension-point id="gama.constants" name="Implementations of IConstantsSupplier" schema="schema/gama.constants.exsd"/>
    <extension-point id="gama.metadata" name="Implementations of IGamaFileMetaData" schema="schema/gama.metadata.exsd"/>
+   <extension-point id="gama.server_command" name="Implementations of ISocketCommand" schema="schema/gama.server_command.exsd"/>
    <extension
          point="gaml.extension">
    </extension>

--- a/gama.api/schema/gama.server_command.exsd
+++ b/gama.api/schema/gama.server_command.exsd
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="gama.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="gama.core" id="gama.server_command" name="Implementations of ISocketCommand"/>
+      </appinfo>
+      <documentation>
+         Allows plug-in developers to register new gama-server commands (implementations of ISocketCommand), so that the WebSocket protocol of both the headless and GUI servers can be extended with new command types (e.g. &quot;stream&quot;).
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="command"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="command">
+      <complexType>
+         <attribute name="type" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The keyword identifying the command in the JSON &apos;type&apos; field sent by clients (e.g. &quot;stream&quot;).
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Class that implements ISocketCommand in the plugin.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":gama.api.utils.server.ISocketCommand"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         &lt;extension point=&quot;gama.server_command&quot;&gt;
+   &lt;command type=&quot;stream&quot; class=&quot;gama.extension.streaming.StreamCommand&quot;/&gt;
+&lt;/extension&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         see ISocketCommand
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/gama.api/src/gama/api/additions/GamaBundleLoader.java
+++ b/gama.api/src/gama/api/additions/GamaBundleLoader.java
@@ -43,6 +43,8 @@ import gama.api.additions.delegates.IEventLayerDelegate;
 import gama.api.additions.delegates.ISaveDelegate;
 import gama.api.additions.registries.GamaAdditionRegistry;
 import gama.api.gaml.GAML;
+import gama.api.utils.server.CommandExecutor;
+import gama.api.utils.server.ISocketCommand;
 import gama.api.gaml.types.Types;
 import gama.api.kernel.GamaMetaModel;
 import gama.api.runtime.SystemInfo;
@@ -184,6 +186,9 @@ public class GamaBundleLoader {
 
 	/** The Constant METADATA_EXTENSION. */
 	public static final String METADATA_EXTENSION = "gama.metadata";
+
+	/** The server command extension. Allows plug-ins to register new gama-server (WebSocket) commands. */
+	public static final String SERVER_COMMAND_EXTENSION = "gama.server_command";
 
 	/** The regular models layout. */
 	public static final String REGULAR_MODELS_LAYOUT = "models";
@@ -381,6 +386,14 @@ public class GamaBundleLoader {
 					ERROR("Error in loading extensions to 'metadata'. ", e);
 				}
 				try {
+					TIMER_WITH_EXCEPTIONS(BANNER_CATEGORY.GAML, "Loading extensions to 'server_command'", "completed in",
+							() -> {
+								loadServerCommandExt(registry);
+							});
+				} catch (RuntimeException e) {
+					ERROR("Error in loading extensions to 'server_command'. ", e);
+				}
+				try {
 					TIMER_WITH_EXCEPTIONS(BANNER_CATEGORY.GAML, "Gathering built-in models", "completed in",
 							() -> { loadModels(registry); });
 				} catch (RuntimeException e) {
@@ -550,6 +563,33 @@ public class GamaBundleLoader {
 				// We do not systematically exit in case of additional plugins failing to load, so as to
 				// give the platform a chance to execute even in case of errors (to save files, to
 				// remove offending plugins, etc.)
+			}
+		}
+	}
+
+	/**
+	 * Loads server command extensions from registered plugins. This method discovers all {@link ISocketCommand}
+	 * implementations contributed through the {@code gama.server_command} extension point and registers them on
+	 * {@link CommandExecutor}, making them available to both the GUI and the headless gama-server.
+	 *
+	 * <p>
+	 * Each contribution associates a command keyword (the JSON {@code type} field sent by clients, e.g. {@code "stream"})
+	 * with a class implementing {@link ISocketCommand}.
+	 *
+	 * @param registry
+	 *            the Eclipse extension registry containing plugin contributions
+	 */
+	private static void loadServerCommandExt(final IExtensionRegistry registry) {
+		for (final IConfigurationElement e : registry.getConfigurationElementsFor(SERVER_COMMAND_EXTENSION)) {
+			try {
+				final String type = e.getAttribute("type");
+				final ISocketCommand command = (ISocketCommand) e.createExecutableExtension("class");
+				CommandExecutor.registerContributedCommand(type, command);
+			} catch (final Exception e1) {
+				ERROR("Error in loading server command from "
+						+ e.getDeclaringExtension().getContributor().getName(), e1);
+				// We do not systematically exit in case of additional plugins failing to load, so as to
+				// give the platform a chance to execute even in case of errors.
 			}
 		}
 	}

--- a/gama.api/src/gama/api/utils/server/CommandExecutor.java
+++ b/gama.api/src/gama/api/utils/server/CommandExecutor.java
@@ -29,8 +29,10 @@ import static gama.api.utils.server.ISocketCommand.VALIDATE;
 import static java.util.Map.entry;
 
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.java_websocket.WebSocket;
@@ -60,6 +62,26 @@ public class CommandExecutor implements ICommandExecuter {
 			entry(UPLOAD, DefaultServerCommands::UPLOAD), entry(ASK, DefaultServerCommands::ASK),
 			entry(VALIDATE, DefaultServerCommands::VALIDATE), entry(DESCRIBE, DefaultServerCommands::DESCRIBE));
 
+	/**
+	 * Commands contributed by plug-ins through the {@code gama.server_command} extension point. Populated by
+	 * {@code GamaBundleLoader} at startup and merged into every {@link CommandExecutor} instance, so that contributed
+	 * commands are available to both the GUI and the headless servers.
+	 */
+	private static final Map<String, ISocketCommand> CONTRIBUTED_COMMANDS = new ConcurrentHashMap<>();
+
+	/**
+	 * Registers a command contributed by a plug-in. Called by {@code GamaBundleLoader} when reading the
+	 * {@code gama.server_command} extension point.
+	 *
+	 * @param type
+	 *            the command keyword (the JSON 'type' field sent by clients)
+	 * @param command
+	 *            the command implementation
+	 */
+	public static void registerContributedCommand(final String type, final ISocketCommand command) {
+		if (type != null && command != null) { CONTRIBUTED_COMMANDS.put(type, command); }
+	}
+
 	/** The commands. */
 	protected final Map<String, ISocketCommand> commands;
 
@@ -77,7 +99,10 @@ public class CommandExecutor implements ICommandExecuter {
 	 */
 
 	public CommandExecutor() {
-		commands = GAMA.getGui().getServerCommands();
+		// Copy into a mutable map (some IGui implementations return an immutable/shared map) and merge the commands
+		// contributed by plug-ins through the 'gama.server_command' extension point.
+		commands = new HashMap<>(GAMA.getGui().getServerCommands());
+		commands.putAll(CONTRIBUTED_COMMANDS);
 		commandQueue = new LinkedBlockingQueue<>();
 	}
 

--- a/gama.extension.streaming/.classpath
+++ b/gama.extension.streaming/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/gama.extension.streaming/.project
+++ b/gama.extension.streaming/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gama.extension.streaming</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/gama.extension.streaming/META-INF/MANIFEST.MF
+++ b/gama.extension.streaming/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: GAML Display Web Streaming Extension
+Bundle-SymbolicName: gama.extension.streaming;singleton:=true
+Bundle-Version: 0.0.0.qualifier
+Export-Package: gama.extension.streaming
+Bundle-Vendor: UMMISCO
+Require-Bundle: gama.core,
+ gama.dependencies
+Bundle-ClassPath: .
+Bundle-RequiredExecutionEnvironment: JavaSE-25
+Automatic-Module-Name: gama.extension.streaming
+Bundle-ActivationPolicy: lazy
+Import-Package: org.osgi.framework

--- a/gama.extension.streaming/build.properties
+++ b/gama.extension.streaming/build.properties
@@ -1,0 +1,8 @@
+source.. = src/
+output.. = bin/
+jre.compilation.profile = JavaSE-25
+bin.includes = .,\
+               plugin.xml,\
+               META-INF/,\
+               client/
+javacDefaultEncoding.. = UTF-8

--- a/gama.extension.streaming/client/README.md
+++ b/gama.extension.streaming/client/README.md
@@ -1,0 +1,45 @@
+# GAMA display web streaming — demo client
+
+A self-contained web page that subscribes to a GAMA display and renders the live frame
+stream pushed by the `gama.extension.streaming` plugin over the gama-server WebSocket.
+
+## Run
+
+1. Start a gama-server (default port `6868`):
+   - **Headless**: launch GAMA headless in server mode.
+   - **GUI**: launch the GAMA desktop with server mode enabled
+     (`Preferences ▸ Runtime ▸ gama-server`) and open an experiment.
+2. Open `index.html` in a browser (just double-click it — no build step).
+3. Click **Connect**, fill in the absolute **Model path** and **Experiment name**, click **load**.
+4. Set the **Display name** (the name of a `display` in your model), then **stream on**.
+5. Click **play**. Frames appear on the canvas as the simulation advances.
+
+## Message sequence
+
+```jsonc
+// client → server
+{ "type": "load", "model": "/abs/model.gaml", "experiment": "my_experiment" }
+// server → client
+{ "type": "CommandExecutedSuccessfully", "content": "0", "command": { "type": "load", ... } }  // content = exp_id
+
+{ "type": "stream", "exp_id": "0", "display": "my_display",
+  "width": 500, "height": 500, "frame_rate": 1, "enabled": true }
+{ "type": "play", "exp_id": "0" }
+
+// server → client, one per streamed cycle
+{ "type": "SimulationImage", "exp_id": "0",
+  "content": { "display": "my_display", "cycle": 12, "width": 500, "height": 500,
+               "mime": "image/png", "data": "<base64 PNG>" } }
+
+// stop streaming a display
+{ "type": "stream", "display": "my_display", "enabled": false }
+```
+
+`frame_rate` is a **decimation in simulation cycles**: `1` streams every cycle, `5` one cycle
+out of five. Resolution is set per subscription via `width`/`height`.
+
+## Notes
+
+- The frame pump reads the live display off a background thread; for very high-rate streaming or
+  3D/OpenGL displays, expect occasional tearing — displays are discrete sim-step frames, not video.
+- PNG keeps frames pixel-exact; switch the server encoding to JPEG if bandwidth matters more than fidelity.

--- a/gama.extension.streaming/client/index.html
+++ b/gama.extension.streaming/client/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>GAMA display web streaming — demo client</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 1rem; display: grid; grid-template-columns: 320px 1fr; gap: 1rem; }
+  h1 { font-size: 1.1rem; grid-column: 1 / -1; margin: 0 0 .25rem; }
+  fieldset { border: 1px solid #8884; border-radius: 8px; margin: 0 0 .75rem; }
+  legend { font-weight: 600; }
+  label { display: block; font-size: .8rem; margin: .35rem 0 .1rem; }
+  input { width: 100%; box-sizing: border-box; padding: .35rem; }
+  .row { display: flex; gap: .4rem; }
+  .row > * { flex: 1; }
+  button { padding: .45rem .6rem; border-radius: 6px; border: 1px solid #8886; cursor: pointer; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  #stage { display: flex; flex-direction: column; gap: .5rem; }
+  canvas { border: 1px solid #8886; border-radius: 8px; background: #0001; max-width: 100%; image-rendering: pixelated; }
+  #log { font-family: ui-monospace, monospace; font-size: .72rem; height: 220px; overflow: auto; white-space: pre-wrap;
+         background: #0001; border-radius: 8px; padding: .5rem; }
+  .pill { font-size: .72rem; padding: .1rem .4rem; border-radius: 999px; background: #8883; }
+</style>
+</head>
+<body>
+  <h1>GAMA display web streaming — demo client</h1>
+
+  <div>
+    <fieldset>
+      <legend>Connection</legend>
+      <label>Server URL</label>
+      <input id="url" value="ws://localhost:6868" />
+      <div class="row" style="margin-top:.5rem">
+        <button id="connect">Connect</button>
+        <button id="disconnect" disabled>Disconnect</button>
+      </div>
+      <p>Status: <span id="status" class="pill">disconnected</span> · exp_id: <span id="expid" class="pill">—</span></p>
+    </fieldset>
+
+    <fieldset>
+      <legend>Model</legend>
+      <label>Model path (absolute .gaml on the server)</label>
+      <input id="model" value="/absolute/path/to/model.gaml" />
+      <label>Experiment name</label>
+      <input id="experiment" value="my_experiment" />
+      <button id="load" disabled style="margin-top:.5rem">load</button>
+    </fieldset>
+
+    <fieldset>
+      <legend>Display stream</legend>
+      <label>Display name</label>
+      <input id="display" value="my_display" />
+      <div class="row">
+        <div><label>width</label><input id="width" type="number" value="500" /></div>
+        <div><label>height</label><input id="height" type="number" value="500" /></div>
+        <div><label>frame_rate</label><input id="frate" type="number" value="1" /></div>
+      </div>
+      <div class="row" style="margin-top:.5rem">
+        <button id="subscribe" disabled>stream on</button>
+        <button id="unsubscribe" disabled>stream off</button>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Simulation</legend>
+      <div class="row">
+        <button id="play" disabled>play</button>
+        <button id="pause" disabled>pause</button>
+        <button id="step" disabled>step</button>
+        <button id="stop" disabled>stop</button>
+      </div>
+    </fieldset>
+  </div>
+
+  <div id="stage">
+    <div>Frames: <span id="frames" class="pill">0</span> · last cycle: <span id="cycle" class="pill">—</span></div>
+    <canvas id="canvas" width="500" height="500"></canvas>
+    <div id="log"></div>
+  </div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const canvas = $('canvas');
+const ctx = canvas.getContext('2d');
+let ws = null, expId = null, frames = 0;
+
+function log(msg) {
+  const t = new Date().toLocaleTimeString();
+  $('log').textContent += `[${t}] ${msg}\n`;
+  $('log').scrollTop = $('log').scrollHeight;
+}
+
+function setConnected(connected) {
+  $('status').textContent = connected ? 'connected' : 'disconnected';
+  $('connect').disabled = connected;
+  $('disconnect').disabled = !connected;
+  for (const id of ['load','subscribe','unsubscribe','play','pause','step','stop'])
+    $(id).disabled = !connected;
+}
+
+// Send a command. The server expects a JSON object with a "type" field.
+function send(cmd) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) { log('not connected'); return; }
+  if (expId && cmd.exp_id === undefined) cmd.exp_id = expId;
+  ws.send(JSON.stringify(cmd));
+  log('→ ' + JSON.stringify(cmd));
+}
+
+function drawFrame(content) {
+  const img = new Image();
+  img.onload = () => {
+    if (canvas.width !== img.width || canvas.height !== img.height) {
+      canvas.width = img.width; canvas.height = img.height;
+    }
+    ctx.drawImage(img, 0, 0);
+    frames++;
+    $('frames').textContent = frames;
+    if (content.cycle !== undefined) $('cycle').textContent = content.cycle;
+  };
+  img.src = 'data:' + (content.mime || 'image/png') + ';base64,' + content.data;
+}
+
+function onMessage(ev) {
+  let msg;
+  try { msg = JSON.parse(ev.data); } catch (e) { log('← (non-JSON, ' + ev.data.length + ' bytes)'); return; }
+
+  if (msg.type === 'SimulationImage') {
+    // content carries { display, cycle, width, height, mime, data }
+    drawFrame(typeof msg.content === 'string' ? { data: msg.content } : msg.content);
+    return;
+  }
+
+  log('← ' + JSON.stringify(msg).slice(0, 400));
+
+  // The 'load' command answers with the new experiment id in 'content'.
+  if (msg.type === 'CommandExecutedSuccessfully' && msg.command && msg.command.type === 'load' && msg.content) {
+    expId = '' + msg.content;
+    $('expid').textContent = expId;
+    log('experiment id = ' + expId);
+  }
+}
+
+$('connect').onclick = () => {
+  ws = new WebSocket($('url').value.trim());
+  ws.onopen = () => { setConnected(true); log('connected'); };
+  ws.onclose = () => { setConnected(false); log('closed'); };
+  ws.onerror = () => log('socket error');
+  ws.onmessage = onMessage;
+};
+$('disconnect').onclick = () => ws && ws.close();
+
+$('load').onclick = () => send({
+  type: 'load',
+  model: $('model').value.trim(),
+  experiment: $('experiment').value.trim(),
+});
+
+$('subscribe').onclick = () => send({
+  type: 'stream',
+  display: $('display').value.trim(),
+  width: parseInt($('width').value, 10),
+  height: parseInt($('height').value, 10),
+  frame_rate: parseInt($('frate').value, 10),
+  enabled: true,
+});
+$('unsubscribe').onclick = () => send({ type: 'stream', display: $('display').value.trim(), enabled: false });
+
+$('play').onclick  = () => send({ type: 'play' });
+$('pause').onclick = () => send({ type: 'pause' });
+$('step').onclick  = () => send({ type: 'step' });
+$('stop').onclick  = () => send({ type: 'stop' });
+</script>
+</body>
+</html>

--- a/gama.extension.streaming/plugin.xml
+++ b/gama.extension.streaming/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="gama.server_command">
+      <command
+            type="stream"
+            class="gama.extension.streaming.StreamCommand">
+      </command>
+   </extension>
+</plugin>

--- a/gama.extension.streaming/pom.xml
+++ b/gama.extension.streaming/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+  	<groupId>org.gama</groupId>
+  	<artifactId>gama.parent</artifactId>
+  	<version>0.0.0-SNAPSHOT</version>
+  	<relativePath>../gama.parent/</relativePath>
+  </parent>
+  <artifactId>gama.extension.streaming</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/gama.extension.streaming/src/gama/extension/streaming/DisplayStreamer.java
+++ b/gama.extension.streaming/src/gama/extension/streaming/DisplayStreamer.java
@@ -1,0 +1,101 @@
+/*******************************************************************************************************
+ *
+ * DisplayStreamer.java, in gama.extension.streaming, is part of the source code of the GAMA modeling and simulation
+ * platform (v.2025-03).
+ *
+ * (c) 2007-2026 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
+ *
+ * Visit https://github.com/gama-platform/gama for license information and contacts.
+ *
+ ********************************************************************************************************/
+package gama.extension.streaming;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import org.java_websocket.WebSocket;
+
+import gama.api.GAMA;
+import gama.api.utils.server.GamaServerMessage;
+import gama.api.utils.server.MessageType;
+import gama.core.outputs.LayeredDisplayOutput;
+import gama.dev.DEBUG;
+
+/**
+ * Captures a single frame of a display and sends it to a client over the gama-server WebSocket as a JSON
+ * {@link MessageType#SimulationImage} message carrying a base64-encoded PNG.
+ *
+ * <p>
+ * The frame is rendered through {@link LayeredDisplayOutput#getImage(int, int)}, which works identically for the
+ * headless ({@code ImageDisplaySurface}) and on-screen (Java2D / OpenGL) backends — each backend already marshals the
+ * pixel read-back to its own thread.
+ */
+public class DisplayStreamer {
+
+	static {
+		DEBUG.OFF();
+	}
+
+	/**
+	 * Renders the given display at the subscription's resolution and sends it to the client as a
+	 * {@code SimulationImage} message. Failures (closed socket, missing surface, encoding error) are swallowed so the
+	 * pump can keep going.
+	 *
+	 * @param socket
+	 *            the client WebSocket
+	 * @param expId
+	 *            the id of the running experiment (used to route the message client-side, may be null)
+	 * @param output
+	 *            the display output to capture
+	 * @param sub
+	 *            the subscription describing resolution and target display
+	 * @param cycle
+	 *            the simulation cycle this frame corresponds to
+	 */
+	public static void streamFrame(final WebSocket socket, final String expId, final LayeredDisplayOutput output,
+			final StreamSubscription sub, final int cycle) {
+		if (socket == null || socket.isClosed() || socket.isClosing()) return;
+		try {
+			final BufferedImage image = output.getImage(sub.width, sub.height);
+			if (image == null) return;
+			final String base64 = toBase64Png(image);
+
+			final Map<String, Object> content = new LinkedHashMap<>();
+			content.put("display", sub.display);
+			content.put("cycle", cycle);
+			content.put("width", image.getWidth());
+			content.put("height", image.getHeight());
+			content.put("mime", "image/png");
+			content.put("data", base64);
+
+			final String message = GAMA.getJsonEncoder()
+					.valueOf(new GamaServerMessage(MessageType.SimulationImage, content, expId)).toString();
+			if (!socket.isClosed() && !socket.isClosing()) { socket.send(message); }
+		} catch (final Exception e) {
+			DEBUG.ERR("Unable to stream a frame of display '" + sub.display + "'", e);
+		}
+	}
+
+	/**
+	 * Encodes a {@link BufferedImage} into a base64 PNG string.
+	 *
+	 * @param image
+	 *            the image to encode
+	 * @return the base64-encoded PNG
+	 * @throws IOException
+	 *             if the PNG encoding fails
+	 */
+	private static String toBase64Png(final BufferedImage image) throws IOException {
+		try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+			ImageIO.write(image, "png", os);
+			return Base64.getEncoder().encodeToString(os.toByteArray());
+		}
+	}
+
+}

--- a/gama.extension.streaming/src/gama/extension/streaming/StreamCommand.java
+++ b/gama.extension.streaming/src/gama/extension/streaming/StreamCommand.java
@@ -1,0 +1,127 @@
+/*******************************************************************************************************
+ *
+ * StreamCommand.java, in gama.extension.streaming, is part of the source code of the GAMA modeling and simulation
+ * platform (v.2025-03).
+ *
+ * (c) 2007-2026 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
+ *
+ * Visit https://github.com/gama-platform/gama for license information and contacts.
+ *
+ ********************************************************************************************************/
+package gama.extension.streaming;
+
+import java.util.Map;
+
+import org.java_websocket.WebSocket;
+
+import gama.api.exceptions.CommandException;
+import gama.api.kernel.simulation.ISimulationAgent;
+import gama.api.kernel.species.IExperimentSpecies;
+import gama.api.ui.IOutput;
+import gama.api.utils.server.CommandResponse;
+import gama.api.utils.server.GamaServerMessage;
+import gama.api.utils.server.IGamaServer;
+import gama.api.utils.server.ISocketCommand;
+import gama.api.utils.server.MessageType;
+import gama.api.utils.server.ReceivedMessage;
+import gama.core.outputs.LayeredDisplayOutput;
+
+/**
+ * The {@code stream} gama-server command. Lets a client subscribe to (or unsubscribe from) the live image stream of a
+ * display of a running experiment, on both the headless and the GUI servers.
+ *
+ * <p>
+ * Expected JSON parameters:
+ * <ul>
+ * <li>{@code display} (required): the original name of the display to stream</li>
+ * <li>{@code exp_id} (optional): the id of the experiment to stream from</li>
+ * <li>{@code width}, {@code height} (optional, default 500): the resolution of the frames</li>
+ * <li>{@code frame_rate} (optional, default 1): number of simulation cycles between two frames</li>
+ * <li>{@code enabled} (optional, default true): {@code false} to stop streaming the display</li>
+ * </ul>
+ *
+ * Frames are then pushed asynchronously as {@link MessageType#SimulationImage} messages by {@link StreamingService}.
+ */
+public class StreamCommand implements ISocketCommand {
+
+	/** The display parameter. */
+	private static final String DISPLAY = "display";
+
+	/** The width parameter. */
+	private static final String WIDTH = "width";
+
+	/** The height parameter. */
+	private static final String HEIGHT = "height";
+
+	/** The frame rate parameter. */
+	private static final String FRAME_RATE = "frame_rate";
+
+	/** The enabled parameter. */
+	private static final String ENABLED = "enabled";
+
+	@Override
+	public GamaServerMessage execute(final IGamaServer server, final WebSocket socket, final ReceivedMessage map) {
+
+		final Object display = map.get(DISPLAY);
+		if (display == null) return new CommandResponse(MessageType.MalformedRequest,
+				"For " + map.get("type") + ", mandatory parameter is: '" + DISPLAY + "'", map, false);
+		final String displayName = display.toString();
+
+		// We resolve the experiment for both runtimes (GUI returns the active experiment, headless the one bound to the
+		// socket / exp_id).
+		final IExperimentSpecies plan;
+		try {
+			plan = server.retrieveExperimentPlan(socket, map);
+		} catch (final CommandException e) {
+			return e.getResponse();
+		}
+
+		final String expId = map.get(EXP_ID) != null ? map.get(EXP_ID).toString()
+				: Integer.toHexString(System.identityHashCode(socket));
+
+		final boolean enabled = map.get(ENABLED) == null || Boolean.parseBoolean("" + map.get(ENABLED));
+		if (!enabled) {
+			StreamingService.getInstance().unsubscribe(expId, displayName);
+			return new CommandResponse(MessageType.CommandExecutedSuccessfully, "", map, false);
+		}
+
+		// We validate that the requested display exists and is a graphical display.
+		final ISimulationAgent sim = plan.getCurrentSimulation();
+		if (sim == null) return new CommandResponse(MessageType.UnableToExecuteRequest,
+				"No running simulation to stream from", map, false);
+		final IOutput output = sim.getOutputManager().getOutputWithOriginalName(displayName);
+		if (!(output instanceof LayeredDisplayOutput)) return new CommandResponse(MessageType.UnableToExecuteRequest,
+				"'" + displayName + "' is not a display of this simulation", map, false);
+
+		final int width = intValue(map, WIDTH, 500);
+		final int height = intValue(map, HEIGHT, 500);
+		final int frameRate = intValue(map, FRAME_RATE, 1);
+
+		StreamingService.getInstance().subscribe(socket, plan, expId,
+				new StreamSubscription(displayName, width, height, frameRate));
+		return new CommandResponse(MessageType.CommandExecutedSuccessfully, "", map, false);
+	}
+
+	/**
+	 * Reads an integer parameter from the request, tolerating numbers parsed as {@link Number} or as strings.
+	 *
+	 * @param map
+	 *            the request
+	 * @param key
+	 *            the parameter name
+	 * @param defaultValue
+	 *            the value to use if the parameter is absent or unreadable
+	 * @return the integer value
+	 */
+	private static int intValue(final Map<String, Object> map, final String key, final int defaultValue) {
+		final Object value = map.get(key);
+		if (value == null) return defaultValue;
+		if (value instanceof Number n) return n.intValue();
+		try {
+			return Integer.parseInt(value.toString());
+		} catch (final NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+}

--- a/gama.extension.streaming/src/gama/extension/streaming/StreamSubscription.java
+++ b/gama.extension.streaming/src/gama/extension/streaming/StreamSubscription.java
@@ -1,0 +1,75 @@
+/*******************************************************************************************************
+ *
+ * StreamSubscription.java, in gama.extension.streaming, is part of the source code of the GAMA modeling and simulation
+ * platform (v.2025-03).
+ *
+ * (c) 2007-2026 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
+ *
+ * Visit https://github.com/gama-platform/gama for license information and contacts.
+ *
+ ********************************************************************************************************/
+package gama.extension.streaming;
+
+/**
+ * Describes a client request to stream one display of a running experiment: which display, at which resolution, and at
+ * which decimation of the simulation cycles (1 = every cycle, n = one cycle out of n).
+ */
+public class StreamSubscription {
+
+	/** The original name of the display to stream. */
+	public final String display;
+
+	/** The width in pixels of the rendered frames. */
+	public final int width;
+
+	/** The height in pixels of the rendered frames. */
+	public final int height;
+
+	/** The frame rate, expressed as a number of simulation cycles between two frames (>= 1). */
+	public final int frameRate;
+
+	/** The last simulation cycle for which a frame has been sent, to avoid sending the same cycle twice. */
+	private volatile int lastSentCycle = -1;
+
+	/**
+	 * Instantiates a new stream subscription.
+	 *
+	 * @param display
+	 *            the original name of the display
+	 * @param width
+	 *            the width in pixels
+	 * @param height
+	 *            the height in pixels
+	 * @param frameRate
+	 *            the number of cycles between two frames (clamped to a minimum of 1)
+	 */
+	public StreamSubscription(final String display, final int width, final int height, final int frameRate) {
+		this.display = display;
+		this.width = Math.max(1, width);
+		this.height = Math.max(1, height);
+		this.frameRate = Math.max(1, frameRate);
+	}
+
+	/**
+	 * Returns whether a frame should be sent for the given simulation cycle: the cycle must be a new one (not already
+	 * sent) and must fall on the configured decimation.
+	 *
+	 * @param cycle
+	 *            the current simulation cycle
+	 * @return true if a frame should be sent now
+	 */
+	public boolean shouldSend(final int cycle) {
+		return cycle != lastSentCycle && cycle % frameRate == 0;
+	}
+
+	/**
+	 * Records that a frame has been sent for the given cycle.
+	 *
+	 * @param cycle
+	 *            the cycle that has just been streamed
+	 */
+	public void markSent(final int cycle) {
+		lastSentCycle = cycle;
+	}
+
+}

--- a/gama.extension.streaming/src/gama/extension/streaming/StreamingService.java
+++ b/gama.extension.streaming/src/gama/extension/streaming/StreamingService.java
@@ -1,0 +1,192 @@
+/*******************************************************************************************************
+ *
+ * StreamingService.java, in gama.extension.streaming, is part of the source code of the GAMA modeling and simulation
+ * platform (v.2025-03).
+ *
+ * (c) 2007-2026 UMI 209 UMMISCO IRD/SU & Partners (IRIT, MIAT, ESPACE-DEV, CTU)
+ *
+ * Visit https://github.com/gama-platform/gama for license information and contacts.
+ *
+ ********************************************************************************************************/
+package gama.extension.streaming;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.java_websocket.WebSocket;
+
+import gama.api.kernel.simulation.ISimulationAgent;
+import gama.api.kernel.species.IExperimentSpecies;
+import gama.api.ui.IOutput;
+import gama.core.outputs.LayeredDisplayOutput;
+import gama.dev.DEBUG;
+
+/**
+ * Holds the active display-streaming subscriptions, one set per running experiment, and runs a background pump that
+ * captures and sends frames as the simulation advances. This service is shared by every gama-server runtime (headless
+ * and GUI) because the capture goes through the public {@link IExperimentSpecies} / {@link LayeredDisplayOutput} API.
+ *
+ * <p>
+ * The pump reads the <em>live</em> experiment each tick: it resolves the current simulation, reads its cycle and, for
+ * every subscription due on that cycle, renders and sends a frame. It stops automatically when the last subscription is
+ * removed, when the client socket closes, or when the simulation dies.
+ */
+public class StreamingService {
+
+	static {
+		DEBUG.OFF();
+	}
+
+	/** How often the pump checks the simulation cycle, in milliseconds. */
+	private static final long POLL_INTERVAL_MS = 25;
+
+	/** The singleton instance. */
+	private static final StreamingService INSTANCE = new StreamingService();
+
+	/**
+	 * Gets the single instance of StreamingService.
+	 *
+	 * @return the streaming service
+	 */
+	public static StreamingService getInstance() { return INSTANCE; }
+
+	/** The active streams, keyed by experiment id. */
+	private final Map<String, ExperimentStream> streams = new ConcurrentHashMap<>();
+
+	/**
+	 * Registers (or updates) a subscription to a display of an experiment and makes sure the pump is running.
+	 *
+	 * @param socket
+	 *            the client WebSocket to which frames are sent
+	 * @param experiment
+	 *            the running experiment
+	 * @param expId
+	 *            the experiment id, used both as a key and as the {@code exp_id} of the messages
+	 * @param subscription
+	 *            the subscription describing the display, resolution and frame rate
+	 */
+	public synchronized void subscribe(final WebSocket socket, final IExperimentSpecies experiment, final String expId,
+			final StreamSubscription subscription) {
+		final ExperimentStream stream =
+				streams.computeIfAbsent(expId, k -> new ExperimentStream(socket, experiment, expId));
+		stream.subscriptions.put(subscription.display, subscription);
+		stream.start();
+	}
+
+	/**
+	 * Removes the subscription to a display. If it was the last subscription of the experiment, the pump is stopped.
+	 *
+	 * @param expId
+	 *            the experiment id
+	 * @param display
+	 *            the display name to stop streaming
+	 */
+	public synchronized void unsubscribe(final String expId, final String display) {
+		final ExperimentStream stream = streams.get(expId);
+		if (stream == null) return;
+		stream.subscriptions.remove(display);
+		if (stream.subscriptions.isEmpty()) { stop(expId); }
+	}
+
+	/**
+	 * Stops all streaming for an experiment and releases its pump.
+	 *
+	 * @param expId
+	 *            the experiment id
+	 */
+	public synchronized void stop(final String expId) {
+		final ExperimentStream stream = streams.remove(expId);
+		if (stream != null) { stream.stop(); }
+	}
+
+	/**
+	 * The streaming state of a single experiment: its socket, its subscriptions and the pump thread.
+	 */
+	private static class ExperimentStream {
+
+		/** The client socket. */
+		final WebSocket socket;
+
+		/** The running experiment. */
+		final IExperimentSpecies experiment;
+
+		/** The experiment id. */
+		final String expId;
+
+		/** The active subscriptions, keyed by display name. */
+		final Map<String, StreamSubscription> subscriptions = new ConcurrentHashMap<>();
+
+		/** The pump thread. */
+		private volatile Thread pump;
+
+		/** Whether the pump should keep running. */
+		private volatile boolean running;
+
+		/**
+		 * Instantiates a new experiment stream.
+		 *
+		 * @param socket
+		 *            the socket
+		 * @param experiment
+		 *            the experiment
+		 * @param expId
+		 *            the exp id
+		 */
+		ExperimentStream(final WebSocket socket, final IExperimentSpecies experiment, final String expId) {
+			this.socket = socket;
+			this.experiment = experiment;
+			this.expId = expId;
+		}
+
+		/**
+		 * Starts the pump thread if it is not already running.
+		 */
+		synchronized void start() {
+			if (running) return;
+			running = true;
+			pump = new Thread(this::run, "gama-display-stream-" + expId);
+			pump.setDaemon(true);
+			pump.start();
+		}
+
+		/**
+		 * Signals the pump to stop.
+		 */
+		synchronized void stop() {
+			running = false;
+			if (pump != null) { pump.interrupt(); }
+		}
+
+		/**
+		 * The pump loop: each tick, resolve the live simulation, read its cycle, and stream every display that is due.
+		 */
+		private void run() {
+			try {
+				while (running) {
+					if (socket == null || socket.isClosed()) { break; }
+					final ISimulationAgent sim = experiment.getCurrentSimulation();
+					if (sim != null && !sim.dead()) {
+						final int cycle = sim.getCycle(sim.getScope());
+						for (final StreamSubscription sub : subscriptions.values()) {
+							if (!sub.shouldSend(cycle)) { continue; }
+							final IOutput output = sim.getOutputManager().getOutputWithOriginalName(sub.display);
+							if (output instanceof LayeredDisplayOutput ldo) {
+								DisplayStreamer.streamFrame(socket, expId, ldo, sub, cycle);
+								sub.markSent(cycle);
+							}
+						}
+					}
+					Thread.sleep(POLL_INTERVAL_MS);
+				}
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+			} catch (final Exception e) {
+				DEBUG.ERR("Display streaming pump for experiment '" + expId + "' stopped on error", e);
+			} finally {
+				running = false;
+			}
+		}
+
+	}
+
+}

--- a/gama.feature.extensions/feature.xml
+++ b/gama.feature.extensions/feature.xml
@@ -93,4 +93,10 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="gama.extension.streaming"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
 </feature>

--- a/gama.parent/pom.xml
+++ b/gama.parent/pom.xml
@@ -139,6 +139,7 @@
 		<module>../gama.extension.stats</module>
 		<module>../gama.extension.maths</module>
 		<module>../gama.extension.image</module>
+		<module>../gama.extension.streaming</module>
 		<module>../gama.extension.traffic</module>
 		<module>../gama.extension.network</module>
 		<module>../gama.extension.physics</module>


### PR DESCRIPTION
This PR is adding several things : 

## Add ability to add server's command to plugins (gama.api)

The existing gama-server had a fixed, hardcoded command table (CommandExecutor.DEFAULT_COMMANDS). There was no way for a plugin to add a new command.

Adding:
- A new Eclipse extension point gama.server_command (declared in gama.api/plugin.xml, schema in gama.api/schema/gama.server_command.exsd) — the same pattern as gama.save, gama.display, etc.
- GamaBundleLoader.loadServerCommandExt() — called at startup alongside all the other extension loaders; reads every plugin that declares a <command type="..." class="..."/> contribution and calls CommandExecutor.registerContributedCommand(type, impl).
- CommandExecutor.CONTRIBUTED_COMMANDS — a static ConcurrentHashMap populated at load time; merged into every CommandExecutor instance at construction time (commands.putAll(CONTRIBUTED_COMMANDS)).

Because CommandExecutor is shared by both GamaGuiWebSocketServer and GamaHeadlessWebSocketServer, any contributed command
automatically works on both runtimes.

## Add a display streaming plugin

Contributes one command (stream) via:

```xml
<extension point="gama.server_command">
    <command type="stream" class="gama.extension.streaming.StreamCommand"/>
</extension>
```

The flow :
- Client sends {type:"stream", display:"my_display", ...} on GAMA Server
- CommandExecutor.execute("stream", ...)
- StreamCommand.execute() 
    - validates display exists (getOutputWithOriginalName instanceof LayeredDisplayOutput)
- StreamingService.subscribe(socket, experiment, expId, subscription)
- ExperimentStream.start()
    - starting a background pulling thread
        1. Gets the live simulation
        2. Reads its current cycle
        3. Send frame with DisplayStreamer.streamFrame():
            1. output.getImage to BufferedImage
            2. PNG-encode to Base64 string (JSON compatible)
            3. Wraps in GamaServerMessage
            4. Serializes to JSON and send

- System stops when: last subscription removed, socket closes, or simulation dies.

### Added a small test demo with this flow : 
```
connect  →  ws://localhost:6868
load     →  { type:"load", model:"/path/model.gaml", experiment:"exp_name" }
         ←  { type:"CommandExecutedSuccessfully", content:"0" }  ← captures exp_id
stream   →  { type:"stream", exp_id:"0", display:"my_display", width:500, height:500, frame_rate:1, enabled:true }
play     →  { type:"play", exp_id:"0" }
         ←  { type:"SimulationImage", exp_id:"0",
              content:{ display, cycle, width, height, mime:"image/png", data:"<base64>" } }
            (one per streamed cycle, pushed by the pump)
```
On receiving SimulationImage: decode the base64 into an <img>, draw it to a <canvas>.

---

Using this new feature doesn't change anything for end-users (no GAML to change), nor any platform stability (adding new server commands, and process enable only when the command is triggered and a user subscribe to a display), and should work on both headless/gui

---

## Discussion

Several things can be discussed : 
- I think the core parts (to be able to add commands to GAMA Server from plugins) is the most important element to add from this PR (and can be cherrypicked as it's self contained in a single commit)
- Not sure the streaming should be added for the next release
  - Since it doesn't break anything, I don't see why not
  - Would be useful for SIMPLE, but can be an external plugin too
- I made a standalone HTML example file, but it can be merged with the Server already existing in the repo
- I have no idea if I'm missing some parts for the automatic documentation ?