### PR TITLE
Fix synchronized output affecting other experiments (#1158)

### DIFF
--- a/gama.api/src/gama/api/ui/IOutputManager.java
+++ b/gama.api/src/gama/api/ui/IOutputManager.java
@@ -142,6 +142,13 @@ public interface IOutputManager extends IStepable, Iterable<IOutput> {
 	boolean isEmpty();
 
 	/**
+	 * Checks if the output manager or any of its outputs requires synchronization.
+	 *
+	 * @return true if synchronized
+	 */
+	default boolean isSynchronized() { return false; }
+
+	/**
 	 * For each.
 	 *
 	 * @param action

--- a/gama.core/src/gama/core/experiment/ExperimentAgent.java
+++ b/gama.core/src/gama/core/experiment/ExperimentAgent.java
@@ -409,6 +409,7 @@ public class ExperimentAgent extends GamlAgent implements IExperimentAgent {
 	public boolean init(final IScope scope) {
 		showParameters(scope);
 		GAMA.changeCurrentTopLevelAgent(this, true);
+		GAMA.desynchronizeFrontmostExperiment();
 		scope.getGui().clearErrors(scope);
 		super.init(scope);
 		final IOutputManager outputs = getOutputManager();

--- a/gama.core/src/gama/core/outputs/AbstractOutputManager.java
+++ b/gama.core/src/gama/core/outputs/AbstractOutputManager.java
@@ -299,9 +299,6 @@ public abstract class AbstractOutputManager extends Symbol implements IOutputMan
 	public AbstractOutputManager(final IDescription desc) {
 		super(desc);
 		autosave = desc.getFacetExpr(IKeyword.AUTOSAVE);
-		boolean sync = GamaPreferences.Runtime.CORE_SYNC.getValue() || "true".equals(desc.getLitteral("synchronized"))
-				|| desc.hasFacet(IKeyword.AUTOSAVE) && !"false".equals(desc.getLitteral(IKeyword.AUTOSAVE));
-		if (sync) { GAMA.synchronizeFrontmostExperiment(); }
 	}
 
 	// @Override
@@ -380,7 +377,6 @@ public abstract class AbstractOutputManager extends Symbol implements IOutputMan
 			if (s instanceof LayoutStatement) {
 				layout = (LayoutStatement) s;
 			} else if (s instanceof IOutput o) {
-				if (o.isAutoSave()) { GAMA.synchronizeFrontmostExperiment(); }
 				add(o);
 				o.setUserCreated(false);
 				if (o instanceof LayeredDisplayOutput ldo) { ldo.setIndex(displayIndex++); }
@@ -419,7 +415,22 @@ public abstract class AbstractOutputManager extends Symbol implements IOutputMan
 	}
 
 	@Override
+	public boolean isSynchronized() {
+		if (GamaPreferences.Runtime.CORE_SYNC.getValue()) return true;
+		final IDescription desc = getDescription();
+		if (desc != null) {
+			if ("true".equals(desc.getLitteral("synchronized"))) return true;
+			if (desc.hasFacet(IKeyword.AUTOSAVE) && !"false".equals(desc.getLitteral(IKeyword.AUTOSAVE))) return true;
+		}
+		for (final IOutput o : outputs.values()) {
+			if (o.isAutoSave()) return true;
+		}
+		return false;
+	}
+
+	@Override
 	public boolean init(final IScope scope) {
+		if (isSynchronized()) { GAMA.synchronizeFrontmostExperiment(); }
 		name = scope.getRoot().getName();
 		for (final IOutput output : ImmutableList.copyOf(outputs.values())) { if (!open(scope, output)) return false; }
 		evaluateAutoSave(scope);

--- a/gama.core/src/gama/core/outputs/AbstractOutputManager.java
+++ b/gama.core/src/gama/core/outputs/AbstractOutputManager.java
@@ -416,16 +416,20 @@ public abstract class AbstractOutputManager extends Symbol implements IOutputMan
 
 	@Override
 	public boolean isSynchronized() {
-		if (GamaPreferences.Runtime.CORE_SYNC.getValue()) return true;
+		return GamaPreferences.Runtime.CORE_SYNC.getValue() || isDescriptionSynchronized()
+				|| outputs.values().stream().anyMatch(IOutput::isAutoSave);
+	}
+
+	/**
+	 * Checks if the manager description specifies synchronization or autosave.
+	 *
+	 * @return true if description requires synchronization
+	 */
+	private boolean isDescriptionSynchronized() {
 		final IDescription desc = getDescription();
-		if (desc != null) {
-			if ("true".equals(desc.getLitteral("synchronized"))) return true;
-			if (desc.hasFacet(IKeyword.AUTOSAVE) && !"false".equals(desc.getLitteral(IKeyword.AUTOSAVE))) return true;
-		}
-		for (final IOutput o : outputs.values()) {
-			if (o.isAutoSave()) return true;
-		}
-		return false;
+		if (desc == null) return false;
+		if ("true".equals(desc.getLitteral("synchronized"))) return true;
+		return desc.hasFacet(IKeyword.AUTOSAVE) && !"false".equals(desc.getLitteral(IKeyword.AUTOSAVE));
 	}
 
 	@Override


### PR DESCRIPTION
Fixed issue #1158 where declaring a synchronized output block in one experiment caused other experiments in the same model or subsequent runs to be synchronized as well.

### Changes Made:
1. `AbstractOutputManager`:
   - Removed `GAMA.synchronizeFrontmostExperiment()` from constructor and `setChildren()`. These calls were executing during GAML model compilation/description building, polluting the global `GAMA.isSynchronized` state.
   - Implemented `isSynchronized()` to dynamically check if the output manager requires synchronization (checking preference, `synchronized` facet, `autosave` facet, or child output autosave state).
   - In `init(IScope scope)`, check `if (isSynchronized()) { GAMA.synchronizeFrontmostExperiment(); }`.

2. `IOutputManager`:
   - Added default `boolean isSynchronized()` method.

3. `ExperimentAgent`:
   - Added `GAMA.desynchronizeFrontmostExperiment()` at the start of `init(IScope scope)` so that the synchronization state is reset when a new experiment initializes.

---
*PR created automatically by Jules for task [12624609911769599104](https://jules.google.com/task/12624609911769599104) started by @AlexisDrogoul*