### PR TITLE
Optimize Containers.toIMap to avoid temporary list allocations

### DIFF
--- a/gama.core/src/gama/gaml/operators/Containers.java
+++ b/gama.core/src/gama/gaml/operators/Containers.java
@@ -150,11 +150,11 @@ public class Containers {
 	 */
 	public static <T, K, U> Collector<T, ?, IMap<K, U>> toIMap(final Function<? super T, ? extends K> keyMapper,
 			final Function<? super T, ? extends U> valueMapper, final IType keyType, final IType valueType) {
-		return Collectors.collectingAndThen(Collectors.toList(), list -> {
-			IMap<K, U> result = GamaMapFactory.create(keyType, valueType);
-			for (T item : list) { result.put(keyMapper.apply(item), valueMapper.apply(item)); }
-			return result;
-		});
+		return Collector.of(() -> GamaMapFactory.<K, U>create(keyType, valueType),
+				(result, item) -> result.put(keyMapper.apply(item), valueMapper.apply(item)), (left, right) -> {
+					left.putAll(right);
+					return left;
+				});
 
 	}
 

--- a/gama.core/src/gama/gaml/operators/Containers.java
+++ b/gama.core/src/gama/gaml/operators/Containers.java
@@ -150,7 +150,7 @@ public class Containers {
 	 */
 	public static <T, K, U> Collector<T, ?, IMap<K, U>> toIMap(final Function<? super T, ? extends K> keyMapper,
 			final Function<? super T, ? extends U> valueMapper, final IType keyType, final IType valueType) {
-		return Collector.of(() -> GamaMapFactory.<K, U>create(keyType, valueType),
+		return Collector.of(() -> GamaMapFactory.create(keyType, valueType),
 				(result, item) -> result.put(keyMapper.apply(item), valueMapper.apply(item)), (left, right) -> {
 					left.putAll(right);
 					return left;


### PR DESCRIPTION
## Summary
- replaces `Collectors.collectingAndThen(Collectors.toList(), ...)` in `Containers.toIMap(...)` with a direct `Collector.of(...)` into `IMap`
- removes the intermediate list materialization and the second pass over elements
- keeps semantics unchanged for `index_by` and `as_map` operators that rely on this collector

## Why this one first
This is a high-impact, low-effort optimization: `toIMap` sits on the path of container-to-map operators (`index_by`, `as_map`) and can be hit frequently in models with large collections. The change is isolated, behavior-preserving, and reduces both CPU and memory churn.

## 10 identified performance improvements
1. **(Done in this PR)** `gama.core/src/gama/gaml/operators/Containers.java`: collect directly into `IMap` in `toIMap` (remove intermediate `List`).
2. `gama.core/src/gama/gaml/skills/PathMovementHelper.java`: avoid repeated `graph.edgeSet().size()` calls inside movement init; cache once per invocation.
3. `gama.core/src/gama/core/topology/graph/GraphTopology.java`: same repeated `edgeSet().size()` pattern; cache once and reuse in distance heuristics.
4. `gama.core/src/gama/gaml/skills/PathMovementHelper.java` + `gama.core/src/gama/core/topology/graph/GraphTopology.java`: extract and share nearest-edge heuristic to avoid duplicated branching and repeated topology lookups.
5. `gama.core/src/gama/core/util/matrix/GamaObjectMatrix.java`: remove expensive `hashCode()` recomputation on mutable matrix (TODO already flags performance concern).
6. `gama.core/src/gama/core/util/matrix/GamaIntMatrix.java`: same `hashCode()` concern (TODO present).
7. `gama.core/src/gama/core/util/matrix/GamaFloatMatrix.java`: same `hashCode()` concern (TODO present).
8. `gama.core/src/gama/gaml/skills/PathMovementHelper.java`: replace `edges.indexOf(line)` in path init with direct tracked index to avoid extra O(n) scan after nearest-edge search.
9. `gama.core/src/gama/gaml/operators/Containers.java`: audit stream-heavy container operators (`collect`, `group_by`, `sort_by`) for avoidable boxing/lambda allocations in tight loops.
10. `gama.core/src/gama/core/agent/GamlAgent.java`: cache micro-population variable detection metadata to avoid repeated species var lookups during micro-population discovery.

## Notes
I could not run a Maven compile in this environment because `mvn` is not installed here.
