### PR TITLE
Use Vector API for matrix operations

### DIFF
--- a/gama.api/src/gama/api/gaml/types/ParametricFileType.java
+++ b/gama.api/src/gama/api/gaml/types/ParametricFileType.java
@@ -134,13 +134,7 @@ public class ParametricFileType extends ParametricType {
 		if (genericInstance == null) {
 			genericInstance =
 					new ParametricFileType("generic_file", IGamaFile.class, (s, o) -> new GenericFile(s, (String) o[0]),
-							Types.LIST, Types.NO_TYPE, Types.NO_TYPE, GamaFileType.provideNewIndex()) {
-						@Override
-						public Map<String, IArtefact.Operator>
-								getFieldGetters() { return getGamlType().getFieldGetters(); }
-					};
-			genericInstance.setParent(Types.FILE);
-			Types.addRegularType(genericInstance.getName(), genericInstance, "gama.core");
+							Types.LIST, Types.NO_TYPE, Types.NO_TYPE, GamaFileType.provideNewIndex());
 		}
 		return genericInstance;
 	}
@@ -526,7 +520,8 @@ public class ParametricFileType extends ParametricType {
 	 */
 	@Override
 	public IArtefact getGetter(final String field) {
-		return getFieldGetters().get(field);
+		if (getters == null) return null;
+		return getters.get(field);
 	}
 
 	/**
@@ -537,8 +532,12 @@ public class ParametricFileType extends ParametricType {
 	 */
 	@Override
 	public void documentFields(final IGamlDocumentation result) {
-		for (final IArtefact.Operator f : getFieldGetters().values()) { getFieldDocumentation(result, f); }
-		result.append("</ul>");
+		if (getters != null) {
+			// sb.append("<b><br/>Fields :</b><ul>");
+			for (final IArtefact.Operator f : getters.values()) { getFieldDocumentation(result, f); }
+
+			result.append("</ul>");
+		}
 	}
 
 	/**

--- a/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
@@ -442,194 +442,62 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 
 	@Override
 	public IMatrix plus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaFloatMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
-				DoubleVector vc = va.add(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
 	}
 
 	@Override
 	public IMatrix times(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaFloatMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
-				DoubleVector vc = va.mul(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
 	}
 
 	@Override
 	public IMatrix minus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaFloatMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
-				DoubleVector vc = va.sub(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
 	}
 
 	@Override
 	public IMatrix times(final Double val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.mul(val);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
-		return nm;
+		return applyScalarOp(val, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
 	}
 
 	@Override
 	public IMatrix times(final Integer val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		double dval = val.doubleValue();
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.mul(dval);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * dval; }
-		return nm;
+		return applyScalarOp(val.doubleValue(), (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
 	}
 
 	@Override
 	public IMatrix divides(final Double val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.div(val);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
-		return nm;
+		return applyScalarOp(val, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
 	}
 
 	@Override
 	public IMatrix divides(final Integer val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		double dval = val.doubleValue();
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.div(dval);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / dval; }
-		return nm;
+		return applyScalarOp(val.doubleValue(), (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
 	}
 
 	@Override
 	public IMatrix divides(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaFloatMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
-				DoubleVector vc = va.div(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
 	}
 
 	@Override
 	public IMatrix plus(final Double val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.add(val);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
-		return nm;
+		return applyScalarOp(val, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
 	}
 
 	@Override
 	public IMatrix plus(final Integer val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		double dval = val.doubleValue();
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.add(dval);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + dval; }
-		return nm;
+		return applyScalarOp(val.doubleValue(), (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
 	}
 
 	@Override
 	public IMatrix minus(final Double val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.sub(val);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
-		return nm;
+		return applyScalarOp(val, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
 	}
 
 	@Override
 	public IMatrix minus(final Integer val) throws GamaRuntimeException {
-		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		double dval = val.doubleValue();
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
-			DoubleVector vc = va.sub(dval);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - dval; }
-		return nm;
+		return applyScalarOp(val.doubleValue(), (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
 	}
 
 	@Override

--- a/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
@@ -442,62 +442,102 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 
 	@Override
 	public IMatrix plus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
+		final GamaFloatMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix times(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
+		final GamaFloatMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix minus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
+		final GamaFloatMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix times(final Double val) throws GamaRuntimeException {
-		return applyScalarOp(val, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix times(final Integer val) throws GamaRuntimeException {
-		return applyScalarOp(val.doubleValue(), (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix divides(final Double val) throws GamaRuntimeException {
-		return applyScalarOp(val, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix divides(final Integer val) throws GamaRuntimeException {
-		return applyScalarOp(val.doubleValue(), (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix divides(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
+		final GamaFloatMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix plus(final Double val) throws GamaRuntimeException {
-		return applyScalarOp(val, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix plus(final Integer val) throws GamaRuntimeException {
-		return applyScalarOp(val.doubleValue(), (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix minus(final Double val) throws GamaRuntimeException {
-		return applyScalarOp(val, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
+		return nm;
 	}
 
 	@Override
 	public IMatrix minus(final Integer val) throws GamaRuntimeException {
-		return applyScalarOp(val.doubleValue(), (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
+		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
+		return nm;
 	}
 
 	@Override

--- a/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java
@@ -14,7 +14,12 @@ import static org.locationtech.jts.index.quadtree.IntervalSize.isZeroWidth;
 
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
+
 import java.util.List;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorSpecies;
+
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.locationtech.jts.index.quadtree.IntervalSize;
@@ -440,7 +445,15 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 		final GamaFloatMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
+				DoubleVector vc = va.add(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -451,7 +464,15 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 		final GamaFloatMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
+				DoubleVector vc = va.mul(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -462,7 +483,15 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 		final GamaFloatMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
+				DoubleVector vc = va.sub(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -471,28 +500,58 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 	@Override
 	public IMatrix times(final Double val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.mul(val);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix times(final Integer val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
+		double dval = val.doubleValue();
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.mul(dval);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * dval; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix divides(final Double val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.div(val);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix divides(final Integer val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / val; }
+		double dval = val.doubleValue();
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.div(dval);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / dval; }
 		return nm;
 	}
 
@@ -501,7 +560,15 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 		final GamaFloatMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+				DoubleVector vb = DoubleVector.fromArray(SPECIES, matb.matrix, i);
+				DoubleVector vc = va.div(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -510,28 +577,58 @@ public class GamaFloatMatrix extends GamaMatrix<Double> implements IImageProvide
 	@Override
 	public IMatrix plus(final Double val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.add(val);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix plus(final Integer val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
+		double dval = val.doubleValue();
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.add(dval);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + dval; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix minus(final Double val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.sub(val);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
 		return nm;
 	}
 
 	@Override
 	public IMatrix minus(final Integer val) throws GamaRuntimeException {
 		final GamaFloatMatrix nm = new GamaFloatMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
+		double dval = val.doubleValue();
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			DoubleVector va = DoubleVector.fromArray(SPECIES, matrix, i);
+			DoubleVector vc = va.sub(dval);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - dval; }
 		return nm;
 	}
 

--- a/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
@@ -491,17 +491,35 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 
 	@Override
 	public IMatrix plus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
+		final GamaIntMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix times(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
+		final GamaIntMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
 	public IMatrix minus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
+		final GamaIntMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
@@ -515,15 +533,7 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix times(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		int ival = val;
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-			IntVector vc = va.mul(ival);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * ival; }
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
 		return nm;
 	}
 
@@ -545,7 +555,13 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 
 	@Override
 	public IMatrix divides(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		return applyMatrixOp(scope, other, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
+		final GamaIntMatrix matb = from(scope, other);
+		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
+			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
+			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
+			return nm;
+		}
+		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
 	}
 
 	@Override
@@ -559,15 +575,7 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix plus(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		int ival = val;
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-			IntVector vc = va.add(ival);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + ival; }
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
 		return nm;
 	}
 
@@ -582,15 +590,7 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix minus(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		int ival = val;
-		int i = 0;
-		int upperBound = SPECIES.loopBound(matrix.length);
-		for (; i < upperBound; i += SPECIES.length()) {
-			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-			IntVector vc = va.sub(ival);
-			vc.intoArray(nm.matrix, i);
-		}
-		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - ival; }
+		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
 		return nm;
 	}
 

--- a/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
@@ -491,59 +491,17 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 
 	@Override
 	public IMatrix plus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaIntMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
-				IntVector vc = va.add(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a + b, jdk.incubator.vector.VectorOperators.ADD);
 	}
 
 	@Override
 	public IMatrix times(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaIntMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
-				IntVector vc = va.mul(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a * b, jdk.incubator.vector.VectorOperators.MUL);
 	}
 
 	@Override
 	public IMatrix minus(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaIntMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
-				IntVector vc = va.sub(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a - b, jdk.incubator.vector.VectorOperators.SUB);
 	}
 
 	@Override
@@ -587,21 +545,7 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 
 	@Override
 	public IMatrix divides(final IScope scope, final IMatrix other) throws GamaRuntimeException {
-		final GamaIntMatrix matb = from(scope, other);
-		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
-			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			int i = 0;
-			int upperBound = SPECIES.loopBound(matrix.length);
-			for (; i < upperBound; i += SPECIES.length()) {
-				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
-				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
-				IntVector vc = va.div(vb);
-				vc.intoArray(nm.matrix, i);
-			}
-			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
-			return nm;
-		}
-		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		return applyMatrixOp(scope, other, (a, b) -> a / b, jdk.incubator.vector.VectorOperators.DIV);
 	}
 
 	@Override

--- a/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
+++ b/gama.core/src/gama/core/util/matrix/GamaIntMatrix.java
@@ -12,7 +12,12 @@ package gama.core.util.matrix;
 
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
+
 import java.util.List;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorSpecies;
+
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -489,7 +494,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 		final GamaIntMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
+				IntVector vc = va.add(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -500,7 +513,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 		final GamaIntMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
+				IntVector vc = va.mul(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -511,7 +532,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 		final GamaIntMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
+				IntVector vc = va.sub(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -528,7 +557,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix times(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * val; }
+		int ival = val;
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+			IntVector vc = va.mul(ival);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] * ival; }
 		return nm;
 	}
 
@@ -553,7 +590,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 		final GamaIntMatrix matb = from(scope, other);
 		if (matb != null && this.numCols == matb.numCols && this.numRows == matb.numRows) {
 			final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-			for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
+			int i = 0;
+			int upperBound = SPECIES.loopBound(matrix.length);
+			for (; i < upperBound; i += SPECIES.length()) {
+				IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+				IntVector vb = IntVector.fromArray(SPECIES, matb.matrix, i);
+				IntVector vc = va.div(vb);
+				vc.intoArray(nm.matrix, i);
+			}
+			for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] / matb.matrix[i]; }
 			return nm;
 		}
 		throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
@@ -570,7 +615,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix plus(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + val; }
+		int ival = val;
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+			IntVector vc = va.add(ival);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] + ival; }
 		return nm;
 	}
 
@@ -585,7 +638,15 @@ public class GamaIntMatrix extends GamaMatrix<Integer> implements IImageProvider
 	@Override
 	public IMatrix minus(final Integer val) throws GamaRuntimeException {
 		final GamaIntMatrix nm = new GamaIntMatrix(this.numCols, this.numRows);
-		for (int i = 0; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - val; }
+		int ival = val;
+		int i = 0;
+		int upperBound = SPECIES.loopBound(matrix.length);
+		for (; i < upperBound; i += SPECIES.length()) {
+			IntVector va = IntVector.fromArray(SPECIES, matrix, i);
+			IntVector vc = va.sub(ival);
+			vc.intoArray(nm.matrix, i);
+		}
+		for (; i < matrix.length; i++) { nm.matrix[i] = matrix[i] - ival; }
 		return nm;
 	}
 

--- a/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
+++ b/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
@@ -10,11 +10,14 @@
  ********************************************************************************************************/
 package gama.extension.maths.matrix;
 
+import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.exception.DimensionMismatchException;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.EigenDecomposition;
 import org.apache.commons.math3.linear.LUDecomposition;
-import org.apache.commons.math3.linear.RealMatrix;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorSpecies;
 
 import gama.annotations.doc;
 import gama.annotations.example;
@@ -41,6 +44,9 @@ import gama.core.util.matrix.GamaIntMatrix;
  * The Class MatrixOperators.
  */
 public class MatrixOperators {
+
+	private static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_PREFERRED;
+
 
 	/**
 	 * Matrix multiplication.
@@ -70,12 +76,68 @@ public class MatrixOperators {
 	@test ("matrix([[1,1],[1,2]]) . matrix([[1,1],[1,2]]) = matrix([[2,3],[3,5]])")
 	public static IMatrix matrixMultiplication(final IScope scope, final IMatrix a, final IMatrix b)
 			throws GamaRuntimeException {
-		try {
-			if (a instanceof GamaIntMatrix && b instanceof GamaIntMatrix)
-				return toGamaIntMatrix(getRealMatrix(a).multiply(getRealMatrix(b)));
-			return toGamaFloatMatrix(getRealMatrix(a).multiply(getRealMatrix(b)));
-		} catch (final DimensionMismatchException e) {
+		int aRows = a.getRows(scope);
+		int aCols = a.getCols(scope);
+		int bRows = b.getRows(scope);
+		int bCols = b.getCols(scope);
+
+		if (aCols != bRows) {
 			throw GamaRuntimeException.error(" The dimensions of the matrices do not correspond", scope);
+		}
+
+		boolean isInt = a instanceof GamaIntMatrix && b instanceof GamaIntMatrix;
+
+		double[] aData = new double[aRows * aCols];
+		for (int i = 0; i < aRows; i++) {
+			for (int j = 0; j < aCols; j++) {
+				aData[i * aCols + j] = Cast.asFloat(scope, a.get(scope, j, i));
+			}
+		}
+
+		double[] bTransposedData = new double[bRows * bCols];
+		for (int i = 0; i < bCols; i++) {
+			for (int j = 0; j < bRows; j++) {
+				bTransposedData[i * bRows + j] = Cast.asFloat(scope, b.get(scope, i, j));
+			}
+		}
+
+		double[] cData = new double[aRows * bCols];
+
+		int upperBound = SPECIES.loopBound(aCols);
+		for (int i = 0; i < aRows; i++) {
+			for (int j = 0; j < bCols; j++) {
+				double sum = 0;
+				int k = 0;
+				DoubleVector sumVector = DoubleVector.zero(SPECIES);
+				for (; k < upperBound; k += SPECIES.length()) {
+					DoubleVector va = DoubleVector.fromArray(SPECIES, aData, i * aCols + k);
+					DoubleVector vb = DoubleVector.fromArray(SPECIES, bTransposedData, j * bRows + k);
+					sumVector = va.fma(vb, sumVector);
+				}
+				sum += sumVector.reduceLanes(jdk.incubator.vector.VectorOperators.ADD);
+				for (; k < aCols; k++) {
+					sum += aData[i * aCols + k] * bTransposedData[j * bRows + k];
+				}
+				cData[i * bCols + j] = sum;
+			}
+		}
+
+		if (isInt) {
+			GamaIntMatrix result = (GamaIntMatrix) GamaMatrixFactory.createIntMatrix(bCols, aRows);
+			for (int i = 0; i < aRows; i++) {
+				for (int j = 0; j < bCols; j++) {
+					result.set(scope, j, i, (int) cData[i * bCols + j]);
+				}
+			}
+			return result;
+		} else {
+			IMatrix result = GamaMatrixFactory.createFloatMatrix(bCols, aRows);
+			for (int i = 0; i < aRows; i++) {
+				for (int j = 0; j < bCols; j++) {
+					result.set(scope, j, i, cData[i * bCols + j]);
+				}
+			}
+			return result;
 		}
 	}
 

--- a/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
+++ b/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
@@ -74,8 +74,7 @@ public class MatrixOperators {
 					examples = @example (
 							value = "matrix([[1,1],[1,2]]) . matrix([[1,1],[1,2]])",
 							equals = "matrix([[2,3],[3,5]])")))
-	@test ("matrix([[1,1],[1,2]]) . matrix([[1,1],[1,2]]) = matrix([[2,3],[3,5]])")
-	public static IMatrix matrixMultiplication(final IScope scope, final IMatrix a, final IMatrix b)
+	@test ("matrix([[1,1],[1,2]]) . matrix([[1,1],[1,2]]) = matrix([[2,3],[3,5]])")	public static IMatrix matrixMultiplication(final IScope scope, final IMatrix a, final IMatrix b)
 			throws GamaRuntimeException {
 		int aRows = a.getRows(scope);
 		int aCols = a.getCols(scope);

--- a/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
+++ b/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
@@ -87,22 +87,35 @@ public class MatrixOperators {
 
 		boolean isInt = a instanceof GamaIntMatrix && b instanceof GamaIntMatrix;
 
-		double[] aData = new double[aRows * aCols];
-		for (int i = 0; i < aRows; i++) {
-			for (int j = 0; j < aCols; j++) {
-				aData[i * aCols + j] = Cast.asFloat(scope, a.get(scope, j, i));
+		double[] aData = extractMatrixData(scope, a, aRows, aCols);
+		double[] bTransposedData = extractTransposedMatrixData(scope, b, bRows, bCols);
+		double[] cData = computeMatrixProduct(aData, bTransposedData, aRows, aCols, bCols);
+
+		return createResultMatrix(scope, cData, aRows, bCols, isInt);
+	}
+
+	private static double[] extractMatrixData(final IScope scope, final IMatrix a, int rows, int cols) {
+		double[] data = new double[rows * cols];
+		for (int i = 0; i < rows; i++) {
+			for (int j = 0; j < cols; j++) {
+				data[i * cols + j] = Cast.asFloat(scope, a.get(scope, j, i));
 			}
 		}
+		return data;
+	}
 
-		double[] bTransposedData = new double[bRows * bCols];
-		for (int i = 0; i < bCols; i++) {
-			for (int j = 0; j < bRows; j++) {
-				bTransposedData[i * bRows + j] = Cast.asFloat(scope, b.get(scope, i, j));
+	private static double[] extractTransposedMatrixData(final IScope scope, final IMatrix b, int rows, int cols) {
+		double[] transposedData = new double[rows * cols];
+		for (int i = 0; i < cols; i++) {
+			for (int j = 0; j < rows; j++) {
+				transposedData[i * rows + j] = Cast.asFloat(scope, b.get(scope, i, j));
 			}
 		}
+		return transposedData;
+	}
 
+	private static double[] computeMatrixProduct(double[] aData, double[] bTransposedData, int aRows, int aCols, int bCols) {
 		double[] cData = new double[aRows * bCols];
-
 		int upperBound = SPECIES.loopBound(aCols);
 		for (int i = 0; i < aRows; i++) {
 			for (int j = 0; j < bCols; j++) {
@@ -111,30 +124,33 @@ public class MatrixOperators {
 				DoubleVector sumVector = DoubleVector.zero(SPECIES);
 				for (; k < upperBound; k += SPECIES.length()) {
 					DoubleVector va = DoubleVector.fromArray(SPECIES, aData, i * aCols + k);
-					DoubleVector vb = DoubleVector.fromArray(SPECIES, bTransposedData, j * bRows + k);
+					DoubleVector vb = DoubleVector.fromArray(SPECIES, bTransposedData, j * aCols + k);
 					sumVector = va.fma(vb, sumVector);
 				}
 				sum += sumVector.reduceLanes(jdk.incubator.vector.VectorOperators.ADD);
 				for (; k < aCols; k++) {
-					sum += aData[i * aCols + k] * bTransposedData[j * bRows + k];
+					sum += aData[i * aCols + k] * bTransposedData[j * aCols + k];
 				}
 				cData[i * bCols + j] = sum;
 			}
 		}
+		return cData;
+	}
 
+	private static IMatrix createResultMatrix(final IScope scope, double[] cData, int rows, int cols, boolean isInt) {
 		if (isInt) {
-			GamaIntMatrix result = (GamaIntMatrix) GamaMatrixFactory.createIntMatrix(bCols, aRows);
-			for (int i = 0; i < aRows; i++) {
-				for (int j = 0; j < bCols; j++) {
-					result.set(scope, j, i, (int) cData[i * bCols + j]);
+			GamaIntMatrix result = (GamaIntMatrix) GamaMatrixFactory.createIntMatrix(cols, rows);
+			for (int i = 0; i < rows; i++) {
+				for (int j = 0; j < cols; j++) {
+					result.set(scope, j, i, (int) cData[i * cols + j]);
 				}
 			}
 			return result;
 		} else {
-			IMatrix result = GamaMatrixFactory.createFloatMatrix(bCols, aRows);
-			for (int i = 0; i < aRows; i++) {
-				for (int j = 0; j < bCols; j++) {
-					result.set(scope, j, i, cData[i * bCols + j]);
+			IMatrix result = GamaMatrixFactory.createFloatMatrix(cols, rows);
+			for (int i = 0; i < rows; i++) {
+				for (int j = 0; j < cols; j++) {
+					result.set(scope, j, i, cData[i * cols + j]);
 				}
 			}
 			return result;

--- a/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
+++ b/gama.extension.maths/src/gama/extension/maths/matrix/MatrixOperators.java
@@ -10,14 +10,15 @@
  ********************************************************************************************************/
 package gama.extension.maths.matrix;
 
-import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.exception.DimensionMismatchException;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.EigenDecomposition;
 import org.apache.commons.math3.linear.LUDecomposition;
+import org.apache.commons.math3.linear.RealMatrix;
 
 import jdk.incubator.vector.DoubleVector;
 import jdk.incubator.vector.VectorSpecies;
+
 
 import gama.annotations.doc;
 import gama.annotations.example;
@@ -89,9 +90,13 @@ public class MatrixOperators {
 
 		double[] aData = extractMatrixData(scope, a, aRows, aCols);
 		double[] bTransposedData = extractTransposedMatrixData(scope, b, bRows, bCols);
-		double[] cData = computeMatrixProduct(aData, bTransposedData, aRows, aCols, bCols);
+		double[] cData = computeMatrixProduct(aData, bTransposedData, new int[]{aRows, aCols, bCols});
 
-		return createResultMatrix(scope, cData, aRows, bCols, isInt);
+		if (isInt) {
+			return createIntResultMatrix(scope, cData, aRows, bCols);
+		} else {
+			return createFloatResultMatrix(scope, cData, aRows, bCols);
+		}
 	}
 
 	private static double[] extractMatrixData(final IScope scope, final IMatrix a, int rows, int cols) {
@@ -114,7 +119,10 @@ public class MatrixOperators {
 		return transposedData;
 	}
 
-	private static double[] computeMatrixProduct(double[] aData, double[] bTransposedData, int aRows, int aCols, int bCols) {
+	private static double[] computeMatrixProduct(double[] aData, double[] bTransposedData, int[] dims) {
+		int aRows = dims[0];
+		int aCols = dims[1];
+		int bCols = dims[2];
 		double[] cData = new double[aRows * bCols];
 		int upperBound = SPECIES.loopBound(aCols);
 		for (int i = 0; i < aRows; i++) {
@@ -137,24 +145,24 @@ public class MatrixOperators {
 		return cData;
 	}
 
-	private static IMatrix createResultMatrix(final IScope scope, double[] cData, int rows, int cols, boolean isInt) {
-		if (isInt) {
-			GamaIntMatrix result = (GamaIntMatrix) GamaMatrixFactory.createIntMatrix(cols, rows);
-			for (int i = 0; i < rows; i++) {
-				for (int j = 0; j < cols; j++) {
-					result.set(scope, j, i, (int) cData[i * cols + j]);
-				}
+	private static GamaIntMatrix createIntResultMatrix(final IScope scope, double[] cData, int rows, int cols) {
+		GamaIntMatrix result = (GamaIntMatrix) GamaMatrixFactory.createIntMatrix(cols, rows);
+		for (int i = 0; i < rows; i++) {
+			for (int j = 0; j < cols; j++) {
+				result.set(scope, j, i, (int) cData[i * cols + j]);
 			}
-			return result;
-		} else {
-			IMatrix result = GamaMatrixFactory.createFloatMatrix(cols, rows);
-			for (int i = 0; i < rows; i++) {
-				for (int j = 0; j < cols; j++) {
-					result.set(scope, j, i, cData[i * cols + j]);
-				}
-			}
-			return result;
 		}
+		return result;
+	}
+
+	private static IMatrix createFloatResultMatrix(final IScope scope, double[] cData, int rows, int cols) {
+		IMatrix result = GamaMatrixFactory.createFloatMatrix(cols, rows);
+		for (int i = 0; i < rows; i++) {
+			for (int j = 0; j < cols; j++) {
+				result.set(scope, j, i, cData[i * cols + j]);
+			}
+		}
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
This PR modifies matrix classes in `gama.core` (`GamaFloatMatrix`, `GamaIntMatrix`) and math operators in `gama.extension.maths` to heavily utilize the Java Vector API (`jdk.incubator.vector`) for SIMD parallelization. This answers issue #724 and relates to PR #1122 by directly addressing the Vector API option.

---
*PR created automatically by Jules for task [8573954757749232640](https://jules.google.com/task/8573954757749232640) started by @AlexisDrogoul*