### PR TITLE
[feat] Add gama.server_command extension point

### DIFF
--- a/gama.api/plugin.xml
+++ b/gama.api/plugin.xml
@@ -11,6 +11,7 @@
    <extension-point id="gama.experiment" name="Implementations of IExperimentAgent" schema="schema/gama.experiment.exsd"/>
    <extension-point id="gama.constants" name="Implementations of IConstantsSupplier" schema="schema/gama.constants.exsd"/>
    <extension-point id="gama.metadata" name="Implementations of IGamaFileMetaData" schema="schema/gama.metadata.exsd"/>
+   <extension-point id="gama.server_command" name="Implementations of ISocketCommand" schema="schema/gama.server_command.exsd"/>
    <extension
          point="gaml.extension">
    </extension>

--- a/gama.api/schema/gama.server_command.exsd
+++ b/gama.api/schema/gama.server_command.exsd
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="gama.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="gama.core" id="gama.server_command" name="Implementations of ISocketCommand"/>
+      </appinfo>
+      <documentation>
+         Allows plug-in developers to register new gama-server commands (implementations of ISocketCommand), so that the WebSocket protocol of both the headless and GUI servers can be extended with new command types (e.g. &quot;stream&quot;).
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="command"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="command">
+      <complexType>
+         <attribute name="type" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The keyword identifying the command in the JSON &apos;type&apos; field sent by clients (e.g. &quot;stream&quot;).
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Class that implements ISocketCommand in the plugin.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":gama.api.utils.server.ISocketCommand"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         &lt;extension point=&quot;gama.server_command&quot;&gt;
+   &lt;command type=&quot;stream&quot; class=&quot;gama.extension.streaming.StreamCommand&quot;/&gt;
+&lt;/extension&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         see ISocketCommand
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/gama.api/src/gama/api/additions/GamaBundleLoader.java
+++ b/gama.api/src/gama/api/additions/GamaBundleLoader.java
@@ -43,6 +43,8 @@ import gama.api.additions.delegates.IEventLayerDelegate;
 import gama.api.additions.delegates.ISaveDelegate;
 import gama.api.additions.registries.GamaAdditionRegistry;
 import gama.api.gaml.GAML;
+import gama.api.utils.server.CommandExecutor;
+import gama.api.utils.server.ISocketCommand;
 import gama.api.gaml.types.Types;
 import gama.api.kernel.GamaMetaModel;
 import gama.api.runtime.SystemInfo;
@@ -184,6 +186,9 @@ public class GamaBundleLoader {
 
 	/** The Constant METADATA_EXTENSION. */
 	public static final String METADATA_EXTENSION = "gama.metadata";
+
+	/** The server command extension. Allows plug-ins to register new gama-server (WebSocket) commands. */
+	public static final String SERVER_COMMAND_EXTENSION = "gama.server_command";
 
 	/** The regular models layout. */
 	public static final String REGULAR_MODELS_LAYOUT = "models";
@@ -381,6 +386,14 @@ public class GamaBundleLoader {
 					ERROR("Error in loading extensions to 'metadata'. ", e);
 				}
 				try {
+					TIMER_WITH_EXCEPTIONS(BANNER_CATEGORY.GAML, "Loading extensions to 'server_command'", "completed in",
+							() -> {
+								loadServerCommandExt(registry);
+							});
+				} catch (RuntimeException e) {
+					ERROR("Error in loading extensions to 'server_command'. ", e);
+				}
+				try {
 					TIMER_WITH_EXCEPTIONS(BANNER_CATEGORY.GAML, "Gathering built-in models", "completed in",
 							() -> { loadModels(registry); });
 				} catch (RuntimeException e) {
@@ -550,6 +563,33 @@ public class GamaBundleLoader {
 				// We do not systematically exit in case of additional plugins failing to load, so as to
 				// give the platform a chance to execute even in case of errors (to save files, to
 				// remove offending plugins, etc.)
+			}
+		}
+	}
+
+	/**
+	 * Loads server command extensions from registered plugins. This method discovers all {@link ISocketCommand}
+	 * implementations contributed through the {@code gama.server_command} extension point and registers them on
+	 * {@link CommandExecutor}, making them available to both the GUI and the headless gama-server.
+	 *
+	 * <p>
+	 * Each contribution associates a command keyword (the JSON {@code type} field sent by clients, e.g. {@code "stream"})
+	 * with a class implementing {@link ISocketCommand}.
+	 *
+	 * @param registry
+	 *            the Eclipse extension registry containing plugin contributions
+	 */
+	private static void loadServerCommandExt(final IExtensionRegistry registry) {
+		for (final IConfigurationElement e : registry.getConfigurationElementsFor(SERVER_COMMAND_EXTENSION)) {
+			try {
+				final String type = e.getAttribute("type");
+				final ISocketCommand command = (ISocketCommand) e.createExecutableExtension("class");
+				CommandExecutor.registerContributedCommand(type, command);
+			} catch (final Exception e1) {
+				ERROR("Error in loading server command from "
+						+ e.getDeclaringExtension().getContributor().getName(), e1);
+				// We do not systematically exit in case of additional plugins failing to load, so as to
+				// give the platform a chance to execute even in case of errors.
 			}
 		}
 	}

--- a/gama.api/src/gama/api/utils/server/CommandExecutor.java
+++ b/gama.api/src/gama/api/utils/server/CommandExecutor.java
@@ -29,8 +29,10 @@ import static gama.api.utils.server.ISocketCommand.VALIDATE;
 import static java.util.Map.entry;
 
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.java_websocket.WebSocket;
@@ -60,6 +62,26 @@ public class CommandExecutor implements ICommandExecuter {
 			entry(UPLOAD, DefaultServerCommands::UPLOAD), entry(ASK, DefaultServerCommands::ASK),
 			entry(VALIDATE, DefaultServerCommands::VALIDATE), entry(DESCRIBE, DefaultServerCommands::DESCRIBE));
 
+	/**
+	 * Commands contributed by plug-ins through the {@code gama.server_command} extension point. Populated by
+	 * {@code GamaBundleLoader} at startup and merged into every {@link CommandExecutor} instance, so that contributed
+	 * commands are available to both the GUI and the headless servers.
+	 */
+	private static final Map<String, ISocketCommand> CONTRIBUTED_COMMANDS = new ConcurrentHashMap<>();
+
+	/**
+	 * Registers a command contributed by a plug-in. Called by {@code GamaBundleLoader} when reading the
+	 * {@code gama.server_command} extension point.
+	 *
+	 * @param type
+	 *            the command keyword (the JSON 'type' field sent by clients)
+	 * @param command
+	 *            the command implementation
+	 */
+	public static void registerContributedCommand(final String type, final ISocketCommand command) {
+		if (type != null && command != null) { CONTRIBUTED_COMMANDS.put(type, command); }
+	}
+
 	/** The commands. */
 	protected final Map<String, ISocketCommand> commands;
 
@@ -77,7 +99,10 @@ public class CommandExecutor implements ICommandExecuter {
 	 */
 
 	public CommandExecutor() {
-		commands = GAMA.getGui().getServerCommands();
+		// Copy into a mutable map (some IGui implementations return an immutable/shared map) and merge the commands
+		// contributed by plug-ins through the 'gama.server_command' extension point.
+		commands = new HashMap<>(GAMA.getGui().getServerCommands());
+		commands.putAll(CONTRIBUTED_COMMANDS);
 		commandQueue = new LinkedBlockingQueue<>();
 	}
 


### PR DESCRIPTION
Adds a new Eclipse extension point so plug-ins can contribute gama-server WebSocket commands without editing core. GamaBundleLoader discovers ISocketCommand contributions at startup and CommandExecutor merges them into every server instance, reaching both the GUI and headless runtimes.

- Cherry picked from #1107 