### PR TITLE
Optimize neighborhood filtering in GamaSpatialMatrix

### DIFF
--- a/gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java
+++ b/gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -1089,8 +1090,13 @@ public class GamaSpatialMatrix extends GamaMatrix<IShape> implements IGrid {
 			final List<IAgent> currentList) throws GamaRuntimeException {
 		final List<IAgent> agents = new ArrayList(getNeighborsOf(scope, agent.getLocation(), 1.0, null));
 		final List<IAgent> neighs = new ArrayList<>();
+		final Set<Integer> visitedCells = new HashSet<>(cells);
+		final Set<IAgent> currentAgents = new HashSet<>(currentList);
+		final Set<IAgent> seenNeighbors = new HashSet<>();
 		for (final IAgent ag : agents) {
-			if (!cells.contains(ag.getIndex()) && !currentList.contains(ag) && !neighs.contains(ag)) { neighs.add(ag); }
+			if (!visitedCells.contains(ag.getIndex()) && !currentAgents.contains(ag) && seenNeighbors.add(ag)) {
+				neighs.add(ag);
+			}
 		}
 		return neighs;
 	}

--- a/gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java
+++ b/gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java
@@ -1088,7 +1088,7 @@ public class GamaSpatialMatrix extends GamaMatrix<IShape> implements IGrid {
 	 */
 	private List<IAgent> getNeighborhoods(final IScope scope, final IAgent agent, final List<Integer> cells,
 			final List<IAgent> currentList) throws GamaRuntimeException {
-		final List<IAgent> agents = new ArrayList(getNeighborsOf(scope, agent.getLocation(), 1.0, null));
+		final List<IAgent> agents = new ArrayList<>(getNeighborsOf(scope, agent.getLocation(), 1.0, null));
 		final List<IAgent> neighs = new ArrayList<>();
 		final Set<Integer> visitedCells = new HashSet<>(cells);
 		final Set<IAgent> currentAgents = new HashSet<>(currentList);


### PR DESCRIPTION
## What changed
Replaced repeated linear membership checks in `GamaSpatialMatrix#getNeighborhoods` with hash-backed lookup sets.

- before: `cells.contains(...)`, `currentList.contains(...)`, and `neighs.contains(...)` inside the neighbor loop
- after: precompute `HashSet` views (`visitedCells`, `currentAgents`) and deduplicate via `seenNeighbors`

This removes avoidable O(n) list scans in a hot loop used by proximity/path exploration on grids.

## 10 identified performance improvements (ranked)
1. **Implemented**: `gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java` (around L1088-L1096) — replace list `contains` checks in `getNeighborhoods` with sets.
2. `gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java` (L1149) — replace `ArrayList` queue + `remove(0)` in BF shortest path with `ArrayDeque`.
3. `gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java` (L1203, L1225, L1280, L1303, L1350, L1371) — avoid anonymous `new ArrayList(){...}` pair allocations in Dijkstra/A* frontiers; use typed lightweight node record.
4. `gama.core/src/gama/core/topology/graph/GraphTopology.java` (L1139-L1144) — avoid repeated `graph.getEdges().contains(ag)` and repeated full edge scans by caching edge set/nearest-edge lookup.
5. `gama.core/src/gama/core/topology/graph/GraphTopology.java` (L1100-L1106 and L1143-L1148) — nearest-edge search is duplicated; extract/cached spatial index for edges.
6. `gama.core/src/gama/core/topology/graph/NBAStarPathfinder.java` (L159-L160, L217-L218) — avoid per-expansion `new ArrayList<>(...)` + `addAll(...)` allocations for undirected graphs.
7. `gama.core/src/gama/core/topology/graph/NBAStarPathfinder.java` (L319) — replace `vertices.keySet().stream().filter(...).findFirst()` fallback with direct equality map to avoid linear stream scans during path traceback.
8. `gama.core/src/gama/core/topology/grid/GamaSpatialMatrix.java` (L266-L268) — avoid calling `gfile.getBand(scope, b)` inside inner loop; preload band arrays once.
9. `gama.core/src/gama/core/population/GamaPopulation.java` (L311) — replace `orderedVarNames.contains(name)` with a set-backed lookup for per-agent attribute initialization.
10. `gama.core/src/gama/core/topology/graph/GraphTopology.java` (L232 and similar edge iterations) — cache `graph.getEdges()` result in local variables within heavy methods to avoid repeated collection/materialization calls.

## Why this one first
This change is low-risk, localized, and immediately reduces algorithmic complexity in a frequently called neighborhood expansion path without changing behavior.
