### PR TITLE
Fix static typing of dataframe columns in GAML

### DIFF
--- a/gama.extension.dataframe/src/gama/extension/dataframe/DataFrameOperators.java
+++ b/gama.extension.dataframe/src/gama/extension/dataframe/DataFrameOperators.java
@@ -70,6 +70,9 @@ public class DataFrameOperators {
 							isExecutable = false) }) })
 	@test ("(dataframe_with([\"name\",\"age\"], [[\"Alice\",30],[\"Bob\",25]])).rows = 2")
 	@test ("(dataframe_with([\"name\",\"age\"], [[\"Alice\",30],[\"Bob\",25]])).keys = [\"name\",\"age\"]")
+	@test ("string(type_of((dataframe_with([\"name\",\"age\"], [[\"Alice\",30],[\"Bob\",25]]))[\"name\"])) = \"list<unknown>\"")
+	@test ("string(type_of((dataframe_with([\"name\",\"age\"], [[\"Alice\",30],[\"Bob\",25]]))[\"name\"][0])) = \"unknown\"")
+	@test ("string(actual_type_of((dataframe_with([\"name\",\"age\"], [[\"Alice\",30],[\"Bob\",25]]))[\"name\"])) = \"list<string>\"")
 	public static IDataFrame dataframeWith(final IScope scope, final IList<String> columns, final IList<IList> data) {
 		return GamaDataFrameFactory.create(scope, columns, data);
 	}

--- a/gama.extension.dataframe/src/gama/extension/dataframe/GamaDataFrameType.java
+++ b/gama.extension.dataframe/src/gama/extension/dataframe/GamaDataFrameType.java
@@ -64,8 +64,11 @@ public class GamaDataFrameType extends GamaContainerType<IDataFrame> {
 	public IType<?> getKeyType() { return Types.STRING; }
 
 	@Override
+	public IType<?> getContentType() { return Types.LIST; }
+
+	@Override
 	public IType<?> contentsTypeIfCasting(final IExpression exp) {
-		return Types.NO_TYPE;
+		return Types.LIST;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #1137 where dataframe column access (e.g., df["col_name"]) evaluated to 'unknown' type instead of 'list<unknown>'. Overrides getContentType() and contentsTypeIfCasting() in GamaDataFrameType to return Types.LIST.
