### PR TITLE
[charts] Improve legend personalization and fix datalist color/legend handling (#1186, #1187)

### DIFF
--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataListStatement.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataListStatement.java
@@ -72,9 +72,9 @@ import gama.annotations.support.ISymbolKind;
 						doc = @doc ("the marker sizes to display. Can be a list of numbers (same size for each marker of the series) or a list of list (different sizes by point)")),
 				@facet (
 						name = IKeyword.LEGEND,
-						type = IType.LIST,
+						type = { IType.LIST, IType.BOOL, IType.STRING, IType.NONE },
 						optional = true,
-						doc = @doc ("the name of the series: a list of strings (can be a variable with dynamic names)")),
+						doc = @doc ("the name of the series: a list of strings (can be a variable with dynamic names), or false to hide the legend. Use nil/whitespace for individual points to hide them from legend.")),
 				@facet (
 						name = ChartDataStatement.MARKER,
 						type = IType.BOOL,
@@ -108,9 +108,9 @@ import gama.annotations.support.ISymbolKind;
 						doc = @doc ("Marker filled (true) or not (false), same for all series.")),
 				@facet (
 						name = IKeyword.COLOR,
-						type = IType.LIST,
+						type = { IType.LIST, IType.COLOR, IType.CONTAINER, IType.NONE },
 						optional = true,
-						doc = @doc ("list of colors, for heatmaps can be a list of [minColor,maxColor] or [minColor,medColor,maxColor]")),
+						doc = @doc ("a single color or list of colors. If a list of colors smaller than the list of values is provided, colors will cycle. For heatmaps can be a list of [minColor,maxColor] or [minColor,medColor,maxColor]")),
 				@facet (
 						name = ChartDataStatement.THICKNESS,
 						type = IType.FLOAT,
@@ -124,7 +124,7 @@ import gama.annotations.support.ISymbolKind;
 								IKeyword.EXPLODED },
 						optional = true,
 						doc = @doc ("Style for the serie (if not the default one sepecified on chart statement)")) },
-		omissible = IKeyword.LEGEND)
+		omissible = IKeyword.VALUE)
 public class ChartDataListStatement extends AbstractStatement {
 
 	/**

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSeries.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSeries.java
@@ -392,8 +392,8 @@ public class ChartDataSeries {
 		if (o instanceof IList) {
 			final IList ol = GamaListFactory.castToList(scope, o);
 			if (ol.isEmpty()) return null;
-			return ol.get(listvalue % ol.size());
-
+			if (IKeyword.COLOR.equals(valuetype)) return ol.get(listvalue % ol.size());
+			return listvalue < ol.size() ? ol.get(listvalue) : null;
 		}
 		return o;
 

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSeries.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSeries.java
@@ -66,6 +66,9 @@ public class ChartDataSeries {
 	/** The name. */
 	String name;
 
+	/** The series legend label. */
+	String seriesLegend = null;
+
 	/** The ongoing update. */
 	boolean ongoing_update = false;
 
@@ -141,9 +144,24 @@ public class ChartDataSeries {
 	 * @return the serie legend
 	 */
 	public Comparable getSerieLegend(final IScope scope) {
-
+		if (seriesLegend != null) return seriesLegend;
 		return name;
 	}
+
+	/**
+	 * Gets the series legend string.
+	 *
+	 * @return the series legend
+	 */
+	public String getSeriesLegend() { return seriesLegend; }
+
+	/**
+	 * Sets the series legend string.
+	 *
+	 * @param legend
+	 *            the legend
+	 */
+	public void setSeriesLegend(final String legend) { this.seriesLegend = legend; }
 
 	/**
 	 * Gets the serie id.
@@ -373,8 +391,8 @@ public class ChartDataSeries {
 
 		if (o instanceof IList) {
 			final IList ol = GamaListFactory.castToList(scope, o);
-			if (ol.size() < listvalue) return null;
-			return ol.get(listvalue);
+			if (ol.isEmpty()) return null;
+			return ol.get(listvalue % ol.size());
 
 		}
 		return o;

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
@@ -106,8 +106,11 @@ public class ChartDataSourceList extends ChartDataSource {
 	}
 
 	private String getLegendLabel(final IScope scope, final IList<?> legends, final int index) {
-		if (legends == null || index >= legends.size() || legends.get(index) == null) return "";
-		return Cast.asString(scope, legends.get(index));
+		if (legends == null) return "";
+		if (index >= legends.size()) return "";
+		final Object val = legends.get(index);
+		if (val == null) return "";
+		return Cast.asString(scope, val);
 	}
 
 	/**

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
@@ -106,75 +106,56 @@ public class ChartDataSourceList extends ChartDataSource {
 	 *            the chart cycle
 	 */
 	private void updateserielist(final IScope scope, final int chartCycle) {
-		final IList<String> legends =
-				legendExp == null ? null : GamaListFactory.castToList(scope, legendExp.value(scope));
-		if (legends == null) return;
-		final IList<?> values = GamaListFactory.castToList(scope, getValue().value(scope));
-		final ArrayList<String> previousSeries = currentSeriesNames;
+		final Object valObj = getValue() == null ? null : getValue().value(scope);
+		final IList<?> values = valObj instanceof IList ? GamaListFactory.castToList(scope, valObj) : GamaListFactory.create();
+		final int targetSize = values.size();
+
+		final Object legObj = legendExp == null ? null : legendExp.value(scope);
+		IList<?> legends = legObj instanceof IList ? GamaListFactory.castToList(scope, legObj) : null;
+		if (legObj instanceof Boolean b && !b) {
+			legends = null;
+		}
+
+		final ArrayList<String> previousSeries = currentSeriesNames != null ? currentSeriesNames : new ArrayList<>();
 		currentSeriesNames = new ArrayList<>();
-		boolean somethingChanged = false;
-		if (legends.size() > 0) {
-			// value list case
-			for (int i = 0; i < Math.min(values.size(), legends.size()); i++) {
-				final String name = legends.get(i);
-				if (name != null) {
-					currentSeriesNames.add(name);
-					if (i >= previousSeries.size() || !previousSeries.get(i).equals(name)) {
-						somethingChanged = true;
-						if (previousSeries.contains(name)) {
-							// serie i was serie k before
-						} else {
-							// new serie
-							newSerie(scope, name);
-						}
-					}
-				}
+
+		for (int i = 0; i < targetSize; i++) {
+			String serieId = "dl_" + this.hashCode() + "_" + i;
+			currentSeriesNames.add(serieId);
+
+			String legendStr = "";
+			if (legends != null && i < legends.size() && legends.get(i) != null) {
+				legendStr = Cast.asString(scope, legends.get(i));
+			}
+
+			ChartDataSeries myserie;
+			if (!previousSeries.contains(serieId)) {
+				myserie = myDataset.createOrGetSerie(scope, serieId, this);
+				mySeries.put(serieId, myserie);
+			} else {
+				myserie = mySeries.get(serieId);
+			}
+			if (myserie != null) {
+				myserie.setSeriesLegend(legendStr);
 			}
 		}
-		if (currentSeriesNames.size() != previousSeries.size()) { somethingChanged = true; }
-		if (somethingChanged) {
-			for (String s : previousSeries) {
-				if (!currentSeriesNames.contains(s)) { getDataset().removeserie(scope, s); }
+
+		if (previousSeries.size() > targetSize) {
+			for (int i = targetSize; i < previousSeries.size(); i++) {
+				String s = previousSeries.get(i);
+				mySeries.remove(s);
+				getDataset().removeserie(scope, s);
 			}
-			for (String element : currentSeriesNames) { getDataset().addSerieAtTheEnd(scope, element); }
-
 		}
 
-	}
-
-	/**
-	 * Newserie.
-	 *
-	 * @param scope
-	 *            the scope
-	 * @param myname
-	 *            the myname
-	 */
-	private void newSerie(final IScope scope, final String myname) {
-		if (this.getDataset().getDataSeriesIds(scope).contains(myname)) {
-			DEBUG.LOG("Serie " + myname + "s already exists... Will replace old one!!");
+		for (String element : currentSeriesNames) {
+			getDataset().addSerieAtTheEnd(scope, element);
 		}
-		final ChartDataSeries myserie = myDataset.createOrGetSerie(scope, myname, this);
-		mySeries.put(myname, myserie);
-
 	}
 
 	@Override
 	public void createInitialSeries(final IScope scope) {
-
-		final Object on = legendExp == null ? null : legendExp.value(scope);
-
-		if (on instanceof IList lval) {
-			currentSeriesNames = new ArrayList<>();
-			for (int i = 0; i < lval.size(); i++) {
-				final Object no = lval.get(i);
-				if (no != null) {
-					final String myname = Cast.asString(scope, no);
-					newSerie(scope, myname);
-					currentSeriesNames.add(i, myname);
-				}
-			}
-		}
+		updateserielist(scope, 0);
 		inferDatasetProperties(scope);
 	}
 

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
@@ -97,6 +97,19 @@ public class ChartDataSourceList extends ChartDataSource {
 
 	}
 
+	private IList<?> extractLegends(final IScope scope) {
+		if (legendExp == null) return null;
+		final Object legObj = legendExp.value(scope);
+		if (legObj instanceof Boolean b && !b) return null;
+		if (legObj instanceof IList l) return GamaListFactory.castToList(scope, l);
+		return null;
+	}
+
+	private String getLegendLabel(final IScope scope, final IList<?> legends, final int index) {
+		if (legends == null || index >= legends.size() || legends.get(index) == null) return "";
+		return Cast.asString(scope, legends.get(index));
+	}
+
 	/**
 	 * Updateserielist.
 	 *
@@ -109,12 +122,7 @@ public class ChartDataSourceList extends ChartDataSource {
 		final Object valObj = getValue() == null ? null : getValue().value(scope);
 		final IList<?> values = valObj instanceof IList ? GamaListFactory.castToList(scope, valObj) : GamaListFactory.create();
 		final int targetSize = values.size();
-
-		final Object legObj = legendExp == null ? null : legendExp.value(scope);
-		IList<?> legends = legObj instanceof IList ? GamaListFactory.castToList(scope, legObj) : null;
-		if (legObj instanceof Boolean b && !b) {
-			legends = null;
-		}
+		final IList<?> legends = extractLegends(scope);
 
 		final ArrayList<String> previousSeries = currentSeriesNames != null ? currentSeriesNames : new ArrayList<>();
 		currentSeriesNames = new ArrayList<>();
@@ -123,17 +131,13 @@ public class ChartDataSourceList extends ChartDataSource {
 			String serieId = "dl_" + this.hashCode() + "_" + i;
 			currentSeriesNames.add(serieId);
 
-			String legendStr = "";
-			if (legends != null && i < legends.size() && legends.get(i) != null) {
-				legendStr = Cast.asString(scope, legends.get(i));
-			}
+			String legendStr = getLegendLabel(scope, legends, i);
 
-			ChartDataSeries myserie;
+			ChartDataSeries myserie = previousSeries.contains(serieId)
+					? mySeries.get(serieId)
+					: myDataset.createOrGetSerie(scope, serieId, this);
 			if (!previousSeries.contains(serieId)) {
-				myserie = myDataset.createOrGetSerie(scope, serieId, this);
 				mySeries.put(serieId, myserie);
-			} else {
-				myserie = mySeries.get(serieId);
 			}
 			if (myserie != null) {
 				myserie.setSeriesLegend(legendStr);

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartDataSourceList.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import gama.annotations.constants.IKeyword;
 import gama.api.gaml.expressions.IExpression;
 import gama.api.gaml.types.Cast;
+import gama.api.gaml.types.Types;
 import gama.api.runtime.scope.IScope;
 import gama.api.types.list.GamaListFactory;
 import gama.api.types.list.IList;
@@ -101,6 +102,7 @@ public class ChartDataSourceList extends ChartDataSource {
 		if (legendExp == null) return null;
 		final Object legObj = legendExp.value(scope);
 		if (legObj instanceof Boolean b && !b) return null;
+		if (legObj instanceof String s) return GamaListFactory.create(scope, Types.STRING, s);
 		if (legObj instanceof IList l) return GamaListFactory.castToList(scope, l);
 		return null;
 	}

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutput.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutput.java
@@ -273,6 +273,12 @@ public class ChartJFreeChartOutput extends ChartOutput implements ChartProgressL
 					}
 			}
 
+			if ("vertical".equalsIgnoreCase(legend_orientation)) {
+				legend.getItemContainer().setArrangement(new org.jfree.chart.block.ColumnArrangement());
+			} else if ("horizontal".equalsIgnoreCase(legend_orientation)) {
+				legend.getItemContainer().setArrangement(new org.jfree.chart.block.FlowArrangement());
+			}
+
 			// Set legend text color
 			if (textColor != null) { legend.setItemPaint(IColor.toAWTColor(textColor)); }
 

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutput.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutput.java
@@ -236,54 +236,50 @@ public class ChartJFreeChartOutput extends ChartOutput implements ChartProgressL
 			if (chart.getLegend() != null) { chart.getLegend().setBackgroundPaint(bg); }
 		}
 		if (chart.getLegend() != null) {
-			LegendTitle legend = chart.getLegend(); // Get the existing legend
+			LegendTitle legend = chart.getLegend();
 			legend.setItemFont(getLegendFont());
 			legend.setFrame(BlockBorder.NONE);
 			legend.setPosition(RectangleEdge.BOTTOM);
-			// legend.setPadding(5, 5, 5, 5);
-			// Set legend position
-			switch (series_label_position) {
-				case IKeyword.LEFT:
-					legend.setPosition(RectangleEdge.LEFT);
-					break;
-				case IKeyword.RIGHT:
-					legend.setPosition(RectangleEdge.RIGHT);
-					break;
-				case IKeyword.TOP:
-					legend.setPosition(RectangleEdge.TOP);
-					break;
-				case "none":
-					legend.setVisible(false);
-					break;
-				case "onchart":
-					if (plot instanceof XYPlot p) {
-						// Place the legend inside the chart area at the corner specified by the anchor
-						double x = series_label_anchor.getX() / 2 + 0.25; // Normalize to [0.25, 0.75]
-						double y = series_label_anchor.getY() / 2 + 0.25;
-						XYTitleAnnotation ta = new XYTitleAnnotation(x, y, legend, RectangleAnchor.CENTER);
-						ta.setMaxWidth(0.5); // Legend will take up to 50% of the chart width by default
-						ta.setMaxHeight(0.5);
-						legend.setHorizontalAlignment(HorizontalAlignment.CENTER);
-						legend.setVerticalAlignment(VerticalAlignment.CENTER);
-						// Legend with 50% transparency by default
-						legend.setBackgroundPaint(IColor.toAWTColor(Colors.rgb(scope, backgroundColor, 0.5)));
-						p.addAnnotation(ta);
-						// Remove the default legend
-						chart.removeLegend();
-					}
-			}
 
-			if ("vertical".equalsIgnoreCase(legend_orientation)) {
-				legend.getItemContainer().setArrangement(new org.jfree.chart.block.ColumnArrangement());
-			} else if ("horizontal".equalsIgnoreCase(legend_orientation)) {
-				legend.getItemContainer().setArrangement(new org.jfree.chart.block.FlowArrangement());
-			}
+			configureLegendPosition(legend, plot, scope);
+			configureLegendOrientation(legend);
 
-			// Set legend text color
 			if (textColor != null) { legend.setItemPaint(IColor.toAWTColor(textColor)); }
-
 		}
 
+	}
+
+	private void configureLegendPosition(final LegendTitle legend, final Plot plot, final IScope scope) {
+		switch (series_label_position) {
+			case IKeyword.LEFT -> legend.setPosition(RectangleEdge.LEFT);
+			case IKeyword.RIGHT -> legend.setPosition(RectangleEdge.RIGHT);
+			case IKeyword.TOP -> legend.setPosition(RectangleEdge.TOP);
+			case "none" -> legend.setVisible(false);
+			case "onchart" -> {
+				if (plot instanceof XYPlot p) {
+					double x = series_label_anchor.getX() / 2 + 0.25;
+					double y = series_label_anchor.getY() / 2 + 0.25;
+					XYTitleAnnotation ta = new XYTitleAnnotation(x, y, legend, RectangleAnchor.CENTER);
+					ta.setMaxWidth(0.5);
+					ta.setMaxHeight(0.5);
+					legend.setHorizontalAlignment(HorizontalAlignment.CENTER);
+					legend.setVerticalAlignment(VerticalAlignment.CENTER);
+					legend.setBackgroundPaint(IColor.toAWTColor(Colors.rgb(scope, backgroundColor, 0.5)));
+					p.addAnnotation(ta);
+					chart.removeLegend();
+				}
+			}
+			default -> {
+			}
+		}
+	}
+
+	private void configureLegendOrientation(final LegendTitle legend) {
+		if ("vertical".equalsIgnoreCase(legend_orientation)) {
+			legend.getItemContainer().setArrangement(new org.jfree.chart.block.ColumnArrangement());
+		} else if ("horizontal".equalsIgnoreCase(legend_orientation)) {
+			legend.getItemContainer().setArrangement(new org.jfree.chart.block.FlowArrangement());
+		}
 	}
 
 	/**

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
@@ -251,6 +251,20 @@ public class ChartJFreeChartOutputHistogram extends ChartJFreeChartOutput {
 			final int myrow = idPosition.get(serieid);
 			if (myserie.getMycolor() != null) { newr.setSeriesPaint(myrow, IColor.toAWTColor(myserie.getMycolor())); }
 
+			final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
+			if (legStr.isEmpty()) {
+				newr.setSeriesVisibleInLegend(myrow, false);
+			} else {
+				newr.setLegendItemLabelGenerator((dataset, series) -> {
+					String id = (String) dataset.getRowKey(series);
+					ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
+					if (ds != null && ds.getSerieLegend(scope) != null) {
+						return ds.getSerieLegend(scope).toString();
+					}
+					return id;
+				});
+			}
+
 			if ("onchart".equals(this.series_label_position)) {
 				// ((BarRenderer)newr).setBaseItemLabelGenerator(new
 				// LabelGenerator());

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
@@ -225,6 +225,19 @@ public class ChartJFreeChartOutputHistogram extends ChartJFreeChartOutput {
 		return newr;
 	}
 
+	private void configureLegend(final AbstractCategoryItemRenderer newr, final ChartDataSeries myserie, final int myrow, final IScope scope) {
+		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
+		if (legStr.isEmpty()) {
+			newr.setSeriesVisibleInLegend(myrow, false);
+			return;
+		}
+		newr.setLegendItemLabelGenerator((dataset, series) -> {
+			String id = (String) dataset.getRowKey(series);
+			ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
+			return ds != null && ds.getSerieLegend(scope) != null ? ds.getSerieLegend(scope).toString() : id;
+		});
+	}
+
 	/**
 	 * Reset renderer.
 	 *
@@ -234,55 +247,30 @@ public class ChartJFreeChartOutputHistogram extends ChartJFreeChartOutput {
 	 *            the serieid
 	 */
 	protected void resetRenderer(final IScope scope, final String serieid) {
-		// AbstractCategoryItemRenderer
-		// newr=(AbstractCategoryItemRenderer)this.getOrCreateRenderer(scope,
-		// serieid);
 		final CategoryPlot plot = (CategoryPlot) this.chart.getPlot();
 		final AbstractCategoryItemRenderer newr = (AbstractCategoryItemRenderer) plot.getRenderer();
-		// if
-		// (serieid!=this.getChartdataset().series.keySet().iterator().next())
-		// newr=(AbstractCategoryItemRenderer)this.getOrCreateRenderer(scope,
-		// serieid);
 
 		final ChartDataSeries myserie = this.getChartdataset().getDataSeries(scope, serieid);
-		if (!idPosition.containsKey(serieid)) {
-			// DEBUG.LOG("pb!!!");
-		} else {
-			final int myrow = idPosition.get(serieid);
-			if (myserie.getMycolor() != null) { newr.setSeriesPaint(myrow, IColor.toAWTColor(myserie.getMycolor())); }
+		if (!idPosition.containsKey(serieid)) return;
 
-			final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
-			if (legStr.isEmpty()) {
-				newr.setSeriesVisibleInLegend(myrow, false);
-			} else {
-				newr.setLegendItemLabelGenerator((dataset, series) -> {
-					String id = (String) dataset.getRowKey(series);
-					ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
-					if (ds != null && ds.getSerieLegend(scope) != null) {
-						return ds.getSerieLegend(scope).toString();
-					}
-					return id;
-				});
-			}
+		final int myrow = idPosition.get(serieid);
+		if (myserie.getMycolor() != null) { newr.setSeriesPaint(myrow, IColor.toAWTColor(myserie.getMycolor())); }
 
-			if ("onchart".equals(this.series_label_position)) {
-				// ((BarRenderer)newr).setBaseItemLabelGenerator(new
-				// LabelGenerator());
-				newr.setDefaultItemLabelGenerator(new LabelGenerator());
-				final ItemLabelPosition itemlabelposition =
-						new ItemLabelPosition(ItemLabelAnchor.OUTSIDE12, TextAnchor.BOTTOM_CENTER);
-				newr.setDefaultPositiveItemLabelPosition(itemlabelposition);
-				newr.setDefaultNegativeItemLabelPosition(itemlabelposition);
-				newr.setDefaultItemLabelsVisible(true);
-				if (textColor != null) { newr.setDefaultItemLabelPaint(IColor.toAWTColor(textColor)); }
-			}
+		configureLegend(newr, myserie, myrow, scope);
 
-			if (newr instanceof BarRenderer && gap >= 0) {
-				((BarRenderer) newr).setMaximumBarWidth(1 - gap);
-
-			}
+		if ("onchart".equals(this.series_label_position)) {
+			newr.setDefaultItemLabelGenerator(new LabelGenerator());
+			final ItemLabelPosition itemlabelposition =
+					new ItemLabelPosition(ItemLabelAnchor.OUTSIDE12, TextAnchor.BOTTOM_CENTER);
+			newr.setDefaultPositiveItemLabelPosition(itemlabelposition);
+			newr.setDefaultNegativeItemLabelPosition(itemlabelposition);
+			newr.setDefaultItemLabelsVisible(true);
+			if (textColor != null) { newr.setDefaultItemLabelPaint(IColor.toAWTColor(textColor)); }
 		}
 
+		if (newr instanceof BarRenderer && gap >= 0) {
+			((BarRenderer) newr).setMaximumBarWidth(1 - gap);
+		}
 	}
 
 	@Override

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputHistogram.java
@@ -227,7 +227,7 @@ public class ChartJFreeChartOutputHistogram extends ChartJFreeChartOutput {
 
 	private void configureLegend(final AbstractCategoryItemRenderer newr, final ChartDataSeries myserie, final int myrow, final IScope scope) {
 		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
-		if (legStr.isEmpty()) {
+		if (StringUtils.isBlank(legStr)) {
 			newr.setSeriesVisibleInLegend(myrow, false);
 			return;
 		}

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
@@ -300,7 +300,19 @@ public class ChartJFreeChartOutputScatter extends ChartJFreeChartOutput {
 		// newr.setSeriesStroke(0, new BasicStroke(0));
 		newr.setDefaultCreateEntities(true);
 		final ChartDataSeries myserie = this.getChartdataset().getDataSeries(scope, serieid);
-		if (myserie.getName() == null || myserie.getName().isEmpty()) { newr.setSeriesVisibleInLegend(0, false); }
+		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
+		if (legStr.isEmpty()) {
+			newr.setSeriesVisibleInLegend(0, false);
+		} else {
+			newr.setLegendItemLabelGenerator((dataset, series) -> {
+				String id = (String) dataset.getSeriesKey(series);
+				ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
+				if (ds != null && ds.getSerieLegend(scope) != null) {
+					return ds.getSerieLegend(scope).toString();
+				}
+				return id;
+			});
+		}
 		if (newr instanceof XYLineAndShapeRenderer xy) {
 			xy.setSeriesLinesVisible(0, myserie.getMysource().showLine);
 			xy.setSeriesShapesFilled(0, myserie.getMysource().fillMarker);

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
@@ -289,7 +289,7 @@ public class ChartJFreeChartOutputScatter extends ChartJFreeChartOutput {
 	private void configureLegend(final AbstractXYItemRenderer newr, final ChartDataSeries myserie,
 			final IScope scope) {
 		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
-		if (legStr.isEmpty()) {
+		if (StringUtils.isBlank(legStr)) {
 			newr.setSeriesVisibleInLegend(0, false);
 			return;
 		}

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
@@ -368,7 +368,7 @@ public class ChartJFreeChartOutputScatter extends ChartJFreeChartOutput {
 	protected void createNewSerie(final IScope scope, final String serieid) {
 
 		final ChartDataSeries dataserie = chartdataset.getDataSeries(scope, serieid);
-		final XYIntervalSeries serie = new XYIntervalSeries(dataserie.getSerieLegend(scope), false, true);
+		final XYIntervalSeries serie = new XYIntervalSeries(serieid, false, true);
 		final XYPlot plot = (XYPlot) this.chart.getPlot();
 
 		final XYIntervalSeriesCollection firstdataset = (XYIntervalSeriesCollection) plot.getDataset();

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartJFreeChartOutputScatter.java
@@ -286,6 +286,27 @@ public class ChartJFreeChartOutputScatter extends ChartJFreeChartOutput {
 		return newr;
 	}
 
+	private void configureLegend(final AbstractXYItemRenderer newr, final ChartDataSeries myserie,
+			final IScope scope) {
+		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
+		if (legStr.isEmpty()) {
+			newr.setSeriesVisibleInLegend(0, false);
+			return;
+		}
+		newr.setLegendItemLabelGenerator((dataset, series) -> {
+			String id = (String) dataset.getSeriesKey(series);
+			ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
+			return ds != null && ds.getSerieLegend(scope) != null ? ds.getSerieLegend(scope).toString() : id;
+		});
+	}
+
+	private void configureErrorRenderer(final CustomXYErrorRenderer xy, final ChartDataSeries myserie,
+			final IScope scope) {
+		xy.setDrawYError(myserie.isUseYErrValues());
+		xy.setDrawXError(myserie.isUseXErrValues());
+		if (myserie.getMysource().isUseSize()) { xy.setUseSize(scope, true); }
+	}
+
 	/**
 	 * Reset renderer.
 	 *
@@ -296,45 +317,28 @@ public class ChartJFreeChartOutputScatter extends ChartJFreeChartOutput {
 	 */
 	protected void resetRenderer(final IScope scope, final String serieid) {
 		final AbstractXYItemRenderer newr = (AbstractXYItemRenderer) this.getOrCreateRenderer(scope, serieid);
-
-		// newr.setSeriesStroke(0, new BasicStroke(0));
 		newr.setDefaultCreateEntities(true);
+
 		final ChartDataSeries myserie = this.getChartdataset().getDataSeries(scope, serieid);
-		final String legStr = myserie.getSerieLegend(scope) == null ? "" : myserie.getSerieLegend(scope).toString();
-		if (legStr.isEmpty()) {
-			newr.setSeriesVisibleInLegend(0, false);
-		} else {
-			newr.setLegendItemLabelGenerator((dataset, series) -> {
-				String id = (String) dataset.getSeriesKey(series);
-				ChartDataSeries ds = getChartdataset().getDataSeries(scope, id);
-				if (ds != null && ds.getSerieLegend(scope) != null) {
-					return ds.getSerieLegend(scope).toString();
-				}
-				return id;
-			});
-		}
+		configureLegend(newr, myserie, scope);
+
 		if (newr instanceof XYLineAndShapeRenderer xy) {
 			xy.setSeriesLinesVisible(0, myserie.getMysource().showLine);
 			xy.setSeriesShapesFilled(0, myserie.getMysource().fillMarker);
 			xy.setSeriesShapesVisible(0, myserie.getMysource().useMarker);
-
 		}
 
 		if (newr instanceof XYShapeRenderer xy && !myserie.getMysource().fillMarker) {
 			xy.setUseFillPaint(false);
-			// ((XYShapeRenderer) newr).setDrawOutlines(true);
 		}
+
 		if (myserie.getMycolor() != null) { newr.setSeriesPaint(0, IColor.toAWTColor(myserie.getMycolor())); }
-		// DEBUG.OUT("Changing series stroke to " + myserie.getLineThickness().value(scope));
+
 		newr.setSeriesStroke(0,
 				new BasicStroke(Cast.asFloat(scope, myserie.getLineThickness().value(scope)).floatValue()));
 
 		if (newr instanceof CustomXYErrorRenderer xy) {
-			xy.setDrawYError(false);
-			xy.setDrawXError(false);
-			if (myserie.isUseYErrValues()) { xy.setDrawYError(true); }
-			if (myserie.isUseXErrValues()) { xy.setDrawXError(true); }
-			if (myserie.getMysource().isUseSize()) { xy.setUseSize(scope, true); }
+			configureErrorRenderer(xy, myserie, scope);
 		}
 
 		if (myserie.getMysource().getUniqueMarkerName() != null) {

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartLayerStatement.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartLayerStatement.java
@@ -588,6 +588,24 @@ public class ChartLayerStatement extends AbstractLayerStatement {
 		return true;
 	}
 
+	private void updateLegendProperties(final IScope scope) {
+		IExpression expr = getFacet(ChartLayerStatement.SERIES_LABEL_POSITION);
+		if (expr != null) {
+			String pos = Cast.asString(scope, expr.value(scope));
+			chartOutput.setSeriesLabelPosition(scope, pos);
+		}
+		expr = getFacet(ChartLayerStatement.LEGEND_ORIENTATION);
+		if (expr != null) {
+			String orient = Cast.asString(scope, expr.value(scope));
+			chartOutput.setLegendOrientation(scope, orient);
+		}
+		expr = getFacet(IKeyword.ANCHOR);
+		if (expr != null) {
+			final IPoint pt = GamaPointFactory.castToPoint(scope, expr.value(scope));
+			chartOutput.setSeriesLabelAnchor(scope, pt);
+		}
+	}
+
 	/**
 	 * Gets the chart name.
 	 *
@@ -726,22 +744,7 @@ public class ChartLayerStatement extends AbstractLayerStatement {
 		string1 = getFacet("lines");
 		if (string1 != null) { chartOutput.setGridLinesVisible(scope, Cast.asBool(scope, string1.value(scope))); }
 
-		// Legend position and anchor
-		expr = getFacet(ChartLayerStatement.SERIES_LABEL_POSITION);
-		if (expr != null) {
-			String pos = Cast.asString(scope, expr.value(scope));
-			chartOutput.setSeriesLabelPosition(scope, pos);
-		}
-		expr = getFacet(ChartLayerStatement.LEGEND_ORIENTATION);
-		if (expr != null) {
-			String orient = Cast.asString(scope, expr.value(scope));
-			chartOutput.setLegendOrientation(scope, orient);
-		}
-		expr = getFacet(IKeyword.ANCHOR);
-		if (expr != null) {
-			final IPoint pt = GamaPointFactory.castToPoint(scope, expr.value(scope));
-			chartOutput.setSeriesLabelAnchor(scope, pt);
-		}
+		updateLegendProperties(scope);
 
 		color = getFacet(IKeyword.COLOR);
 		if (color != null) { colorvalue = GamaColorFactory.castToColor(scope, color.value(scope)); }

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartLayerStatement.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartLayerStatement.java
@@ -250,6 +250,12 @@ import gama.core.outputs.layers.AbstractLayerStatement;
 						optional = true,
 						doc = @doc ("Position of the legend: default (best guess), none, legend, onchart, xaxis (for category plots) or yaxis (uses the first serie name). 'left', 'right', 'top' and 'bottom' can also be used to force the position of the legend (default is bottom).")),
 				@facet (
+						name = ChartLayerStatement.LEGEND_ORIENTATION,
+						type = IType.ID,
+						values = { "default", "horizontal", "vertical" },
+						optional = true,
+						doc = @doc ("Orientation of the legend: default, horizontal or vertical.")),
+				@facet (
 						name = ANCHOR,
 						type = IType.POINT,
 						optional = true,
@@ -370,6 +376,9 @@ public class ChartLayerStatement extends AbstractLayerStatement {
 
 	/** The Constant SERIES_LABEL_POSITION. */
 	public static final String SERIES_LABEL_POSITION = "series_label_position";
+
+	/** The Constant LEGEND_ORIENTATION. */
+	public static final String LEGEND_ORIENTATION = "legend_orientation";
 
 	/** The Constant X_LOGSCALE. */
 	public static final String X_LOGSCALE = "x_log_scale";
@@ -722,6 +731,11 @@ public class ChartLayerStatement extends AbstractLayerStatement {
 		if (expr != null) {
 			String pos = Cast.asString(scope, expr.value(scope));
 			chartOutput.setSeriesLabelPosition(scope, pos);
+		}
+		expr = getFacet(ChartLayerStatement.LEGEND_ORIENTATION);
+		if (expr != null) {
+			String orient = Cast.asString(scope, expr.value(scope));
+			chartOutput.setLegendOrientation(scope, orient);
 		}
 		expr = getFacet(IKeyword.ANCHOR);
 		if (expr != null) {

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartOutput.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartOutput.java
@@ -172,6 +172,9 @@ public abstract class ChartOutput implements IChart {
 	/** The series label position. */
 	protected String series_label_position = IKeyword.DEFAULT;
 
+	/** The legend orientation. */
+	protected String legend_orientation = "default";
+
 	/** The series label anchor. */
 	protected IPoint series_label_anchor = GamaPointFactory.create(1, 1);
 

--- a/gama.core/src/gama/core/outputs/layers/charts/ChartOutput.java
+++ b/gama.core/src/gama/core/outputs/layers/charts/ChartOutput.java
@@ -172,9 +172,11 @@ public abstract class ChartOutput implements IChart {
 	/** The series label position. */
 	protected String series_label_position = IKeyword.DEFAULT;
 
-	/** The legend orientation. */
-	protected String legend_orientation = "default";
-
+/** The legend orientation. */
+protected String legend_orientation = "default";
+/** Sets the legend orientation. */
+public void setLegendOrientation(final IScope scope, final String orient) { legend_orientation = orient; }
+
 	/** The series label anchor. */
 	protected IPoint series_label_anchor = GamaPointFactory.create(1, 1);
 


### PR DESCRIPTION
This change addresses issues #1186 and #1187 regarding chart legends and datalist handling:
- Changed omissible facet on ChartDataListStatement to VALUE (instead of LEGEND) so `datalist [1, 2, 3]` assigns values properly.
- Expanded accepted types for `color` facet on `datalist` to accept single colors or lists without compiler warnings, and added modulo list indexing in `ChartDataSeries` to cycle colors when list length is smaller than values.
- Decoupled internal unique series IDs from displayed series legend strings in `ChartDataSeries` and `ChartDataSourceList`.
- Supported subset legend visibility: empty or nil legend strings in `datalist` hide individual items from the legend box via `renderer.setSeriesVisibleInLegend(index, false)`.
- Added `legend_orientation` facet to `ChartLayerStatement` (`default`, `horizontal`, `vertical`) and implemented vertical/horizontal legend arrangements in `ChartOutput` and `ChartJFreeChartOutput`.

---
*PR created automatically by Jules for task [4161660271994994385](https://jules.google.com/task/4161660271994994385) started by @AlexisDrogoul*