### PR TITLE
Fix models library loading on new workspace (#1181)

### DIFF
--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -136,10 +136,7 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 		if (project == null || !project.exists()) return false;
 		// TODO This one is clearly a hack. Should be replaced by a proper way
 		// to track persistently the closed projects
-		if (!project.isOpen()) {
-			final Location estimated = estimateLocation(project.getLocation());
-			return estimated == location || estimated == Location.Unknown && location == Location.Other;
-		}
+		if (!project.isOpen()) return estimateLocation(project.getLocation()) == location;
 		try {
 			return accepts(project.getDescription());
 		} catch (final CoreException e) {
@@ -186,8 +183,8 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 
 			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
 
-			final String parentPath = new java.io.File(corePath).getParent();
-			if (parentPath != null && projectPath.startsWith(parentPath.replace('\\', '/'))) {
+			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
+			if (parentPath != null && projectPath.startsWith(parentPath)) {
 				return isTest ? Location.Tests : Location.Plugins;
 			}
 		} catch (final Exception e) {

--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -145,25 +145,6 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	}
 
 	/**
-	 * Resolves the core models physical directory path with forward slashes.
-	 */
-	private String getCoreModelsPath() throws IOException, URISyntaxException {
-		final URL oldUrl = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
-		final URL newUrl = FileLocator.toFileURL(oldUrl);
-		final URI resolvedURI = new URI(newUrl.getProtocol(), newUrl.getPath(), null).normalize();
-		return new java.io.File(resolvedURI).getAbsolutePath().replace('\\', '/');
-	}
-
-	/**
-	 * Checks if the path belongs to tutorials or recipes virtual folders.
-	 */
-	private Location checkTutorialOrRecipe(final String pathString) {
-		if (pathString.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/")) return Location.Tutorials;
-		if (pathString.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/")) return Location.Recipes;
-		return null;
-	}
-
-	/**
 	 * Estimate location.
 	 *
 	 * @param location
@@ -173,24 +154,23 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	protected Location estimateLocation(final IPath location) {
 		if (location == null) return Location.Unknown;
 		try {
-			final String pathString = location.toString();
-			final Location specificLoc = checkTutorialOrRecipe(pathString);
-			if (specificLoc != null) return specificLoc;
+			final String locPath = location.toFile().getAbsolutePath().replace('\\', '/');
+			if (locPath.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/")) return Location.Tutorials;
+			if (locPath.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/")) return Location.Recipes;
 
-			final boolean isTest = pathString.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT)
-					|| pathString.contains(GamaBundleLoader.GENERATED_TESTS_LAYOUT);
-			final String corePath = getCoreModelsPath();
-			final String projectPath = location.toFile().getAbsolutePath().replace('\\', '/');
+			final URL oldUrl = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
+			final URL resolvedUrl = FileLocator.toFileURL(oldUrl);
+			final URI uri = new URI(resolvedUrl.getProtocol(), resolvedUrl.getPath(), null).normalize();
+			final String corePath = new java.io.File(uri).getAbsolutePath().replace('\\', '/');
 
-			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
+			final boolean isTest = locPath.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT);
+			if (!isTest && locPath.startsWith(corePath)) return Location.CoreModels;
 
 			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
-			if (parentPath != null && projectPath.startsWith(parentPath)) {
-				return isTest ? Location.Tests : Location.Plugins;
-			}
+			if (parentPath != null && locPath.startsWith(parentPath)) return isTest ? Location.Tests : Location.Plugins;
+
 			return Location.Other;
 		} catch (final Exception e) {
-			e.printStackTrace();
 			return Location.Unknown;
 		}
 	}

--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -145,6 +145,26 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	}
 
 	/**
+	 * Checks if the location matches special layout categories like Tutorials or Recipes.
+	 */
+	private Location checkSpecialLayouts(final IPath location) {
+		final String path = location.toString();
+		if (path.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/")) return Location.Tutorials;
+		if (path.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/")) return Location.Recipes;
+		return null;
+	}
+
+	/**
+	 * Resolves the core models folder path normalized with forward slashes.
+	 */
+	private String getCoreModelsPath() throws Exception {
+		final URL oldUrl = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
+		final URL newUrl = FileLocator.toFileURL(oldUrl);
+		final URI uri = new URI(newUrl.getProtocol(), newUrl.getPath(), null).normalize();
+		return new java.io.File(uri).getAbsolutePath().replace('\\', '/');
+	}
+
+	/**
 	 * Estimate location.
 	 *
 	 * @param location
@@ -153,26 +173,24 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	 */
 	protected Location estimateLocation(final IPath location) {
 		if (location == null) return Location.Unknown;
+		final Location special = checkSpecialLayouts(location);
+		if (special != null) return special;
+
 		try {
-			final String locPath = location.toFile().getAbsolutePath().replace('\\', '/');
-			if (locPath.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/")) return Location.Tutorials;
-			if (locPath.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/")) return Location.Recipes;
+			final String corePath = getCoreModelsPath();
+			final String projectPath = location.toFile().getAbsolutePath().replace('\\', '/');
+			final boolean isTest = location.toString().contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT);
 
-			final URL oldUrl = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
-			final URL resolvedUrl = FileLocator.toFileURL(oldUrl);
-			final URI uri = new URI(resolvedUrl.getProtocol(), resolvedUrl.getPath(), null).normalize();
-			final String corePath = new java.io.File(uri).getAbsolutePath().replace('\\', '/');
-
-			final boolean isTest = locPath.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT);
-			if (!isTest && locPath.startsWith(corePath)) return Location.CoreModels;
+			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
 
 			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
-			if (parentPath != null && locPath.startsWith(parentPath)) return isTest ? Location.Tests : Location.Plugins;
-
-			return Location.Other;
+			if (parentPath != null && projectPath.startsWith(parentPath)) {
+				return isTest ? Location.Tests : Location.Plugins;
+			}
 		} catch (final Exception e) {
 			return Location.Unknown;
 		}
+		return Location.Other;
 	}
 
 	/**

--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -152,26 +152,31 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	 * @return the location
 	 */
 	protected Location estimateLocation(final IPath location) {
+		if (location == null) return Location.Unknown;
 		try {
 			final var old_url = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
 			final var new_url = FileLocator.toFileURL(old_url);
 			// windows URL formating
 			final var resolvedURI = new URI(new_url.getProtocol(), new_url.getPath(), null).normalize();
-			final var urlRep = resolvedURI.toURL();
-			final var osString = location.toOSString();
-			final var isTest = osString.contains(GamaBundleLoader.REGULAR_TESTS_LAYOUT);
-			final var isTutorial = osString.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/");
-			final var isRecipe = osString.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/");
+			final var pathString = location.toString();
+			final var isTest = pathString.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT)
+					|| pathString.contains(GamaBundleLoader.GENERATED_TESTS_LAYOUT);
+			final var isTutorial = pathString.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/");
+			final var isRecipe = pathString.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/");
 			if (isTutorial) return Location.Tutorials;
 			if (isRecipe) return Location.Recipes;
-			if (!isTest && osString.startsWith(urlRep.getPath())) return Location.CoreModels;
-			if (osString
-					.startsWith(urlRep.getPath().replace(GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/", ""))) {
+
+			final String corePath = new java.io.File(resolvedURI).getAbsolutePath().replace('\\', '/');
+			final String projectPath = location.toFile().getAbsolutePath().replace('\\', '/');
+
+			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
+			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
+			if (parentPath != null && projectPath.startsWith(parentPath)) {
 				if (isTest) return Location.Tests;
 				return Location.Plugins;
 			}
 			return Location.Other;
-		} catch (final IOException | URISyntaxException e) {
+		} catch (final Exception e) {
 			e.printStackTrace();
 			return Location.Unknown;
 		}

--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -136,7 +136,10 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 		if (project == null || !project.exists()) return false;
 		// TODO This one is clearly a hack. Should be replaced by a proper way
 		// to track persistently the closed projects
-		if (!project.isOpen()) return estimateLocation(project.getLocation()) == location;
+		if (!project.isOpen()) {
+			final Location estimated = estimateLocation(project.getLocation());
+			return estimated == location || estimated == Location.Unknown && location == Location.Other;
+		}
 		try {
 			return accepts(project.getDescription());
 		} catch (final CoreException e) {
@@ -183,8 +186,8 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 
 			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
 
-			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
-			if (parentPath != null && projectPath.startsWith(parentPath)) {
+			final String parentPath = new java.io.File(corePath).getParent();
+			if (parentPath != null && projectPath.startsWith(parentPath.replace('\\', '/'))) {
 				return isTest ? Location.Tests : Location.Plugins;
 			}
 		} catch (final Exception e) {

--- a/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
+++ b/gama.ui.navigator/src/gama/ui/navigator/view/contents/TopLevelFolder.java
@@ -145,6 +145,25 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	}
 
 	/**
+	 * Resolves the core models physical directory path with forward slashes.
+	 */
+	private String getCoreModelsPath() throws IOException, URISyntaxException {
+		final URL oldUrl = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
+		final URL newUrl = FileLocator.toFileURL(oldUrl);
+		final URI resolvedURI = new URI(newUrl.getProtocol(), newUrl.getPath(), null).normalize();
+		return new java.io.File(resolvedURI).getAbsolutePath().replace('\\', '/');
+	}
+
+	/**
+	 * Checks if the path belongs to tutorials or recipes virtual folders.
+	 */
+	private Location checkTutorialOrRecipe(final String pathString) {
+		if (pathString.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/")) return Location.Tutorials;
+		if (pathString.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/")) return Location.Recipes;
+		return null;
+	}
+
+	/**
 	 * Estimate location.
 	 *
 	 * @param location
@@ -154,26 +173,20 @@ public class TopLevelFolder extends VirtualContent<NavigatorRoot> implements IGa
 	protected Location estimateLocation(final IPath location) {
 		if (location == null) return Location.Unknown;
 		try {
-			final var old_url = new URL("platform:/plugin/" + GamaBundleLoader.CORE_MODELS.getSymbolicName() + "/");
-			final var new_url = FileLocator.toFileURL(old_url);
-			// windows URL formating
-			final var resolvedURI = new URI(new_url.getProtocol(), new_url.getPath(), null).normalize();
-			final var pathString = location.toString();
-			final var isTest = pathString.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT)
-					|| pathString.contains(GamaBundleLoader.GENERATED_TESTS_LAYOUT);
-			final var isTutorial = pathString.contains("/" + GamaBundleLoader.REGULAR_TUTORIALS_LAYOUT + "/");
-			final var isRecipe = pathString.contains("/" + GamaBundleLoader.REGULAR_RECIPES_LAYOUT + "/");
-			if (isTutorial) return Location.Tutorials;
-			if (isRecipe) return Location.Recipes;
+			final String pathString = location.toString();
+			final Location specificLoc = checkTutorialOrRecipe(pathString);
+			if (specificLoc != null) return specificLoc;
 
-			final String corePath = new java.io.File(resolvedURI).getAbsolutePath().replace('\\', '/');
+			final boolean isTest = pathString.contains("/" + GamaBundleLoader.REGULAR_TESTS_LAYOUT)
+					|| pathString.contains(GamaBundleLoader.GENERATED_TESTS_LAYOUT);
+			final String corePath = getCoreModelsPath();
 			final String projectPath = location.toFile().getAbsolutePath().replace('\\', '/');
 
 			if (!isTest && projectPath.startsWith(corePath)) return Location.CoreModels;
+
 			final String parentPath = new java.io.File(corePath).getParent().replace('\\', '/');
 			if (parentPath != null && projectPath.startsWith(parentPath)) {
-				if (isTest) return Location.Tests;
-				return Location.Plugins;
+				return isTest ? Location.Tests : Location.Plugins;
 			}
 			return Location.Other;
 		} catch (final Exception e) {

--- a/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
+++ b/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
@@ -425,6 +425,7 @@ public class WorkspaceModelsManager {
 			@Override
 			public IStatus runInWorkspace(final IProgressMonitor monitor) {
 				// DEBUG.OUT("Asynchronous link of models library...");
+				loadModelsLibrary();
 				GAMA.getGui().refreshNavigator();
 				return GamaBundleLoader.ERRORED ? Status.CANCEL_STATUS : Status.OK_STATUS;
 			}
@@ -479,6 +480,7 @@ public class WorkspaceModelsManager {
 		// DEBUG.OUT("Linking library from bundle " + bundle.getSymbolicName() + " at path " + path);
 		final boolean core = bundle.equals(GamaBundleLoader.CORE_MODELS);
 		final URL fileURL = bundle.getEntry(path);
+		if (fileURL == null) return;
 		File modelsRep = null;
 		try {
 			final URL resolvedFileURL = FileLocator.toFileURL(fileURL);
@@ -490,7 +492,7 @@ public class WorkspaceModelsManager {
 			e1.printStackTrace();
 		}
 
-		final Map<File, IPath> foundProjects = new HashMap<>();
+		final Map<File, IPath> foundProjects = new ConcurrentHashMap<>();
 		findProjects(modelsRep, foundProjects);
 		importBuiltInProjects(bundle, core, tests, foundProjects);
 

--- a/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
+++ b/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
@@ -480,10 +480,7 @@ public class WorkspaceModelsManager {
 		// DEBUG.OUT("Linking library from bundle " + bundle.getSymbolicName() + " at path " + path);
 		final boolean core = bundle.equals(GamaBundleLoader.CORE_MODELS);
 		final URL fileURL = bundle.getEntry(path);
-		if (fileURL == null) {
-			DEBUG.OUT("No models entry '" + path + "' found in bundle " + bundle.getSymbolicName());
-			return;
-		}
+		if (fileURL == null) return;
 		File modelsRep = null;
 		try {
 			final URL resolvedFileURL = FileLocator.toFileURL(fileURL);

--- a/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
+++ b/gama.workspace/src/gama/workspace/manager/WorkspaceModelsManager.java
@@ -480,7 +480,10 @@ public class WorkspaceModelsManager {
 		// DEBUG.OUT("Linking library from bundle " + bundle.getSymbolicName() + " at path " + path);
 		final boolean core = bundle.equals(GamaBundleLoader.CORE_MODELS);
 		final URL fileURL = bundle.getEntry(path);
-		if (fileURL == null) return;
+		if (fileURL == null) {
+			DEBUG.OUT("No models entry '" + path + "' found in bundle " + bundle.getSymbolicName());
+			return;
+		}
 		File modelsRep = null;
 		try {
 			final URL resolvedFileURL = FileLocator.toFileURL(fileURL);

--- a/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
+++ b/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
@@ -1071,9 +1071,9 @@ public class ModelFactory implements IModelFactory {
 		String p = cd.getLitteral(IKeyword.PARENT);
 		// If no parent is defined, we assume it is "agent"
 		if (p == null) { p = IKeyword.OBJECT; }
-		IClassDescription parent = lookupClass(p, cache);
-		if (parent == null) { parent = model.getClassDescription(p); }
-		cd.setParent(parent);
+		IClassDescription parentDesc = lookupClass(p, cache);
+		if (parentDesc == null) { parentDesc = model.getClassDescription(p); }
+		cd.setParent(parentDesc);
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue #1181 where the models library may fail to appear in a new workspace on Windows (and other platforms).

Key fixes:
1. Called `loadModelsLibrary()` inside `WorkspaceModelsManager.linkSampleModelsToWorkspace()` to ensure model projects are loaded when a new workspace is created.
2. Replaced `HashMap` with `ConcurrentHashMap` in `WorkspaceModelsManager.findProjects()` to prevent race conditions during parallel project scanning.
3. Fixed path normalization in `TopLevelFolder.estimateLocation()` to use uniform forward slashes and absolute paths, ensuring correct project classification on Windows.
