### PR TITLE
Fix #mouse_click event not being recognised in event layer

### DIFF
--- a/gama.api/src/gama/api/additions/delegates/IEventLayerDelegate.java
+++ b/gama.api/src/gama/api/additions/delegates/IEventLayerDelegate.java
@@ -139,8 +139,8 @@ public interface IEventLayerDelegate {
 					IKeyword.MOUSE_DRAG;
 
 	/** The Constant MOUSE_EVENTS. */
-	Set<String> MOUSE_EVENTS = new HashSet<>(Arrays.asList(MOUSE_UP, MOUSE_DOWN, MOUSE_CLICKED, MOUSE_MOVED,
-			MOUSE_ENTERED, MOUSE_EXITED, MOUSE_MENU, MOUSE_DRAGGED));
+	Set<String> MOUSE_EVENTS = Set.of(MOUSE_UP, MOUSE_DOWN, MOUSE_CLICKED, MOUSE_MOVED, MOUSE_ENTERED, MOUSE_EXITED,
+			MOUSE_MENU, MOUSE_DRAGGED);
 
 	/** The Constant SHIFT_MODIFIER. */
 	@constant (

--- a/gama.api/src/gama/api/additions/delegates/IEventLayerDelegate.java
+++ b/gama.api/src/gama/api/additions/delegates/IEventLayerDelegate.java
@@ -139,8 +139,8 @@ public interface IEventLayerDelegate {
 					IKeyword.MOUSE_DRAG;
 
 	/** The Constant MOUSE_EVENTS. */
-	Set<String> MOUSE_EVENTS = new HashSet<>(
-			Arrays.asList(MOUSE_UP, MOUSE_DOWN, MOUSE_MOVED, MOUSE_ENTERED, MOUSE_EXITED, MOUSE_MENU, MOUSE_DRAGGED));
+	Set<String> MOUSE_EVENTS = new HashSet<>(Arrays.asList(MOUSE_UP, MOUSE_DOWN, MOUSE_CLICKED, MOUSE_MOVED,
+			MOUSE_ENTERED, MOUSE_EXITED, MOUSE_MENU, MOUSE_DRAGGED));
 
 	/** The Constant SHIFT_MODIFIER. */
 	@constant (

--- a/gama.core/src/gama/core/outputs/layers/EventLayerStatement.java
+++ b/gama.core/src/gama/core/outputs/layers/EventLayerStatement.java
@@ -66,7 +66,7 @@ import gama.core.outputs.layers.EventLayerStatement.EventLayerValidator;
 				name = ILayerStatement.Event.TRIGGER,
 				type = { IType.STRING },
 				optional = false,
-				doc = @doc ("the type of event captured: basic events include #mouse_up, #mouse_down, #mouse_move, #mouse_exit, #mouse_enter, #mouse_menu, #mouse_drag, #arrow_down, #arrow_up, #arrow_left, #arrow_right, #escape, #tab, #enter, #page_up, #page_down or a character")),
+				doc = @doc ("the type of event captured: basic events include #mouse_up, #mouse_down, #mouse_click, #mouse_move, #mouse_exit, #mouse_enter, #mouse_menu, #mouse_drag, #arrow_down, #arrow_up, #arrow_left, #arrow_right, #escape, #tab, #enter, #page_up, #page_down or a character")),
 				@facet (
 						name = IKeyword.TYPE,
 						type = IType.STRING,


### PR DESCRIPTION
Fixes issue #1171 where the #mouse_click event keyword was present in autocomplete and documentation constants but was missing from the MOUSE_EVENTS set in IEventLayerDelegate, causing GAML compilation to reject #mouse_click as an invalid event trigger name.

---
*PR created automatically by Jules for task [3020056816865979487](https://jules.google.com/task/3020056816865979487) started by @AlexisDrogoul*