### PR TITLE
[Class] Disallow reflex, aspect, and init blocks in class definitions (#1165)

### DIFF
--- a/gama.core/tests/Class Tests/.project
+++ b/gama.core/tests/Class Tests/.project
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Class Tests</name>
+	<comment>core plugin</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>gama.workspace.gamaNature</nature>
+		<nature>gama.workspace.testNature</nature>
+	</natures>
+</projectDescription>

--- a/gama.core/tests/Class Tests/models/Classes access and manipulation.experiment
+++ b/gama.core/tests/Class Tests/models/Classes access and manipulation.experiment
@@ -1,0 +1,126 @@
+/**
+* Name: Classesaccessandmanipulation
+* Based on the internal empty template.
+* Author: Baptiste Lesquoy
+* Tags: Class, Object, Test
+*/
+
+
+model Classesaccessandmanipulation
+
+class ExampleClass {
+
+	int notInitializedInt;
+	int initializedInt <- 5;
+	int initializedInInit <- 10;
+
+	int simple_action(){
+		return 5;
+	}
+
+	int action_with_parameters(int i, int j){
+		return 2 * i * j;
+	}
+
+	action state_changing_action(){
+		notInitializedInt <- 123;
+	}
+}
+
+
+experiment testAccess type:test{
+
+	test unitializedClassIsNil {
+		ExampleClass c;
+		assert c = nil;
+	}
+	test defaultIntFieldValue {
+		ExampleClass c <- ExampleClass();
+		assert c.notInitializedInt = 0;
+	}
+
+	test declarationLevelInitialization{
+		ExampleClass c <- ExampleClass();
+		assert c.initializedInt = 5;
+	}
+
+	test initLevelInitialization{
+		ExampleClass c <- ExampleClass();
+		assert c.initializedInInit = 10;
+	}
+
+	test creationLevelInitialization {
+		ExampleClass c <- ExampleClass(notInitializedInt:1, initializedInt:2, initializedInInit:3);
+		assert c.notInitializedInt = 1;
+		assert c.initializedInt = 2;
+		assert c.initializedInInit = 3;
+	}
+
+	test valueAssignment {
+		ExampleClass c <- ExampleClass();
+		c.initializedInt <- 123;
+		assert c.initializedInt = 123;
+	}
+
+	test objectIsAReference {
+		ExampleClass c <- ExampleClass();
+		ExampleClass b <- c;
+		c.notInitializedInt <- 10;
+		assert b.notInitializedInt = 10;
+	}
+
+	test referencesEquality {
+		ExampleClass c <- ExampleClass();
+		ExampleClass b <- c;
+		assert c = b;
+	}
+
+	test sameObjectsAreNotEqual{
+		ExampleClass a <- ExampleClass();
+		ExampleClass b <- ExampleClass();
+		assert a != b;
+	}
+
+
+	test objectCopy {
+		ExampleClass c <- ExampleClass();
+		ExampleClass b <- copy(c);
+		c.notInitializedInt <- 10;
+		assert b.notInitializedInt != 10;
+		assert b != c;
+	}
+
+
+	test execSimpleAction{
+		ExampleClass c <- ExampleClass();
+		assert c.simple_action() = 5;
+	}
+
+
+	test execActionWithParams{
+		ExampleClass c <- ExampleClass();
+		assert c.action_with_parameters(4, 5) = 40;
+	}
+
+	test execStateAlteringAction{
+		ExampleClass c <- ExampleClass();
+		assert c.notInitializedInt = 0;
+		c.state_changing_action();
+		assert c.notInitializedInt = 123;
+
+	}
+
+	test objectsAreNotInAgents {
+		ExampleClass obj <- ExampleClass();
+		assert !(agents contains obj);
+	}
+
+	test createListObjects {
+		list<ExampleClass> l <- list_with(3, ExampleClass(initializedInt:rnd(1,10)));
+		assert length(l) = 3;
+		assert l none_matches (each = nil);
+		assert l all_match (each.initializedInt > 0);
+	}
+
+
+}

--- a/gama.core/tests/Class Tests/models/Classes access and manipulation.experiment
+++ b/gama.core/tests/Class Tests/models/Classes access and manipulation.experiment
@@ -30,7 +30,7 @@ class ExampleClass {
 
 experiment testAccess type:test{
 
-	test unitializedClassIsNil {
+	test uninitializedClassIsNil {
 		ExampleClass c;
 		assert c = nil;
 	}

--- a/gama.core/tests/Class Tests/models/Complex classes.experiment
+++ b/gama.core/tests/Class Tests/models/Complex classes.experiment
@@ -1,0 +1,85 @@
+/**
+* Name: Complexclasses
+* Based on the internal empty template.
+* Author: Baptiste Lesquoy
+* Tags: Class, Object, Test
+*/
+
+
+model Complexclasses
+
+/* Insert your model definition here */
+
+// TODO: double inheritance
+// TODO: access to grid/species
+
+// This is just to validate that the compiler is able to handle interdependances between classes
+class A {
+	B b;
+	A a;
+}
+
+class B {
+	A a;
+}
+
+class Node {
+	list<Node> children;
+
+	pair<Node,int> getDeepestChild(){
+		int maxDepth <- 0;
+		Node deepestChild <- self;
+		loop child over:children{
+			pair<Node, int> res <- child.getDeepestChild();
+			if res.value + 1 > maxDepth{
+				maxDepth <- res.value + 1;
+				deepestChild <- res.key;
+			}
+		}
+		return pair<Node,int>(deepestChild, maxDepth);
+	}
+
+	action add_child(Node n){
+		add n to:children;
+	}
+
+	action add_children(list<Node> nodes){
+		children <- children + nodes;
+	}
+}
+
+
+experiment "Complex classes" type:test{
+
+	test recursiveAlgorithm{
+		Node root <- Node();
+		root.add_children(list_with(3, Node()));
+		write root.children[1];
+		Node n <- root.children[1];
+		n.add_children(list_with(4, Node()));
+		Node n2 <- n.children[3];
+		Node deepest <- Node();
+		n2.add_child(deepest);
+		assert root.getDeepestChild() = pair<Node,int>(deepest, 3);
+	}
+
+	test selfReference{
+		A a <- A();
+		assert a.a = nil;
+		a.a <- a;
+		assert a.a = a;
+	}
+
+	test interdependantClasses {
+		A a <- A();
+		B b <- B(a:a);
+		a.b <- b;
+		assert a != b;
+		assert a.a = nil;
+		assert a.b = b;
+		assert b.a = a;
+	}
+
+
+
+}

--- a/gama.core/tests/Class Tests/models/Complex classes.experiment
+++ b/gama.core/tests/Class Tests/models/Complex classes.experiment
@@ -13,7 +13,7 @@ model Complexclasses
 // TODO: double inheritance
 // TODO: access to grid/species
 
-// This is just to validate that the compiler is able to handle interdependances between classes
+// This is just to validate that the compiler is able to handle interdependencies between classes
 class A {
 	B b;
 	A a;

--- a/gama.core/tests/Class Tests/models/Inheritance.experiment
+++ b/gama.core/tests/Class Tests/models/Inheritance.experiment
@@ -1,0 +1,100 @@
+/**
+* Name: Inheritance
+* Based on the internal empty template.
+* Author: Baptiste Lesquoy
+* Tags: Class, Object, Test
+*/
+
+
+model Inheritance
+
+class Parent {
+
+	int notInitializedInt;
+	int initializedInt <- 5;
+	int initializedInInit <- 10;
+	int intToOverride <- 4;
+
+	int action_to_inherit(){
+		return 5;
+	}
+
+	int action_to_override(){
+		return 3;
+	}
+
+	int virtual_action();
+
+}
+
+class Child parent:Parent{
+
+	int intToOverride <- 5;
+
+	int action_to_override(){
+		return super.action_to_override() * 2;
+	}
+	int virtual_action(){
+		return 3;
+	}
+}
+
+class Child2 parent:Parent{
+	int virtual_action(){ return 1;}
+}
+
+experiment "Test inheritance" type:test{
+
+	test inheritedFieldsAreStillInitialisedInParent {
+		Child c <- Child();
+		assert c.notInitializedInt = 0;
+		assert c.initializedInt = 5;
+		assert c.initializedInInit = 10;
+	}
+
+	test inheritedFieldInitializationIsOverriden{
+		Child c <- Child();
+		assert c.intToOverride = 5;
+	}
+
+	test constructorInitializationWorksOnChild{
+		Child c <- Child(notInitializedInt: 1, initializedInt: 2, intToOverride: 3);
+		assert c.notInitializedInt = 1;
+		assert c.initializedInt = 2;
+		assert c.intToOverride = 3;
+	}
+
+	test inheritedActionIsStillAvailable{
+		Child c <- Child();
+		assert c.action_to_inherit() = 5;
+	}
+
+	test virtualActionImplementationIsCalled {
+		Child c <- Child();
+		assert c.virtual_action() = 3;
+	}
+
+	test overridingAndCallingParentsAction{
+		Child c <- Child();
+		assert c.action_to_override() = 6;
+	}
+
+	test usingBaseClassToHoldChildren{
+		Parent p <- Child();
+		assert p.intToOverride = 5;
+		assert p.virtual_action() = 3;
+	}
+
+	test usingBaseClassToHoldChild{
+		Parent p <- Child();
+		assert p.intToOverride = 5;
+		assert p.virtual_action() = 3;
+	}
+
+	test usingBaseClassToHoldChildren{
+		list<Parent> l <- [Child(), Child2()];
+		assert type_of(l[0]) = Parent;
+		assert actual_type_of(l[0]) = Child;
+		assert l[0].virtual_action() != l[1].virtual_action();
+	}
+}

--- a/gama.core/tests/Class Tests/models/Inheritance.experiment
+++ b/gama.core/tests/Class Tests/models/Inheritance.experiment
@@ -52,7 +52,7 @@ experiment "Test inheritance" type:test{
 		assert c.initializedInInit = 10;
 	}
 
-	test inheritedFieldInitializationIsOverriden{
+	test inheritedFieldInitializationIsOverridden{
 		Child c <- Child();
 		assert c.intToOverride = 5;
 	}

--- a/gaml.compiler/src/gaml/compiler/descriptions/ClassDescription.java
+++ b/gaml.compiler/src/gaml/compiler/descriptions/ClassDescription.java
@@ -13,9 +13,12 @@ package gaml.compiler.descriptions;
 import org.eclipse.emf.ecore.EObject;
 
 import gama.annotations.constants.IKeyword;
+import gama.api.compilation.descriptions.IActionDescription;
 import gama.api.compilation.descriptions.IClassDescription;
 import gama.api.compilation.descriptions.IDescription;
+import gama.api.compilation.descriptions.IVariableDescription;
 import gama.api.compilation.documentation.IGamlDocumentation;
+import gama.api.constants.IGamlIssue;
 import gama.api.gaml.symbols.Facets;
 import gama.api.kernel.GamaMetaModel;
 import gama.api.kernel.object.IClass;
@@ -86,6 +89,17 @@ public class ClassDescription extends TypeDescription implements IClassDescripti
 
 	@Override
 	public Class<? extends IObject> getJavaBase() { return IObject.class; }
+
+	@Override
+	public void addChild(final IDescription child) {
+		if (child instanceof IActionDescription ad) {
+			addAction(ad);
+		} else if (child instanceof IVariableDescription vd) {
+			addOwnAttribute(vd);
+		} else if (child != null) {
+			child.error(child.getKeyword() + " cannot be defined in " + getKeyword(), IGamlIssue.WRONG_CONTEXT);
+		}
+	}
 
 	/**
 	 * Document this.


### PR DESCRIPTION
Resolves #1165 and incorporates PR #1159:
1. Overrides `addChild` in `ClassDescription` to validate child descriptions, raising a compilation error (`IGamlIssue.WRONG_CONTEXT`) if unsupported constructs like `reflex`, `aspect`, or `init` blocks are defined in a GAML class.
2. Incorporates the unit tests for classes (`Class Tests`) from PR #1159 into `gama.core/tests/Class Tests`.

---
*PR created automatically by Jules for task [7014677716257702917](https://jules.google.com/task/7014677716257702917) started by @AlexisDrogoul*