### PR TITLE
Fix minimum value of simulation parameter forced to 1 by UI

### DIFF
--- a/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
@@ -98,8 +98,10 @@ public class FloatEditor extends NumberEditor<Double> {
 
 	@Override
 	protected Double normalizeValues() throws GamaRuntimeException {
-		final Double valueToConsider = getOriginalValue() == null ? 0.0 : Cast.asFloat(getScope(), getOriginalValue());
-		currentValue = getOriginalValue() == null ? null : valueToConsider;
+		Object orig = getOriginalValue();
+		if (orig == null && param != null) { orig = param.value(getScope()); }
+		final Double valueToConsider = orig == null ? 0.0 : Cast.asFloat(getScope(), orig);
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 

--- a/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
@@ -98,10 +98,10 @@ public class FloatEditor extends NumberEditor<Double> {
 
 	@Override
 	protected Double normalizeValues() throws GamaRuntimeException {
-		Object orig = getOriginalValue();
-		if (orig == null && param != null) { orig = param.value(getScope()); }
-		final Double valueToConsider = orig == null ? 0.0 : Cast.asFloat(getScope(), orig);
-		currentValue = valueToConsider;
+		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
+		final Double valueToConsider = orig == null ? 0.0 : Cast.asFloat(getScope(), orig);
+		if (getOriginalValue() == null && orig != null) { setOriginalValue(valueToConsider); }
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 
@@ -126,9 +126,9 @@ public class FloatEditor extends NumberEditor<Double> {
 	protected void updateToolbar() {
 		super.updateToolbar();
 		editorToolbar.enable(PLUS,
-				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asFloat(getScope(), getMaxValue())));
+				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asFloat(getScope(), getMaxValue())));
 		editorToolbar.enable(MINUS,
-				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asFloat(getScope(), getMinValue())));
+				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asFloat(getScope(), getMinValue())));
 	}
 
 	@Override

--- a/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/FloatEditor.java
@@ -98,10 +98,16 @@ public class FloatEditor extends NumberEditor<Double> {
 
 	@Override
 	protected Double normalizeValues() throws GamaRuntimeException {
-		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
-		final Double valueToConsider = orig == null ? 0.0 : Cast.asFloat(getScope(), orig);
-		if (getOriginalValue() == null && orig != null) { setOriginalValue(valueToConsider); }
-		currentValue = valueToConsider;
+		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
+
+		if (acceptNull && orig == null) {
+			setOriginalValue(null);
+			currentValue = null;
+			return null;
+		}
+		final Double valueToConsider = orig == null ? 0.0 : Cast.asFloat(getScope(), orig);
+		if (getOriginalValue() == null) { setOriginalValue(valueToConsider); }
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 
@@ -126,9 +132,11 @@ public class FloatEditor extends NumberEditor<Double> {
 	protected void updateToolbar() {
 		super.updateToolbar();
 		editorToolbar.enable(PLUS,
-				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asFloat(getScope(), getMaxValue())));
+				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asFloat(getScope(), getMaxValue())));
+
 		editorToolbar.enable(MINUS,
-				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asFloat(getScope(), getMinValue())));
+				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asFloat(getScope(), getMinValue())));
+
 	}
 
 	@Override

--- a/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
@@ -83,8 +83,10 @@ public class IntEditor extends NumberEditor<Integer> {
 
 	@Override
 	protected Integer normalizeValues() throws GamaRuntimeException {
-		final Integer valueToConsider = getOriginalValue() == null ? 0 : Cast.asInt(getScope(), getOriginalValue());
-		currentValue = getOriginalValue() == null ? null : valueToConsider;
+		Object orig = getOriginalValue();
+		if (orig == null && param != null) { orig = param.value(getScope()); }
+		final Integer valueToConsider = orig == null ? 0 : Cast.asInt(getScope(), orig);
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 

--- a/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
@@ -76,17 +76,17 @@ public class IntEditor extends NumberEditor<Integer> {
 		// Disable + and - if the value is among a set of values
 		if (param.getAmongValue(getScope()) != null) return;
 		editorToolbar.enable(PLUS,
-				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asInt(getScope(), getMaxValue())));
+				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asInt(getScope(), getMaxValue())));
 		editorToolbar.enable(MINUS,
-				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asInt(getScope(), getMinValue())));
+				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asInt(getScope(), getMinValue())));
 	}
 
 	@Override
 	protected Integer normalizeValues() throws GamaRuntimeException {
-		Object orig = getOriginalValue();
-		if (orig == null && param != null) { orig = param.value(getScope()); }
-		final Integer valueToConsider = orig == null ? 0 : Cast.asInt(getScope(), orig);
-		currentValue = valueToConsider;
+		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
+		final Integer valueToConsider = orig == null ? 0 : Cast.asInt(getScope(), orig);
+		if (getOriginalValue() == null && orig != null) { setOriginalValue(valueToConsider); }
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 

--- a/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
+++ b/gama.ui.shared/src/gama/ui/shared/parameters/IntEditor.java
@@ -76,17 +76,25 @@ public class IntEditor extends NumberEditor<Integer> {
 		// Disable + and - if the value is among a set of values
 		if (param.getAmongValue(getScope()) != null) return;
 		editorToolbar.enable(PLUS,
-				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asInt(getScope(), getMaxValue())));
+				param.isDefined() && (getMaxValue() == null || applyPlus() <= Cast.asInt(getScope(), getMaxValue())));
+
 		editorToolbar.enable(MINUS,
-				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asInt(getScope(), getMinValue())));
+				param.isDefined() && (getMinValue() == null || applyMinus() >= Cast.asInt(getScope(), getMinValue())));
+
 	}
 
 	@Override
 	protected Integer normalizeValues() throws GamaRuntimeException {
-		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
-		final Integer valueToConsider = orig == null ? 0 : Cast.asInt(getScope(), orig);
-		if (getOriginalValue() == null && orig != null) { setOriginalValue(valueToConsider); }
-		currentValue = valueToConsider;
+		final Object orig = getOriginalValue() == null && param != null ? param.value(getScope()) : getOriginalValue();
+
+		if (acceptNull && orig == null) {
+			setOriginalValue(null);
+			currentValue = null;
+			return null;
+		}
+		final Integer valueToConsider = orig == null ? 0 : Cast.asInt(getScope(), orig);
+		if (getOriginalValue() == null) { setOriginalValue(valueToConsider); }
+		currentValue = valueToConsider;
 		return valueToConsider;
 	}
 


### PR DESCRIPTION
This change fixes issue #1175 where setting a parameter value to 1 disabled the minus button when min: 0. normalizeValues in IntEditor and FloatEditor now falls back to param.value(getScope()) if originalValue is null so currentValue is properly initialized.
