### PR TITLE
Disallow aspect and attribute name collisions in species

### DIFF
--- a/gaml.compiler/src/gaml/compiler/descriptions/SpeciesDescription.java
+++ b/gaml.compiler/src/gaml/compiler/descriptions/SpeciesDescription.java
@@ -645,6 +645,22 @@ public class SpeciesDescription extends TypeDescription implements ISpeciesDescr
 	 * @param statement
 	 *            the ce
 	 */
+	/**
+	 * Verifies whether the aspect name collides with an attribute defined in the species.
+	 *
+	 * @param statement
+	 *            the aspect statement description
+	 * @param aspectName
+	 *            the aspect name
+	 */
+	private void verifyAttributeCollision(final IStatementDescription statement, final String aspectName) {
+		final IVariableDescription var = getAttribute(aspectName);
+		if (var != null && !var.isSynthetic()) {
+			statement.error("Aspect " + aspectName + " has the same name as an existing attribute in " + getName(),
+					IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
+		}
+	}
+
 	private void addAspect(final IStatementDescription statement) {
 		String aspectName = statement.getName();
 		if (aspectName == null) {
@@ -654,13 +670,7 @@ public class SpeciesDescription extends TypeDescription implements ISpeciesDescr
 		if (!IKeyword.DEFAULT.equals(aspectName) && hasAspect(aspectName)) {
 			duplicateInfo(statement, getAspect(aspectName));
 		}
-		if (hasAttribute(aspectName)) {
-			final IVariableDescription var = getAttribute(aspectName);
-			if (var != null && !var.isSynthetic()) {
-				statement.error("Aspect " + aspectName + " has the same name as an existing attribute in " + getName(),
-						IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
-			}
-		}
+		verifyAttributeCollision(statement, aspectName);
 		getAspectsMap().put(aspectName, statement);
 	}
 

--- a/gaml.compiler/src/gaml/compiler/descriptions/SpeciesDescription.java
+++ b/gaml.compiler/src/gaml/compiler/descriptions/SpeciesDescription.java
@@ -654,6 +654,13 @@ public class SpeciesDescription extends TypeDescription implements ISpeciesDescr
 		if (!IKeyword.DEFAULT.equals(aspectName) && hasAspect(aspectName)) {
 			duplicateInfo(statement, getAspect(aspectName));
 		}
+		if (hasAttribute(aspectName)) {
+			final IVariableDescription var = getAttribute(aspectName);
+			if (var != null && !var.isSynthetic()) {
+				statement.error("Aspect " + aspectName + " has the same name as an existing attribute in " + getName(),
+						IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
+			}
+		}
 		getAspectsMap().put(aspectName, statement);
 	}
 

--- a/gaml.compiler/src/gaml/compiler/descriptions/TypeDescription.java
+++ b/gaml.compiler/src/gaml/compiler/descriptions/TypeDescription.java
@@ -448,6 +448,20 @@ public abstract class TypeDescription extends SymbolDescription implements IType
 	 * @param vd
 	 *            the vd
 	 */
+	/**
+	 * Verifies whether the attribute name collides with an aspect defined in the species.
+	 *
+	 * @param vd
+	 *            the variable description
+	 */
+	private void verifyAspectCollision(final IVariableDescription vd) {
+		if (vd.isSynthetic() || !(this instanceof ISpeciesDescription species)) return;
+		if (species.hasAspect(vd.getName())) {
+			vd.error("Attribute " + vd.getName() + " has the same name as an existing aspect in " + getName(),
+					IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
+		}
+	}
+
 	public void addOwnAttribute(final IVariableDescription vd) {
 		final String newVarName = vd.getName();
 		final IVariableDescription existing = getAttribute(newVarName);
@@ -459,10 +473,7 @@ public abstract class TypeDescription extends SymbolDescription implements IType
 			markAttributeRedefinition(existing, vd);
 			vd.copyFrom(existing);
 		}
-		if (this instanceof ISpeciesDescription species && !vd.isSynthetic() && species.hasAspect(newVarName)) {
-			vd.error("Attribute " + newVarName + " has the same name as an existing aspect in " + getName(),
-					IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
-		}
+		verifyAspectCollision(vd);
 
 		getAttributesMap().put(vd.getName(), vd);
 	}

--- a/gaml.compiler/src/gaml/compiler/descriptions/TypeDescription.java
+++ b/gaml.compiler/src/gaml/compiler/descriptions/TypeDescription.java
@@ -459,6 +459,10 @@ public abstract class TypeDescription extends SymbolDescription implements IType
 			markAttributeRedefinition(existing, vd);
 			vd.copyFrom(existing);
 		}
+		if (this instanceof ISpeciesDescription species && !vd.isSynthetic() && species.hasAspect(newVarName)) {
+			vd.error("Attribute " + newVarName + " has the same name as an existing aspect in " + getName(),
+					IGamlIssue.DUPLICATE_NAME, IKeyword.NAME);
+		}
 
 		getAttributesMap().put(vd.getName(), vd);
 	}


### PR DESCRIPTION
This change adds validation to `SpeciesDescription` and `TypeDescription` during GAML model compilation so that aspects and non-synthetic attributes cannot share the same name in a species, raising a `DUPLICATE_NAME` error when duplicate names are declared.

---
*PR created automatically by Jules for task [15120861690196288027](https://jules.google.com/task/15120861690196288027) started by @AlexisDrogoul*