### PR TITLE
Fix #1131: make powertest unit test mathematically robust

### DIFF
--- a/gama.extension.stats/tests/Statistical Tests/models/Stats Sim Tests.experiment
+++ b/gama.extension.stats/tests/Statistical Tests/models/Stats Sim Tests.experiment
@@ -21,14 +21,10 @@ experiment "Tests Stockanalysis" type: test {
 	}
 	
 	test powertest {
-		
-		int nbrep <- power_test(data,0.95,0.80,0.05);
-		assert nbrep<=length(data);
 		list data_mult <- range(50) accumulate (data);
-		int nbrep_obsmult <- power_test(data_mult,0.95,0.80,0.1);
-		write length(data_mult);
-		assert nbrep_obsmult<nbrep;
-		
+		int nbrep_01 <- power_test(data_mult,0.95,0.80,0.01);
+		int nbrep_10 <- power_test(data_mult,0.95,0.80,0.1);
+		assert nbrep_10 < nbrep_01;
 	}
 	
 }

--- a/gama.extension.stats/tests/Statistical Tests/models/Stats Sim Tests.experiment
+++ b/gama.extension.stats/tests/Statistical Tests/models/Stats Sim Tests.experiment
@@ -1,4 +1,4 @@
-experiment "Tests Stockanalysis" type: test {
+experiment "Tests Stochanalysis" type: test {
 	
 	list<float> data <- [];
 	


### PR DESCRIPTION
fix #1131 @lesquoyb 

I don't know why I was comparing two different datasets for .01 and .10 effect sizes, sorry for the mistake. 