### PR TITLE
Fix issue #1162: handle Class as parent of Species gracefully

### DIFF
--- a/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
+++ b/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
@@ -999,8 +999,10 @@ public class ModelFactory implements IModelFactory {
 		if (parent == null) { parent = model.getSpeciesDescription(parentName); }
 
 		if (parent == null) {
-			speciesDesc.error("Species " + parentName + " is not a valid species or does not exist",
+			speciesDesc.error("Parent '" + parentName + "' is not a valid species or does not exist",
 					IGamlIssue.WRONG_PARENT, IKeyword.PARENT);
+			// Keep the species hierarchy consistent to avoid cascading errors
+			speciesDesc.setParent(GamaMetaModel.getSpeciesDescription(IKeyword.AGENT));
 		} else {
 			speciesDesc.setParent(parent);
 		}

--- a/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
+++ b/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
@@ -987,8 +987,8 @@ public class ModelFactory implements IModelFactory {
 	void parentSpecies(final ISpeciesDescription macro, final ISyntacticElement micro, final IModelDescription model,
 			final Map<String, ITypeDescription> cache) {
 		// Gather the previously created species
-		final ISpeciesDescription speciesDesc = (ISpeciesDescription) cache.get(micro.getName());
-		if (speciesDesc == null || speciesDesc.isExperiment()) return;
+		final ITypeDescription tDesc = cache.get(micro.getName());
+		if (!(tDesc instanceof ISpeciesDescription speciesDesc) || speciesDesc.isExperiment()) return;
 
 		// Get parent name from facet, default to "agent" if not specified
 		String parentName = speciesDesc.getLitteral(IKeyword.PARENT);
@@ -998,7 +998,12 @@ public class ModelFactory implements IModelFactory {
 		ISpeciesDescription parent = lookupSpecies(parentName, cache);
 		if (parent == null) { parent = model.getSpeciesDescription(parentName); }
 
-		speciesDesc.setParent(parent);
+		if (parent == null) {
+			speciesDesc.error("Species " + parentName + " is not a valid species or does not exist",
+					IGamlIssue.WRONG_PARENT, IKeyword.PARENT);
+		} else {
+			speciesDesc.setParent(parent);
+		}
 
 		// Recursively process micro-species
 		micro.visitSpecies(element -> parentSpecies(speciesDesc, element, model, cache));
@@ -1019,9 +1024,10 @@ public class ModelFactory implements IModelFactory {
 	 * @return the species description if found, null otherwise
 	 */
 	ISpeciesDescription lookupSpecies(final String name, final Map<String, ITypeDescription> cache) {
-		ISpeciesDescription result = (ISpeciesDescription) cache.get(name);
-		if (result == null) { result = GamaMetaModel.getSpeciesDescription(name); }
-		return result;
+		ITypeDescription desc = cache.get(name);
+		if (desc instanceof ISpeciesDescription speciesDesc) return speciesDesc;
+		if (desc != null) return null;
+		return GamaMetaModel.getSpeciesDescription(name);
 	}
 
 	/**
@@ -1065,15 +1071,19 @@ public class ModelFactory implements IModelFactory {
 	 */
 	void parentClass(final IModelDescription model, final ISyntacticElement micro,
 			final Map<String, ITypeDescription> cache) {
-		// Gather the previously created species
+		// Gather the previously created class
 		final ITypeDescription mDesc = cache.get(micro.getName());
 		if (!(mDesc instanceof IClassDescription cd)) return;
 		String p = cd.getLitteral(IKeyword.PARENT);
-		// If no parent is defined, we assume it is "agent"
+		// If no parent is defined, we assume it is "object"
 		if (p == null) { p = IKeyword.OBJECT; }
 		IClassDescription parent = lookupClass(p, cache);
 		if (parent == null) { parent = model.getClassDescription(p); }
-		cd.setParent(parent);
+		if (parent == null) {
+			cd.error("Class " + p + " is not a valid class or does not exist", IGamlIssue.WRONG_PARENT, IKeyword.PARENT);
+		} else {
+			cd.setParent(parent);
+		}
 	}
 
 	/**

--- a/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
+++ b/gaml.compiler/src/gaml/compiler/factories/ModelFactory.java
@@ -999,10 +999,13 @@ public class ModelFactory implements IModelFactory {
 		if (parent == null) { parent = model.getSpeciesDescription(parentName); }
 
 		if (parent == null) {
-			speciesDesc.error("Parent '" + parentName + "' is not a valid species or does not exist",
+			speciesDesc.error("Parent '" + parentName + "' is not a valid species or does not exist",
+
 					IGamlIssue.WRONG_PARENT, IKeyword.PARENT);
-			// Keep the species hierarchy consistent to avoid cascading errors
-			speciesDesc.setParent(GamaMetaModel.getSpeciesDescription(IKeyword.AGENT));
+			// Keep the species hierarchy consistent to avoid cascading errors
+
+			speciesDesc.setParent(GamaMetaModel.getSpeciesDescription(IKeyword.AGENT));
+
 		} else {
 			speciesDesc.setParent(parent);
 		}
@@ -1079,7 +1082,8 @@ public class ModelFactory implements IModelFactory {
 		String p = cd.getLitteral(IKeyword.PARENT);
 		// If no parent is defined, we assume it is "object"
 		if (p == null) { p = IKeyword.OBJECT; }
-		IClassDescription parent = lookupClass(p, cache);
+			cd.error("Parent '" + p + "' is not a valid class or does not exist", IGamlIssue.WRONG_PARENT, IKeyword.PARENT);
+			cd.setParent(GamaMetaModel.getObjectClassDescription());
 		if (parent == null) { parent = model.getClassDescription(p); }
 		if (parent == null) {
 			cd.error("Class " + p + " is not a valid class or does not exist", IGamlIssue.WRONG_PARENT, IKeyword.PARENT);


### PR DESCRIPTION
Fix issue #1162 by replacing unsafe casts in ModelFactory with pattern matching instanceof checks, returning null when a class description is looked up as a species, and reporting proper compilation errors on the parent facet.

The goal is to make sure that a species cannot inherit directly from a class (as it should inherit by default from `agent`, which itself inherits from `object`). 