### PR TITLE
Fix OpenGL antialias preference forced after first step

### DIFF
--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
@@ -1163,9 +1163,17 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
+	 * Invalidate cached texture state.
+	 */
+	public void invalidateTextureCache() {
+		lastBoundTexture = NO_TEXTURE;
+	}
+
+	/**
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
+		lastBoundTexture = NO_TEXTURE;
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
@@ -1163,9 +1163,9 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
-	 * Invalidate cached bound-texture state.
+	 * Invalidate cached texture state.
 	 */
-	public void invalidateBoundTextureState() {
+	public void invalidateTextureCache() {
 		lastBoundTexture = NO_TEXTURE;
 	}
 
@@ -1173,7 +1173,7 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
-		invalidateBoundTextureState();
+		lastBoundTexture = NO_TEXTURE;
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/OpenGL.java
@@ -1163,9 +1163,9 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
-	 * Invalidate cached texture state.
+	 * Invalidate cached bound-texture state.
 	 */
-	public void invalidateTextureCache() {
+	public void invalidateBoundTextureState() {
 		lastBoundTexture = NO_TEXTURE;
 	}
 
@@ -1173,7 +1173,7 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
-		lastBoundTexture = NO_TEXTURE;
+		invalidateBoundTextureState();
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
@@ -151,6 +151,7 @@ public class TextureCache2 implements ITextureCache/* , IPreferenceAfterChangeLi
 		if (texture == null) {
 			texture = this.buildTexture(gl.getGL(), img);
 			volatileTextures.put(id, texture);
+			gl.invalidateTextureCache();
 		}
 		return texture;
 	}

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
@@ -150,8 +150,10 @@ public class TextureCache2 implements ITextureCache/* , IPreferenceAfterChangeLi
 		Texture texture = volatileTextures.get(id);
 		if (texture == null) {
 			texture = this.buildTexture(gl.getGL(), img);
-			volatileTextures.put(id, texture);
-			gl.invalidateBoundTextureState();
+			if (texture != null) {
+				volatileTextures.put(id, texture);
+				gl.invalidateBoundTextureState();
+			}
 		}
 		return texture;
 	}

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
@@ -150,10 +150,8 @@ public class TextureCache2 implements ITextureCache/* , IPreferenceAfterChangeLi
 		Texture texture = volatileTextures.get(id);
 		if (texture == null) {
 			texture = this.buildTexture(gl.getGL(), img);
-			if (texture != null) {
-				volatileTextures.put(id, texture);
-				gl.invalidateBoundTextureState();
-			}
+			volatileTextures.put(id, texture);
+			gl.invalidateTextureCache();
 		}
 		return texture;
 	}

--- a/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl/src/gama/ui/display/opengl/renderer/caches/TextureCache2.java
@@ -151,7 +151,7 @@ public class TextureCache2 implements ITextureCache/* , IPreferenceAfterChangeLi
 		if (texture == null) {
 			texture = this.buildTexture(gl.getGL(), img);
 			volatileTextures.put(id, texture);
-			gl.invalidateTextureCache();
+			gl.invalidateBoundTextureState();
 		}
 		return texture;
 	}

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
@@ -1410,9 +1410,17 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
+	 * Invalidate cached texture state.
+	 */
+	public void invalidateTextureCache() {
+		lastBoundTexture = NO_TEXTURE;
+	}
+
+	/**
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
+		lastBoundTexture = NO_TEXTURE;
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
@@ -1410,9 +1410,9 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
-	 * Invalidate cached bound-texture state.
+	 * Invalidate cached texture state.
 	 */
-	public void invalidateBoundTextureState() {
+	public void invalidateTextureCache() {
 		lastBoundTexture = NO_TEXTURE;
 	}
 
@@ -1420,7 +1420,7 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
-		invalidateBoundTextureState();
+		lastBoundTexture = NO_TEXTURE;
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/OpenGL.java
@@ -1410,9 +1410,9 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	}
 
 	/**
-	 * Invalidate cached texture state.
+	 * Invalidate cached bound-texture state.
 	 */
-	public void invalidateTextureCache() {
+	public void invalidateBoundTextureState() {
 		lastBoundTexture = NO_TEXTURE;
 	}
 
@@ -1420,7 +1420,7 @@ public class OpenGL extends AbstractRendererHelper implements ITesselator {
 	 * Delete volatile textures.
 	 */
 	public void deleteVolatileTextures() {
-		lastBoundTexture = NO_TEXTURE;
+		invalidateBoundTextureState();
 		textureCache.deleteVolatileTextures();
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
@@ -138,6 +138,7 @@ public class TextureCache2 implements ITextureCache {
 		if (old != null) { old.destroy(gl.getGL()); }
 		Texture texture = this.buildTexture(gl.getGL(), img);
 		if (texture != null) { volatileTextures.put(id, texture); }
+		gl.invalidateTextureCache();
 		return texture;
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
@@ -138,7 +138,7 @@ public class TextureCache2 implements ITextureCache {
 		if (old != null) { old.destroy(gl.getGL()); }
 		Texture texture = this.buildTexture(gl.getGL(), img);
 		if (texture != null) { volatileTextures.put(id, texture); }
-		gl.invalidateTextureCache();
+		gl.invalidateBoundTextureState();
 		return texture;
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
@@ -137,8 +137,10 @@ public class TextureCache2 implements ITextureCache {
 		Texture old = volatileTextures.remove(id);
 		if (old != null) { old.destroy(gl.getGL()); }
 		Texture texture = this.buildTexture(gl.getGL(), img);
-		if (texture != null) { volatileTextures.put(id, texture); }
-		gl.invalidateBoundTextureState();
+		if (texture != null) {
+			volatileTextures.put(id, texture);
+			gl.invalidateBoundTextureState();
+		}
 		return texture;
 	}
 

--- a/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
+++ b/gama.ui.display.opengl4/src/gama/ui/display/opengl4/renderer/caches/TextureCache2.java
@@ -137,10 +137,8 @@ public class TextureCache2 implements ITextureCache {
 		Texture old = volatileTextures.remove(id);
 		if (old != null) { old.destroy(gl.getGL()); }
 		Texture texture = this.buildTexture(gl.getGL(), img);
-		if (texture != null) {
-			volatileTextures.put(id, texture);
-			gl.invalidateBoundTextureState();
-		}
+		if (texture != null) { volatileTextures.put(id, texture); }
+		gl.invalidateTextureCache();
 		return texture;
 	}
 


### PR DESCRIPTION
Fix OpenGL antialias preference being overridden after step 1 by invalidating the cached bound texture state when volatile textures are generated or destroyed.

This could fix #1157 