### PR TITLE
Fix negative dates and antiquity handling in date type

### DIFF
--- a/gama.api/src/gama/api/gaml/types/GamaDateType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaDateType.java
@@ -440,41 +440,33 @@ public class GamaDateType extends GamaType<IDate> {
 	private static DateTimeFormatter buildModelFormatter(final String pattern, final String locale) {
 		final DateTimeFormatterBuilder df = new DateTimeFormatterBuilder();
 		df.parseCaseInsensitive();
-		for (final String s : parseModelPatternTokens(pattern)) {
-			appendModelToken(df, s);
+		final Matcher m = model_pattern.matcher(pattern);
+		int last = 0;
+		while (m.find()) {
+			if (last != m.start()) {
+				df.appendLiteral(pattern.substring(last, m.start()));
+			}
+			appendModelSymbol(df, m.group().charAt(1));
+			last = m.end();
+		}
+		if (last != pattern.length()) {
+			df.appendLiteral(pattern.substring(last));
 		}
 		return df.toFormatter(getLocale(locale));
 	}
 
-	private static List<String> parseModelPatternTokens(final String pattern) {
-		final List<String> dateList = new ArrayList<>();
-		final Matcher m = model_pattern.matcher(pattern);
-		int i = 0;
-		while (m.find()) {
-			if (i != m.start()) { dateList.add(pattern.substring(i, m.start())); }
-			dateList.add(m.group());
-			i = m.end();
-		}
-		if (i != pattern.length()) { dateList.add(pattern.substring(i)); }
-		return dateList;
-	}
-
-	private static void appendModelToken(final DateTimeFormatterBuilder df, final String s) {
-		if (s.length() == 2 && s.charAt(0) == '%') {
-			switch (s.charAt(1)) {
-				case 'Y' -> df.appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD);
-				case 'M' -> df.appendValue(MONTH_OF_YEAR, 2);
-				case 'N' -> df.appendText(MONTH_OF_YEAR);
-				case 'D' -> df.appendValue(DAY_OF_MONTH, 2);
-				case 'E' -> df.appendText(DAY_OF_WEEK);
-				case 'h' -> df.appendValue(HOUR_OF_DAY, 2);
-				case 'm' -> df.appendValue(MINUTE_OF_HOUR, 2);
-				case 's' -> df.appendValue(SECOND_OF_MINUTE, 2);
-				case 'z' -> df.appendZoneOrOffsetId();
-				default -> df.appendLiteral(s);
-			}
-		} else {
-			df.appendLiteral(s);
+	private static void appendModelSymbol(final DateTimeFormatterBuilder df, final char symbol) {
+		switch (symbol) {
+			case 'Y' -> df.appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD);
+			case 'M' -> df.appendValue(MONTH_OF_YEAR, 2);
+			case 'N' -> df.appendText(MONTH_OF_YEAR);
+			case 'D' -> df.appendValue(DAY_OF_MONTH, 2);
+			case 'E' -> df.appendText(DAY_OF_WEEK);
+			case 'h' -> df.appendValue(HOUR_OF_DAY, 2);
+			case 'm' -> df.appendValue(MINUTE_OF_HOUR, 2);
+			case 's' -> df.appendValue(SECOND_OF_MINUTE, 2);
+			case 'z' -> df.appendZoneOrOffsetId();
+			default -> df.appendLiteral("%" + symbol);
 		}
 	}
 

--- a/gama.api/src/gama/api/gaml/types/GamaDateType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaDateType.java
@@ -408,62 +408,74 @@ public class GamaDateType extends GamaType<IDate> {
 	 * @return the DateTimeFormatter for the pattern and locale
 	 */
 	public static DateTimeFormatter getFormatter(final String p, final String locale) {
-
 		final String pattern = p != null && p.contains("y") ? p.replace('y', 'u') : p;
-		// Can happen during initialization
 		if (FORMATTERS == null || FORMATTERS.isEmpty()) return DateTimeFormatter.ofPattern(GamaDateType.DEFAULT_FORMAT);
 		if (pattern == null) return FORMATTERS.get(GamaDateType.DEFAULT_KEY);
-		final DateTimeFormatter formatter = FORMATTERS.get(getFormatterKey(pattern, locale));
-		if (formatter != null) return formatter;
-		if (!pattern.contains("%")) {
-			try {
-				final DateTimeFormatterBuilder df = new DateTimeFormatterBuilder();
-				final DateTimeFormatter result =
-						df.parseCaseInsensitive().appendPattern(pattern).toFormatter(getLocale(locale));
-				FORMATTERS.put(getFormatterKey(pattern, locale), result);
-				return result;
-			} catch (final IllegalArgumentException e) {
-				GAMA.reportAndThrowIfNeeded(GAMA.getRuntimeScope(),
-						GamaRuntimeException.create(e, GAMA.getRuntimeScope()), false);
-				return FORMATTERS.get(GamaDateType.DEFAULT_KEY);
-			}
+
+		final String key = getFormatterKey(pattern, locale);
+		final DateTimeFormatter cached = FORMATTERS.get(key);
+		if (cached != null) return cached;
+
+		final DateTimeFormatter formatter = pattern.contains("%")
+				? buildModelFormatter(pattern, locale)
+				: buildJavaFormatter(pattern, locale);
+
+		FORMATTERS.put(key, formatter);
+		return formatter;
+	}
+
+	private static DateTimeFormatter buildJavaFormatter(final String pattern, final String locale) {
+		try {
+			return new DateTimeFormatterBuilder()
+					.parseCaseInsensitive()
+					.appendPattern(pattern)
+					.toFormatter(getLocale(locale));
+		} catch (final IllegalArgumentException e) {
+			GAMA.reportAndThrowIfNeeded(GAMA.getRuntimeScope(),
+					GamaRuntimeException.create(e, GAMA.getRuntimeScope()), false);
+			return FORMATTERS.get(GamaDateType.DEFAULT_KEY);
 		}
+	}
+
+	private static DateTimeFormatter buildModelFormatter(final String pattern, final String locale) {
 		final DateTimeFormatterBuilder df = new DateTimeFormatterBuilder();
 		df.parseCaseInsensitive();
+		for (final String s : parseModelPatternTokens(pattern)) {
+			appendModelToken(df, s);
+		}
+		return df.toFormatter(getLocale(locale));
+	}
+
+	private static List<String> parseModelPatternTokens(final String pattern) {
 		final List<String> dateList = new ArrayList<>();
 		final Matcher m = model_pattern.matcher(pattern);
 		int i = 0;
 		while (m.find()) {
-			final String tmp = m.group();
 			if (i != m.start()) { dateList.add(pattern.substring(i, m.start())); }
-			dateList.add(tmp);
+			dateList.add(m.group());
 			i = m.end();
 		}
 		if (i != pattern.length()) { dateList.add(pattern.substring(i)); }
-		for (i = 0; i < dateList.size(); i++) {
-			final String s = dateList.get(i);
-			if (s.charAt(0) == '%' && s.length() == 2) {
-				final Character c = s.charAt(1);
-				switch (c) {
-					case 'Y' -> df.appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD);
-					case 'M' -> df.appendValue(MONTH_OF_YEAR, 2);
-					case 'N' -> df.appendText(MONTH_OF_YEAR);
-					case 'D' -> df.appendValue(DAY_OF_MONTH, 2);
-					case 'E' -> df.appendText(DAY_OF_WEEK);
-					case 'h' -> df.appendValue(HOUR_OF_DAY, 2);
-					case 'm' -> df.appendValue(MINUTE_OF_HOUR, 2);
-					case 's' -> df.appendValue(SECOND_OF_MINUTE, 2);
-					case 'z' -> df.appendZoneOrOffsetId();
-					default -> df.appendLiteral(s);
-				}
+		return dateList;
+	}
 
-			} else {
-				df.appendLiteral(s);
+	private static void appendModelToken(final DateTimeFormatterBuilder df, final String s) {
+		if (s.length() == 2 && s.charAt(0) == '%') {
+			switch (s.charAt(1)) {
+				case 'Y' -> df.appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD);
+				case 'M' -> df.appendValue(MONTH_OF_YEAR, 2);
+				case 'N' -> df.appendText(MONTH_OF_YEAR);
+				case 'D' -> df.appendValue(DAY_OF_MONTH, 2);
+				case 'E' -> df.appendText(DAY_OF_WEEK);
+				case 'h' -> df.appendValue(HOUR_OF_DAY, 2);
+				case 'm' -> df.appendValue(MINUTE_OF_HOUR, 2);
+				case 's' -> df.appendValue(SECOND_OF_MINUTE, 2);
+				case 'z' -> df.appendZoneOrOffsetId();
+				default -> df.appendLiteral(s);
 			}
+		} else {
+			df.appendLiteral(s);
 		}
-		final DateTimeFormatter result = df.toFormatter(getLocale(locale));
-		FORMATTERS.put(getFormatterKey(pattern, locale), result);
-		return result;
 	}
 
 }

--- a/gama.api/src/gama/api/gaml/types/GamaDateType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaDateType.java
@@ -409,7 +409,7 @@ public class GamaDateType extends GamaType<IDate> {
 	 */
 	public static DateTimeFormatter getFormatter(final String p, final String locale) {
 
-		final String pattern = p;
+		final String pattern = p != null && p.contains("y") ? p.replace('y', 'u') : p;
 		// Can happen during initialization
 		if (FORMATTERS == null || FORMATTERS.isEmpty()) return DateTimeFormatter.ofPattern(GamaDateType.DEFAULT_FORMAT);
 		if (pattern == null) return FORMATTERS.get(GamaDateType.DEFAULT_KEY);

--- a/gama.api/src/gama/api/gaml/types/GamaDateType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaDateType.java
@@ -421,6 +421,8 @@ public class GamaDateType extends GamaType<IDate> {
 				? buildModelFormatter(pattern, loc)
 				: buildJavaFormatter(pattern, loc);
 
+		if (formatter == null) return FORMATTERS.get(GamaDateType.DEFAULT_KEY);
+
 		FORMATTERS.put(key, formatter);
 		return formatter;
 	}
@@ -434,7 +436,7 @@ public class GamaDateType extends GamaType<IDate> {
 		} catch (final IllegalArgumentException e) {
 			GAMA.reportAndThrowIfNeeded(GAMA.getRuntimeScope(),
 					GamaRuntimeException.create(e, GAMA.getRuntimeScope()), false);
-			return FORMATTERS.get(GamaDateType.DEFAULT_KEY);
+			return null;
 		}
 	}
 

--- a/gama.api/src/gama/api/gaml/types/GamaDateType.java
+++ b/gama.api/src/gama/api/gaml/types/GamaDateType.java
@@ -416,20 +416,21 @@ public class GamaDateType extends GamaType<IDate> {
 		final DateTimeFormatter cached = FORMATTERS.get(key);
 		if (cached != null) return cached;
 
+		final Locale loc = getLocale(locale);
 		final DateTimeFormatter formatter = pattern.contains("%")
-				? buildModelFormatter(pattern, locale)
-				: buildJavaFormatter(pattern, locale);
+				? buildModelFormatter(pattern, loc)
+				: buildJavaFormatter(pattern, loc);
 
 		FORMATTERS.put(key, formatter);
 		return formatter;
 	}
 
-	private static DateTimeFormatter buildJavaFormatter(final String pattern, final String locale) {
+	private static DateTimeFormatter buildJavaFormatter(final String pattern, final Locale loc) {
 		try {
 			return new DateTimeFormatterBuilder()
 					.parseCaseInsensitive()
 					.appendPattern(pattern)
-					.toFormatter(getLocale(locale));
+					.toFormatter(loc);
 		} catch (final IllegalArgumentException e) {
 			GAMA.reportAndThrowIfNeeded(GAMA.getRuntimeScope(),
 					GamaRuntimeException.create(e, GAMA.getRuntimeScope()), false);
@@ -437,7 +438,7 @@ public class GamaDateType extends GamaType<IDate> {
 		}
 	}
 
-	private static DateTimeFormatter buildModelFormatter(final String pattern, final String locale) {
+	private static DateTimeFormatter buildModelFormatter(final String pattern, final Locale loc) {
 		final DateTimeFormatterBuilder df = new DateTimeFormatterBuilder();
 		df.parseCaseInsensitive();
 		final Matcher m = model_pattern.matcher(pattern);
@@ -452,7 +453,7 @@ public class GamaDateType extends GamaType<IDate> {
 		if (last != pattern.length()) {
 			df.appendLiteral(pattern.substring(last));
 		}
-		return df.toFormatter(getLocale(locale));
+		return df.toFormatter(loc);
 	}
 
 	private static void appendModelSymbol(final DateTimeFormatterBuilder df, final char symbol) {

--- a/gama.api/src/gama/api/types/date/GamaDateFactory.java
+++ b/gama.api/src/gama/api/types/date/GamaDateFactory.java
@@ -330,74 +330,37 @@ public class GamaDateFactory {
 	private static Temporal parse(final IScope scope, final String original, final DateTimeFormatter df) {
 		if (original == null || original.isEmpty() || "now".equals(original))
 			return LocalDateTime.now(GamaDateFactory.DEFAULT_ZONE);
-		Temporal result = null;
 
-		if (df != null) {
-			try {
-				final TemporalAccessor ta = df.parse(original);
-				if (ta instanceof Temporal tmp) return tmp;
-				if (!ta.isSupported(ChronoField.YEAR) && !ta.isSupported(ChronoField.MONTH_OF_YEAR)
-						&& !ta.isSupported(ChronoField.DAY_OF_MONTH) && ta.isSupported(ChronoField.HOUR_OF_DAY))
-					return LocalTime.from(ta);
-				if (!ta.isSupported(ChronoField.HOUR_OF_DAY) && !ta.isSupported(ChronoField.MINUTE_OF_HOUR)
-						&& !ta.isSupported(ChronoField.SECOND_OF_MINUTE))
-					return LocalDate.from(ta);
-				return LocalDateTime.from(ta);
-			} catch (final DateTimeParseException e) {
-				e.printStackTrace();
-			}
-			GAMA.reportAndThrowIfNeeded(scope,
-					GamaRuntimeException.warning(
-							THE_DATE + original + " can not correctly be parsed by the pattern provided", scope),
-					false);
-			return parse(scope, original, null);
+		if (df != null) return parseWithFormatter(scope, original, df);
+
+		return parseIsoString(scope, original);
+	}
+
+	private static Temporal parseWithFormatter(final IScope scope, final String original, final DateTimeFormatter df) {
+		try {
+			final TemporalAccessor ta = df.parse(original);
+			if (ta instanceof Temporal tmp) return tmp;
+			if (!ta.isSupported(ChronoField.YEAR) && !ta.isSupported(ChronoField.MONTH_OF_YEAR)
+					&& !ta.isSupported(ChronoField.DAY_OF_MONTH) && ta.isSupported(ChronoField.HOUR_OF_DAY))
+				return LocalTime.from(ta);
+			if (!ta.isSupported(ChronoField.HOUR_OF_DAY) && !ta.isSupported(ChronoField.MINUTE_OF_HOUR)
+					&& !ta.isSupported(ChronoField.SECOND_OF_MINUTE))
+				return LocalDate.from(ta);
+			return LocalDateTime.from(ta);
+		} catch (final DateTimeParseException e) {
+			e.printStackTrace();
 		}
+		GAMA.reportAndThrowIfNeeded(scope,
+				GamaRuntimeException.warning(
+						THE_DATE + original + " can not correctly be parsed by the pattern provided", scope),
+				false);
+		return parse(scope, original, null);
+	}
 
+	private static Temporal parseIsoString(final IScope scope, final String original) {
 		String dateStr;
 		try {
-			// We first make sure all date fields have the correct length and
-			// the string is correctly formatted
-			String string = original;
-			if (!original.contains("T") && original.contains(" ")) {
-				string = StringUtils.replaceOnce(original, " ", "T");
-			}
-			final String[] base = string.split("T");
-			final String[] date = base[0].split("-");
-			String other;
-			if (base.length == 1) {
-				other = "00:00:00";
-			} else {
-				other = base[1];
-			}
-			String year, month = "01", day = "01";
-			boolean negativeYear = date[0].isEmpty();
-			int yearIndex = negativeYear ? 1 : 0;
-			if (date.length <= yearIndex) {
-				throw GamaRuntimeException.error(
-						THE_DATE + original + " is not correctly formatted. Please refer to the ISO date/time format",
-						scope);
-			}
-			String numericPart = date[yearIndex];
-			if (negativeYear) {
-				year = "-" + "0".repeat(Math.max(0, 4 - numericPart.length())) + numericPart;
-			} else {
-				if (numericPart.length() >= 8 && date.length == 1) {
-					// ISO basic date format e.g. 20240315
-					year = numericPart.substring(0, 4);
-					month = numericPart.substring(4, 6);
-					day = numericPart.substring(6, 8);
-				} else {
-					year = numericPart;
-					if (year.length() == 2) { year = "20" + year; }
-				}
-			}
-			if (!(!negativeYear && numericPart.length() >= 8 && date.length == 1)) {
-				if (date.length > yearIndex + 1) month = date[yearIndex + 1];
-				if (date.length > yearIndex + 2) day = date[yearIndex + 2];
-			}
-			if (month.length() == 1) { month = '0' + month; }
-			if (day.length() == 1) { day = '0' + day; }
-			dateStr = year + "-" + month + "-" + day + "T" + other;
+			dateStr = formatIsoDateString(original, scope);
 		} catch (final Exception e1) {
 			throw GamaRuntimeException.error(
 					THE_DATE + original + " is not correctly formatted. Please refer to the ISO date/time format",
@@ -405,21 +368,72 @@ public class GamaDateFactory {
 		}
 
 		try {
-			result = LocalDateTime.parse(dateStr);
+			return LocalDateTime.parse(dateStr);
 		} catch (final DateTimeParseException e) {
 			try {
-				result = OffsetDateTime.parse(dateStr);
+				return OffsetDateTime.parse(dateStr);
 			} catch (final DateTimeParseException e2) {
 				try {
-					result = ZonedDateTime.parse(dateStr);
+					return ZonedDateTime.parse(dateStr);
 				} catch (final DateTimeParseException e3) {
 					throw GamaRuntimeException.error(THE_DATE + original
 							+ " is not correctly formatted. Please refer to the ISO date/time format", scope);
 				}
 			}
 		}
+	}
 
-		return result;
+	private static String formatIsoDateString(final String original, final IScope scope) {
+		final String string = original.contains(" ") && !original.contains("T")
+				? StringUtils.replaceOnce(original, " ", "T")
+				: original;
+		final String[] base = string.split("T");
+		final String other = base.length == 1 ? "00:00:00" : base[1];
+		final String[] dateParts = base[0].split("-");
+
+		final boolean negativeYear = dateParts[0].isEmpty();
+		final int yearIndex = negativeYear ? 1 : 0;
+		if (dateParts.length <= yearIndex) {
+			throw GamaRuntimeException.error(
+					THE_DATE + original + " is not correctly formatted. Please refer to the ISO date/time format",
+					scope);
+		}
+
+		final String year = extractIsoYear(dateParts, yearIndex, negativeYear);
+		final String month = extractIsoMonth(dateParts, yearIndex, negativeYear);
+		final String day = extractIsoDay(dateParts, yearIndex, negativeYear);
+
+		return year + "-" + month + "-" + day + "T" + other;
+	}
+
+	private static String extractIsoYear(final String[] dateParts, final int yearIndex, final boolean negativeYear) {
+		final String numericPart = dateParts[yearIndex];
+		if (negativeYear) return "-" + "0".repeat(Math.max(0, 4 - numericPart.length())) + numericPart;
+		if (numericPart.length() >= 8 && dateParts.length == 1) return numericPart.substring(0, 4);
+		if (numericPart.length() == 2) return "20" + numericPart;
+		return numericPart;
+	}
+
+	private static String extractIsoMonth(final String[] dateParts, final int yearIndex, final boolean negativeYear) {
+		String month = "01";
+		final String numericPart = dateParts[yearIndex];
+		if (!negativeYear && numericPart.length() >= 8 && dateParts.length == 1) {
+			month = numericPart.substring(4, 6);
+		} else if (dateParts.length > yearIndex + 1) {
+			month = dateParts[yearIndex + 1];
+		}
+		return month.length() == 1 ? "0" + month : month;
+	}
+
+	private static String extractIsoDay(final String[] dateParts, final int yearIndex, final boolean negativeYear) {
+		String day = "01";
+		final String numericPart = dateParts[yearIndex];
+		if (!negativeYear && numericPart.length() >= 8 && dateParts.length == 1) {
+			day = numericPart.substring(6, 8);
+		} else if (dateParts.length > yearIndex + 2) {
+			day = dateParts[yearIndex + 2];
+		}
+		return day.length() == 1 ? "0" + day : day;
 	}
 
 }

--- a/gama.api/src/gama/api/types/date/GamaDateFactory.java
+++ b/gama.api/src/gama/api/types/date/GamaDateFactory.java
@@ -369,25 +369,32 @@ public class GamaDateFactory {
 			} else {
 				other = base[1];
 			}
-			String year, month, day;
-			if (date.length == 1) {
-				// ISO basic date format
-				year = date[0].substring(0, 4);
-				month = date[0].substring(4, 6);
-				day = date[0].substring(6, 8);
-			} else if (date.length >= 4 && date[0].isEmpty()) {
-				// Negative year: "-1000-01-01" splits to ["", "1000", "01", "01"]
-				// Pad the numeric portion to at least 4 digits for ISO compliance
-				final String numericPart = date[1];
-				year = "-" + "0".repeat(Math.max(0, 4 - numericPart.length())) + numericPart;
-				month = date[2];
-				day = date[3];
-			} else {
-				year = date[0];
-				month = date[1];
-				day = date[2];
+			String year, month = "01", day = "01";
+			boolean negativeYear = date[0].isEmpty();
+			int yearIndex = negativeYear ? 1 : 0;
+			if (date.length <= yearIndex) {
+				throw GamaRuntimeException.error(
+						THE_DATE + original + " is not correctly formatted. Please refer to the ISO date/time format",
+						scope);
 			}
-			if (year.length() == 2 && !year.startsWith("-")) { year = "20" + year; }
+			String numericPart = date[yearIndex];
+			if (negativeYear) {
+				year = "-" + "0".repeat(Math.max(0, 4 - numericPart.length())) + numericPart;
+			} else {
+				if (numericPart.length() >= 8 && date.length == 1) {
+					// ISO basic date format e.g. 20240315
+					year = numericPart.substring(0, 4);
+					month = numericPart.substring(4, 6);
+					day = numericPart.substring(6, 8);
+				} else {
+					year = numericPart;
+					if (year.length() == 2) { year = "20" + year; }
+				}
+			}
+			if (!(!negativeYear && numericPart.length() >= 8 && date.length == 1)) {
+				if (date.length > yearIndex + 1) month = date[yearIndex + 1];
+				if (date.length > yearIndex + 2) day = date[yearIndex + 2];
+			}
 			if (month.length() == 1) { month = '0' + month; }
 			if (day.length() == 1) { day = '0' + day; }
 			dateStr = year + "-" + month + "-" + day + "T" + other;

--- a/gama.api/src/gama/api/types/date/GamaDateFactory.java
+++ b/gama.api/src/gama/api/types/date/GamaDateFactory.java
@@ -340,12 +340,8 @@ public class GamaDateFactory {
 		try {
 			final TemporalAccessor ta = df.parse(original);
 			if (ta instanceof Temporal tmp) return tmp;
-			if (!ta.isSupported(ChronoField.YEAR) && !ta.isSupported(ChronoField.MONTH_OF_YEAR)
-					&& !ta.isSupported(ChronoField.DAY_OF_MONTH) && ta.isSupported(ChronoField.HOUR_OF_DAY))
-				return LocalTime.from(ta);
-			if (!ta.isSupported(ChronoField.HOUR_OF_DAY) && !ta.isSupported(ChronoField.MINUTE_OF_HOUR)
-					&& !ta.isSupported(ChronoField.SECOND_OF_MINUTE))
-				return LocalDate.from(ta);
+			if (isTimeOnly(ta)) return LocalTime.from(ta);
+			if (isDateOnly(ta)) return LocalDate.from(ta);
 			return LocalDateTime.from(ta);
 		} catch (final DateTimeParseException e) {
 			e.printStackTrace();
@@ -355,6 +351,20 @@ public class GamaDateFactory {
 						THE_DATE + original + " can not correctly be parsed by the pattern provided", scope),
 				false);
 		return parse(scope, original, null);
+	}
+
+	private static boolean isTimeOnly(final TemporalAccessor ta) {
+		final boolean hasDate = ta.isSupported(ChronoField.YEAR)
+				|| ta.isSupported(ChronoField.MONTH_OF_YEAR)
+				|| ta.isSupported(ChronoField.DAY_OF_MONTH);
+		return !hasDate && ta.isSupported(ChronoField.HOUR_OF_DAY);
+	}
+
+	private static boolean isDateOnly(final TemporalAccessor ta) {
+		final boolean hasTime = ta.isSupported(ChronoField.HOUR_OF_DAY)
+				|| ta.isSupported(ChronoField.MINUTE_OF_HOUR)
+				|| ta.isSupported(ChronoField.SECOND_OF_MINUTE);
+		return !hasTime;
 	}
 
 	private static Temporal parseIsoString(final IScope scope, final String original) {

--- a/gama.core/src/gama/core/simulation/SimulationClock.java
+++ b/gama.core/src/gama/core/simulation/SimulationClock.java
@@ -343,7 +343,7 @@ public class SimulationClock implements IClock {
 			try {
 				IDate d = getCurrentDate();
 				final String date = outputAsDuration ? Dates.asDuration(getStartingDate(), d)
-						: d.toString("yyyy-MM-dd HH:mm:ss", "en");
+						: d.toString("uuuu-MM-dd HH:mm:ss", "en");
 				sb.append("[").append(date).append("]");
 			} catch (final DateTimeException e) {}
 		}

--- a/gama.core/src/gama/gaml/operators/Colors.java
+++ b/gama.core/src/gama/gaml/operators/Colors.java
@@ -684,7 +684,7 @@ public class Colors {
 					equals = "a random color, equivalent to rgb(rnd(255),rnd(255),rnd(255))",
 					test = false),
 			see = { "rgb", "hsb" })
-	@no_test
+	@test ("seed <- 1.0; int(rnd_color(255)) = -3749758")
 	public static IColor random_color(final IScope scope, final Integer max) {
 		final IRandom r = scope.getRandom();
 		final int realMax = Math.max(0, Math.min(max, 255));
@@ -715,7 +715,7 @@ public class Colors {
 					equals = "a random color, equivalent to rgb(rnd(100, 200),rnd(100, 200),rnd(100, 200))",
 					test = false),
 			see = { "rgb", "hsb" })
-	@no_test
+	@test ("seed <- 1.0; int(rnd_color(100, 200)) = -5065833")
 	public static IColor random_color(final IScope scope, final Integer min, final Integer max) {
 		final IRandom r = scope.getRandom();
 		final int realMax = Math.max(0, Math.min(max, 255));

--- a/gama.core/src/gama/gaml/operators/Colors.java
+++ b/gama.core/src/gama/gaml/operators/Colors.java
@@ -684,7 +684,7 @@ public class Colors {
 					equals = "a random color, equivalent to rgb(rnd(255),rnd(255),rnd(255))",
 					test = false),
 			see = { "rgb", "hsb" })
-	@test ("seed <- 1.0; int(rnd_color(255)) = -3749758")
+	@no_test
 	public static IColor random_color(final IScope scope, final Integer max) {
 		final IRandom r = scope.getRandom();
 		final int realMax = Math.max(0, Math.min(max, 255));
@@ -715,7 +715,7 @@ public class Colors {
 					equals = "a random color, equivalent to rgb(rnd(100, 200),rnd(100, 200),rnd(100, 200))",
 					test = false),
 			see = { "rgb", "hsb" })
-	@test ("seed <- 1.0; int(rnd_color(100, 200)) = -5065833")
+	@no_test
 	public static IColor random_color(final IScope scope, final Integer min, final Integer max) {
 		final IRandom r = scope.getRandom();
 		final int realMax = Math.max(0, Math.min(max, 255));

--- a/gama.core/src/gama/gaml/operators/Dates.java
+++ b/gama.core/src/gama/gaml/operators/Dates.java
@@ -1113,6 +1113,8 @@ public class Dates {
 					equals = "'2000-01-01 00:00:00_Test'") })
 	@test ("date('2000-01-01 00:00:00') + '_Test' = '2000-01-01 00:00:00_Test'")
 	@test ("date('-1000-01-01 00:00:00') + '' = '-1000-01-01 00:00:00'")
+	@test ("date([-1000, 1, 1]) + '' = '-1000-01-01 00:00:00'")
+	@test ("(date([0, 1, 1]) subtract_years 1) + '' = '-0001-01-01 00:00:00'")
 	public static String concatenateDate(final IScope scope, final IDate date1, final String text)
 			throws GamaRuntimeException {
 		return date1.toString() + text;

--- a/gama.core/tests/Basic Tests/models/Date Parsing.experiment
+++ b/gama.core/tests/Basic Tests/models/Date Parsing.experiment
@@ -45,6 +45,22 @@ experiment DateParsingTest type: test {
 		assert date4.year = 2025 and date4.month = 1 and date4.day = 15;
 		date date5 <- date(['15.01.2025', 'dd.MM.yyyy']);
 		assert date5.year = 2025 and date5.month = 1 and date5.day = 15;
+
+		// Test 8: Antiquity / Negative year dates
+		date neg_date1 <- date([-1000, 1, 1]);
+		assert neg_date1.year = -1000 and neg_date1.month = 1 and neg_date1.day = 1;
+		assert string(neg_date1, 'yyyy-MM-dd') = '-1000-01-01';
+
+		date neg_date2 <- date("-1000-01-01");
+		assert neg_date2.year = -1000 and neg_date2.month = 1 and neg_date2.day = 1;
+
+		date neg_date3 <- date("-100-01-01");
+		assert neg_date3.year = -100 and neg_date3.month = 1 and neg_date3.day = 1;
+
+		date zero_date <- date([0, 1, 1]);
+		date sub_date <- zero_date subtract_years 1;
+		assert sub_date.year = -1;
+		assert string(sub_date, 'yyyy-MM-dd') = '-0001-01-01';
 	}
 	
 }


### PR DESCRIPTION
Properly support negative years (antiquity dates) by mapping year pattern symbols ('y') to proleptic years ('u') in DateTimeFormatter, supporting negative year ISO string parsing with padded digits, and updating clock date formatting.
