### PR TITLE
Fix overlapping and spatial queries for geometries outside the world shape

### DIFF
--- a/gama.core/src/gama/core/topology/AbstractTopology.java
+++ b/gama.core/src/gama/core/topology/AbstractTopology.java
@@ -44,7 +44,6 @@ import gama.api.types.topology.ITopology;
 import gama.api.utils.collections.Collector;
 import gama.api.utils.collections.ICollector;
 import gama.api.utils.geometry.GeometryUtils;
-import gama.api.utils.geometry.GamaEnvelopeFactory;
 import gama.api.utils.geometry.IEnvelope;
 import gama.api.utils.interfaces.IAgentFilter;
 import gama.core.topology.continuous.RootTopology;
@@ -628,7 +627,7 @@ public abstract class AbstractTopology implements ITopology {
 		boolean covered = relation == SpatialRelation.INSIDE;
 		// insertAgents(scope, f);
 		if (!isTorus()) {
-			final IEnvelope envelope = GamaEnvelopeFactory.of(source.getEnvelope());
+			final IEnvelope envelope = source.getEnvelope();
 			try {
 				final Collection<IAgent> shapes = getSpatialIndex().allInEnvelope(scope, source, envelope, f, covered);
 				final PreparedGeometry pg = pgFact.create(source.getInnerGeometry());

--- a/gama.core/src/gama/core/topology/AbstractTopology.java
+++ b/gama.core/src/gama/core/topology/AbstractTopology.java
@@ -44,6 +44,7 @@ import gama.api.types.topology.ITopology;
 import gama.api.utils.collections.Collector;
 import gama.api.utils.collections.ICollector;
 import gama.api.utils.geometry.GeometryUtils;
+import gama.api.utils.geometry.GamaEnvelopeFactory;
 import gama.api.utils.geometry.IEnvelope;
 import gama.api.utils.interfaces.IAgentFilter;
 import gama.core.topology.continuous.RootTopology;
@@ -627,7 +628,7 @@ public abstract class AbstractTopology implements ITopology {
 		boolean covered = relation == SpatialRelation.INSIDE;
 		// insertAgents(scope, f);
 		if (!isTorus()) {
-			final IEnvelope envelope = source.getEnvelope().intersection(environment.getEnvelope());
+			final IEnvelope envelope = GamaEnvelopeFactory.of(source.getEnvelope());
 			try {
 				final Collection<IAgent> shapes = getSpatialIndex().allInEnvelope(scope, source, envelope, f, covered);
 				final PreparedGeometry pg = pgFact.create(source.getInnerGeometry());

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -429,13 +429,82 @@ public class GamaOctTree implements ISpatialIndex {
 	 * @param agent
 	 *            the agent to insert; {@code null} is silently ignored
 	 */
+	private void ensureBoundsCover(final IEnvelope env) {
+		if (env == null || env.isNull() || root.bounds.covers(env)) return;
+		while (!root.bounds.covers(env)) {
+			final double minX = root.bounds.getMinX();
+			final double maxX = root.bounds.getMaxX();
+			final double minY = root.bounds.getMinY();
+			final double maxY = root.bounds.getMaxY();
+			final double minZ = root.bounds.getMinZ();
+			final double maxZ = root.bounds.getMaxZ();
+			double w = maxX - minX;
+			double h = maxY - minY;
+			double d = maxZ - minZ;
+			if (w <= 0 || h <= 0 || d <= 0) {
+				w = Math.max(1.0, env.getWidth());
+				h = Math.max(1.0, env.getHeight());
+				d = Math.max(1.0, env.getDepth());
+				root = new OctNode(GamaEnvelopeFactory.of(
+						Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
+						Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY()),
+						Math.min(minZ, env.getMinZ()), Math.max(maxZ, env.getMaxZ())));
+				break;
+			}
+			final boolean expandWest = env.getMinX() < minX;
+			final boolean expandNorth = env.getMinY() < minY;
+			final boolean expandFront = env.getMinZ() < minZ;
+
+			final double newMinX = expandWest ? minX - w : minX;
+			final double newMaxX = expandWest ? maxX : maxX + w;
+			final double newMinY = expandNorth ? minY - h : minY;
+			final double newMaxY = expandNorth ? maxY : maxY + h;
+			final double newMinZ = expandFront ? minZ - d : minZ;
+			final double newMaxZ = expandFront ? maxZ : maxZ + d;
+
+			final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
+			final OctNode newRoot = new OctNode(newBounds);
+
+			final double halfx = newRoot.halfx;
+			final double halfy = newRoot.halfy;
+			final double halfz = newRoot.halfz;
+
+			newRoot.nwf = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy, newMinZ, halfz));
+			newRoot.nef = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy, newMinZ, halfz));
+			newRoot.swf = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY, newMinZ, halfz));
+			newRoot.sef = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY, newMinZ, halfz));
+			newRoot.nwb = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy, halfz, newMaxZ));
+			newRoot.neb = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy, halfz, newMaxZ));
+			newRoot.swb = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY, halfz, newMaxZ));
+			newRoot.seb = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY, halfz, newMaxZ));
+
+			if (expandFront) {
+				if (expandNorth) {
+					if (expandWest) newRoot.seb = root; else newRoot.swb = root;
+				} else {
+					if (expandWest) newRoot.neb = root; else newRoot.nwb = root;
+				}
+			} else {
+				if (expandNorth) {
+					if (expandWest) newRoot.sef = root; else newRoot.swf = root;
+				} else {
+					if (expandWest) newRoot.nef = root; else newRoot.nwf = root;
+				}
+			}
+
+			root = newRoot;
+		}
+	}
+
 	@Override
 	public void insert(final IAgent agent) {
 		if (agent == null) return;
+		final IEnvelope env = agent.getEnvelope();
+		ensureBoundsCover(env);
 		if (agent.isPoint()) {
 			root.add(agent.getLocation(), agent);
 		} else {
-			root.add(agent.getEnvelope(), agent);
+			root.add(env, agent);
 		}
 	}
 

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -448,7 +448,15 @@ public class GamaOctTree implements ISpatialIndex {
 		final double h = b.getHeight();
 		final double d = b.getDepth();
 
-		if (w <= 0 || h <= 0 || d <= 0) {
+		if (w <= 0) {
+			recreateDegenerateRoot(env, b);
+			return false;
+		}
+		if (h <= 0) {
+			recreateDegenerateRoot(env, b);
+			return false;
+		}
+		if (d <= 0) {
 			recreateDegenerateRoot(env, b);
 			return false;
 		}
@@ -458,32 +466,55 @@ public class GamaOctTree implements ISpatialIndex {
 	}
 
 	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
-		root = new OctNode(GamaEnvelopeFactory.of(
-				Math.min(b.getMinX(), env.getMinX()), Math.max(b.getMaxX(), env.getMaxX()),
-				Math.min(b.getMinY(), env.getMinY()), Math.max(b.getMaxY(), env.getMaxY()),
-				Math.min(b.getMinZ(), env.getMinZ()), Math.max(b.getMaxZ(), env.getMaxZ())));
+		final double minX = Math.min(b.getMinX(), env.getMinX());
+		final double maxX = Math.max(b.getMaxX(), env.getMaxX());
+		final double minY = Math.min(b.getMinY(), env.getMinY());
+		final double maxY = Math.max(b.getMaxY(), env.getMaxY());
+		final double minZ = Math.min(b.getMinZ(), env.getMinZ());
+		final double maxZ = Math.max(b.getMaxZ(), env.getMaxZ());
+		root = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h, final double d) {
-		final boolean expandWest = env.getMinX() < b.getMinX();
-		final boolean expandNorth = env.getMinY() < b.getMinY();
-		final boolean expandFront = env.getMinZ() < b.getMinZ();
+		final IEnvelope newEnv = computeExpandedEnvelope3D(env, b, w, h, d);
+		final int oldOctant = computeOldOctant(env, b);
+		final OctNode newRoot = new OctNode(newEnv);
 
-		final double minX = expandWest ? b.getMinX() - w : b.getMinX();
-		final double maxX = expandWest ? b.getMaxX() : b.getMaxX() + w;
-		final double minY = expandNorth ? b.getMinY() - h : b.getMinY();
-		final double maxY = expandNorth ? b.getMaxY() : b.getMaxY() + h;
-		final double minZ = expandFront ? b.getMinZ() - d : b.getMinZ();
-		final double maxZ = expandFront ? b.getMaxZ() : b.getMaxZ() + d;
-
-		final OctNode newRoot = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
-		final int oldOctant = (expandFront ? 4 : 0) | (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
-
-		populateNewRootChildren(newRoot, oldOctant, minX, maxX, minY, maxY, minZ, maxZ);
+		populateNewRootChildren(newRoot, oldOctant);
 		root = newRoot;
 	}
 
-	private void populateNewRootChildren(final OctNode newRoot, final int oldOctant, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
+	private IEnvelope computeExpandedEnvelope3D(final IEnvelope env, final IEnvelope b, final double w, final double h, final double d) {
+		double minX = b.getMinX();
+		double maxX = b.getMaxX();
+		double minY = b.getMinY();
+		double maxY = b.getMaxY();
+		double minZ = b.getMinZ();
+		double maxZ = b.getMaxZ();
+
+		if (env.getMinX() < b.getMinX()) minX -= w; else maxX += w;
+		if (env.getMinY() < b.getMinY()) minY -= h; else maxY += h;
+		if (env.getMinZ() < b.getMinZ()) minZ -= d; else maxZ += d;
+
+		return GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ);
+	}
+
+	private int computeOldOctant(final IEnvelope env, final IEnvelope b) {
+		int octant = 0;
+		if (env.getMinZ() < b.getMinZ()) octant |= 4;
+		if (env.getMinY() < b.getMinY()) octant |= 2;
+		if (env.getMinX() < b.getMinX()) octant |= 1;
+		return octant;
+	}
+
+	private void populateNewRootChildren(final OctNode newRoot, final int oldOctant) {
+		final IEnvelope env = newRoot.bounds;
+		final double minX = env.getMinX();
+		final double maxX = env.getMaxX();
+		final double minY = env.getMinY();
+		final double maxY = env.getMaxY();
+		final double minZ = env.getMinZ();
+		final double maxZ = env.getMaxZ();
 		final double hx = newRoot.halfx;
 		final double hy = newRoot.halfy;
 		final double hz = newRoot.halfz;

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -114,7 +114,7 @@ public class GamaOctTree implements ISpatialIndex {
 	/**
 	 * The root node of the octree. It covers the entire simulation envelope.
 	 */
-	final OctNode root;
+	volatile OctNode root;
 
 	/**
 	 * The maximum number of agents that a single {@link OctNode} may hold before it is split into eight children.
@@ -466,13 +466,26 @@ public class GamaOctTree implements ISpatialIndex {
 	}
 
 	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
+		final OctNode oldRoot = root;
 		final double minX = Math.min(b.getMinX(), env.getMinX());
 		final double maxX = Math.max(b.getMaxX(), env.getMaxX());
 		final double minY = Math.min(b.getMinY(), env.getMinY());
 		final double maxY = Math.max(b.getMaxY(), env.getMaxY());
 		final double minZ = Math.min(b.getMinZ(), env.getMinZ());
 		final double maxZ = Math.max(b.getMaxZ(), env.getMaxZ());
-		root = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
+		final OctNode newRoot = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
+
+		oldRoot.objects.forEach((a, e) -> {
+			if (a != null && !a.dead() && e != null) {
+				if (e instanceof IPoint) {
+					newRoot.add((IPoint) e, a);
+				} else {
+					newRoot.add((IEnvelope) e, a);
+				}
+			}
+		});
+		oldRoot.objects.clear();
+		root = newRoot;
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h, final double d) {

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -429,89 +429,73 @@ public class GamaOctTree implements ISpatialIndex {
 	 * @param agent
 	 *            the agent to insert; {@code null} is silently ignored
 	 */
+	private boolean isCovered(final IEnvelope env) {
+		if (env == null) return true;
+		if (env.isNull()) return true;
+		return root.bounds.covers(env);
+	}
+
 	private void ensureBoundsCover(final IEnvelope env) {
-		if (env == null || env.isNull() || root.bounds.covers(env)) return;
+		if (isCovered(env)) return;
 		while (!root.bounds.covers(env)) {
 			if (!expandRootStep(env)) break;
 		}
 	}
 
 	private boolean expandRootStep(final IEnvelope env) {
-		final double minX = root.bounds.getMinX();
-		final double maxX = root.bounds.getMaxX();
-		final double minY = root.bounds.getMinY();
-		final double maxY = root.bounds.getMaxY();
-		final double minZ = root.bounds.getMinZ();
-		final double maxZ = root.bounds.getMaxZ();
-		final double w = maxX - minX;
-		final double h = maxY - minY;
-		final double d = maxZ - minZ;
+		final IEnvelope b = root.bounds;
+		final double w = b.getWidth();
+		final double h = b.getHeight();
+		final double d = b.getDepth();
 
 		if (w <= 0 || h <= 0 || d <= 0) {
-			recreateDegenerateRoot(env, minX, maxX, minY, maxY, minZ, maxZ);
+			recreateDegenerateRoot(env, b);
 			return false;
 		}
 
-		expandRootBounds(env, minX, maxX, minY, maxY, minZ, maxZ, w, h, d);
+		expandRootBounds(env, b, w, h, d);
 		return true;
 	}
 
-	private void recreateDegenerateRoot(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
+	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
 		root = new OctNode(GamaEnvelopeFactory.of(
-				Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
-				Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY()),
-				Math.min(minZ, env.getMinZ()), Math.max(maxZ, env.getMaxZ())));
+				Math.min(b.getMinX(), env.getMinX()), Math.max(b.getMaxX(), env.getMaxX()),
+				Math.min(b.getMinY(), env.getMinY()), Math.max(b.getMaxY(), env.getMaxY()),
+				Math.min(b.getMinZ(), env.getMinZ()), Math.max(b.getMaxZ(), env.getMaxZ())));
 	}
 
-	private void expandRootBounds(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ, final double w, final double h, final double d) {
-		final boolean expandWest = env.getMinX() < minX;
-		final boolean expandNorth = env.getMinY() < minY;
-		final boolean expandFront = env.getMinZ() < minZ;
+	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h, final double d) {
+		final boolean expandWest = env.getMinX() < b.getMinX();
+		final boolean expandNorth = env.getMinY() < b.getMinY();
+		final boolean expandFront = env.getMinZ() < b.getMinZ();
 
-		final double newMinX = expandWest ? minX - w : minX;
-		final double newMaxX = expandWest ? maxX : maxX + w;
-		final double newMinY = expandNorth ? minY - h : minY;
-		final double newMaxY = expandNorth ? maxY : maxY + h;
-		final double newMinZ = expandFront ? minZ - d : minZ;
-		final double newMaxZ = expandFront ? maxZ : maxZ + d;
+		final double minX = expandWest ? b.getMinX() - w : b.getMinX();
+		final double maxX = expandWest ? b.getMaxX() : b.getMaxX() + w;
+		final double minY = expandNorth ? b.getMinY() - h : b.getMinY();
+		final double maxY = expandNorth ? b.getMaxY() : b.getMaxY() + h;
+		final double minZ = expandFront ? b.getMinZ() - d : b.getMinZ();
+		final double maxZ = expandFront ? b.getMaxZ() : b.getMaxZ() + d;
 
-		final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
-		final OctNode newRoot = new OctNode(newBounds);
+		final OctNode newRoot = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
+		final int oldOctant = (expandFront ? 4 : 0) | (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
 
-		createChildrenForNewRoot(newRoot, newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
-		assignOldRootToOctant(newRoot, expandFront, expandNorth, expandWest);
-
+		populateNewRootChildren(newRoot, oldOctant, minX, maxX, minY, maxY, minZ, maxZ);
 		root = newRoot;
 	}
 
-	private void createChildrenForNewRoot(final OctNode newRoot, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
+	private void populateNewRootChildren(final OctNode newRoot, final int oldOctant, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
 		final double hx = newRoot.halfx;
 		final double hy = newRoot.halfy;
 		final double hz = newRoot.halfz;
 
-		newRoot.nwf = new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, minZ, hz));
-		newRoot.nef = new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, minZ, hz));
-		newRoot.swf = new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, minZ, hz));
-		newRoot.sef = new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, minZ, hz));
-		newRoot.nwb = new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, hz, maxZ));
-		newRoot.neb = new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, hz, maxZ));
-		newRoot.swb = new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, hz, maxZ));
-		newRoot.seb = new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, hz, maxZ));
-	}
-
-	private void assignOldRootToOctant(final OctNode newRoot, final boolean expandFront, final boolean expandNorth, final boolean expandWest) {
-		final int oldOctant = (expandFront ? 4 : 0) | (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
-		switch (oldOctant) {
-			case 0 -> newRoot.nwf = root;
-			case 1 -> newRoot.nef = root;
-			case 2 -> newRoot.swf = root;
-			case 3 -> newRoot.sef = root;
-			case 4 -> newRoot.nwb = root;
-			case 5 -> newRoot.neb = root;
-			case 6 -> newRoot.swb = root;
-			case 7 -> newRoot.seb = root;
-			default -> {}
-		}
+		newRoot.nwf = oldOctant == 0 ? root : new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, minZ, hz));
+		newRoot.nef = oldOctant == 1 ? root : new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, minZ, hz));
+		newRoot.swf = oldOctant == 2 ? root : new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, minZ, hz));
+		newRoot.sef = oldOctant == 3 ? root : new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, minZ, hz));
+		newRoot.nwb = oldOctant == 4 ? root : new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, hz, maxZ));
+		newRoot.neb = oldOctant == 5 ? root : new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, hz, maxZ));
+		newRoot.swb = oldOctant == 6 ? root : new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, hz, maxZ));
+		newRoot.seb = oldOctant == 7 ? root : new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, hz, maxZ));
 	}
 
 	@Override

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -435,7 +435,7 @@ public class GamaOctTree implements ISpatialIndex {
 		return root.bounds.covers(env);
 	}
 
-	private void ensureBoundsCover(final IEnvelope env) {
+	private synchronized void ensureBoundsCover(final IEnvelope env) {
 		if (isCovered(env)) return;
 		while (!root.bounds.covers(env)) {
 			if (!expandRootStep(env)) break;
@@ -475,17 +475,31 @@ public class GamaOctTree implements ISpatialIndex {
 		final double maxZ = Math.max(b.getMaxZ(), env.getMaxZ());
 		final OctNode newRoot = new OctNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY, minZ, maxZ));
 
-		oldRoot.objects.forEach((a, e) -> {
+		migrateSubtree(oldRoot, newRoot);
+		root = newRoot;
+	}
+
+	private void migrateSubtree(final OctNode node, final OctNode target) {
+		if (node == null) return;
+		node.objects.forEach((a, e) -> {
 			if (a != null && !a.dead() && e != null) {
 				if (e instanceof IPoint) {
-					newRoot.add((IPoint) e, a);
+					target.add((IPoint) e, a);
 				} else {
-					newRoot.add((IEnvelope) e, a);
+					target.add((IEnvelope) e, a);
 				}
 			}
 		});
-		oldRoot.objects.clear();
-		root = newRoot;
+		if (node.nwf != null) {
+			migrateSubtree(node.nwf, target);
+			migrateSubtree(node.nef, target);
+			migrateSubtree(node.swf, target);
+			migrateSubtree(node.sef, target);
+			migrateSubtree(node.nwb, target);
+			migrateSubtree(node.neb, target);
+			migrateSubtree(node.swb, target);
+			migrateSubtree(node.seb, target);
+		}
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h, final double d) {

--- a/gama.core/src/gama/core/topology/GamaOctTree.java
+++ b/gama.core/src/gama/core/topology/GamaOctTree.java
@@ -432,67 +432,85 @@ public class GamaOctTree implements ISpatialIndex {
 	private void ensureBoundsCover(final IEnvelope env) {
 		if (env == null || env.isNull() || root.bounds.covers(env)) return;
 		while (!root.bounds.covers(env)) {
-			final double minX = root.bounds.getMinX();
-			final double maxX = root.bounds.getMaxX();
-			final double minY = root.bounds.getMinY();
-			final double maxY = root.bounds.getMaxY();
-			final double minZ = root.bounds.getMinZ();
-			final double maxZ = root.bounds.getMaxZ();
-			double w = maxX - minX;
-			double h = maxY - minY;
-			double d = maxZ - minZ;
-			if (w <= 0 || h <= 0 || d <= 0) {
-				w = Math.max(1.0, env.getWidth());
-				h = Math.max(1.0, env.getHeight());
-				d = Math.max(1.0, env.getDepth());
-				root = new OctNode(GamaEnvelopeFactory.of(
-						Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
-						Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY()),
-						Math.min(minZ, env.getMinZ()), Math.max(maxZ, env.getMaxZ())));
-				break;
-			}
-			final boolean expandWest = env.getMinX() < minX;
-			final boolean expandNorth = env.getMinY() < minY;
-			final boolean expandFront = env.getMinZ() < minZ;
+			if (!expandRootStep(env)) break;
+		}
+	}
 
-			final double newMinX = expandWest ? minX - w : minX;
-			final double newMaxX = expandWest ? maxX : maxX + w;
-			final double newMinY = expandNorth ? minY - h : minY;
-			final double newMaxY = expandNorth ? maxY : maxY + h;
-			final double newMinZ = expandFront ? minZ - d : minZ;
-			final double newMaxZ = expandFront ? maxZ : maxZ + d;
+	private boolean expandRootStep(final IEnvelope env) {
+		final double minX = root.bounds.getMinX();
+		final double maxX = root.bounds.getMaxX();
+		final double minY = root.bounds.getMinY();
+		final double maxY = root.bounds.getMaxY();
+		final double minZ = root.bounds.getMinZ();
+		final double maxZ = root.bounds.getMaxZ();
+		final double w = maxX - minX;
+		final double h = maxY - minY;
+		final double d = maxZ - minZ;
 
-			final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
-			final OctNode newRoot = new OctNode(newBounds);
+		if (w <= 0 || h <= 0 || d <= 0) {
+			recreateDegenerateRoot(env, minX, maxX, minY, maxY, minZ, maxZ);
+			return false;
+		}
 
-			final double halfx = newRoot.halfx;
-			final double halfy = newRoot.halfy;
-			final double halfz = newRoot.halfz;
+		expandRootBounds(env, minX, maxX, minY, maxY, minZ, maxZ, w, h, d);
+		return true;
+	}
 
-			newRoot.nwf = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy, newMinZ, halfz));
-			newRoot.nef = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy, newMinZ, halfz));
-			newRoot.swf = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY, newMinZ, halfz));
-			newRoot.sef = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY, newMinZ, halfz));
-			newRoot.nwb = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy, halfz, newMaxZ));
-			newRoot.neb = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy, halfz, newMaxZ));
-			newRoot.swb = new OctNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY, halfz, newMaxZ));
-			newRoot.seb = new OctNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY, halfz, newMaxZ));
+	private void recreateDegenerateRoot(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
+		root = new OctNode(GamaEnvelopeFactory.of(
+				Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
+				Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY()),
+				Math.min(minZ, env.getMinZ()), Math.max(maxZ, env.getMaxZ())));
+	}
 
-			if (expandFront) {
-				if (expandNorth) {
-					if (expandWest) newRoot.seb = root; else newRoot.swb = root;
-				} else {
-					if (expandWest) newRoot.neb = root; else newRoot.nwb = root;
-				}
-			} else {
-				if (expandNorth) {
-					if (expandWest) newRoot.sef = root; else newRoot.swf = root;
-				} else {
-					if (expandWest) newRoot.nef = root; else newRoot.nwf = root;
-				}
-			}
+	private void expandRootBounds(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ, final double w, final double h, final double d) {
+		final boolean expandWest = env.getMinX() < minX;
+		final boolean expandNorth = env.getMinY() < minY;
+		final boolean expandFront = env.getMinZ() < minZ;
 
-			root = newRoot;
+		final double newMinX = expandWest ? minX - w : minX;
+		final double newMaxX = expandWest ? maxX : maxX + w;
+		final double newMinY = expandNorth ? minY - h : minY;
+		final double newMaxY = expandNorth ? maxY : maxY + h;
+		final double newMinZ = expandFront ? minZ - d : minZ;
+		final double newMaxZ = expandFront ? maxZ : maxZ + d;
+
+		final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
+		final OctNode newRoot = new OctNode(newBounds);
+
+		createChildrenForNewRoot(newRoot, newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ);
+		assignOldRootToOctant(newRoot, expandFront, expandNorth, expandWest);
+
+		root = newRoot;
+	}
+
+	private void createChildrenForNewRoot(final OctNode newRoot, final double minX, final double maxX, final double minY, final double maxY, final double minZ, final double maxZ) {
+		final double hx = newRoot.halfx;
+		final double hy = newRoot.halfy;
+		final double hz = newRoot.halfz;
+
+		newRoot.nwf = new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, minZ, hz));
+		newRoot.nef = new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, minZ, hz));
+		newRoot.swf = new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, minZ, hz));
+		newRoot.sef = new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, minZ, hz));
+		newRoot.nwb = new OctNode(GamaEnvelopeFactory.of(minX, hx, minY, hy, hz, maxZ));
+		newRoot.neb = new OctNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy, hz, maxZ));
+		newRoot.swb = new OctNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY, hz, maxZ));
+		newRoot.seb = new OctNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY, hz, maxZ));
+	}
+
+	private void assignOldRootToOctant(final OctNode newRoot, final boolean expandFront, final boolean expandNorth, final boolean expandWest) {
+		final int oldOctant = (expandFront ? 4 : 0) | (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
+		switch (oldOctant) {
+			case 0 -> newRoot.nwf = root;
+			case 1 -> newRoot.nef = root;
+			case 2 -> newRoot.swf = root;
+			case 3 -> newRoot.sef = root;
+			case 4 -> newRoot.nwb = root;
+			case 5 -> newRoot.neb = root;
+			case 6 -> newRoot.swb = root;
+			case 7 -> newRoot.seb = root;
+			default -> {}
 		}
 	}
 

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -208,13 +208,66 @@ public class GamaQuadTree implements ISpatialIndex {
 		root.dispose();
 	}
 
+	private void ensureBoundsCover(final IEnvelope env) {
+		if (env == null || env.isNull() || root.bounds.covers(env)) return;
+		while (!root.bounds.covers(env)) {
+			final double minX = root.bounds.getMinX();
+			final double maxX = root.bounds.getMaxX();
+			final double minY = root.bounds.getMinY();
+			final double maxY = root.bounds.getMaxY();
+			double w = maxX - minX;
+			double h = maxY - minY;
+			if (w <= 0 || h <= 0) {
+				w = Math.max(1.0, env.getWidth());
+				h = Math.max(1.0, env.getHeight());
+				root = new QuadNode(GamaEnvelopeFactory.of(
+						Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
+						Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY())));
+				break;
+			}
+			final boolean expandWest = env.getMinX() < minX;
+			final boolean expandNorth = env.getMinY() < minY;
+			final double newMinX = expandWest ? minX - w : minX;
+			final double newMaxX = expandWest ? maxX : maxX + w;
+			final double newMinY = expandNorth ? minY - h : minY;
+			final double newMaxY = expandNorth ? maxY : maxY + h;
+
+			final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY);
+			final QuadNode newRoot = new QuadNode(newBounds);
+			final QuadNode[] ch = new QuadNode[4];
+
+			final int oldQuadrant = (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
+			ch[oldQuadrant] = root;
+
+			final double halfx = newRoot.halfx;
+			final double halfy = newRoot.halfy;
+
+			if (0 != oldQuadrant) {
+				ch[0] = new QuadNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy));
+			}
+			if (1 != oldQuadrant) {
+				ch[1] = new QuadNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy));
+			}
+			if (2 != oldQuadrant) {
+				ch[2] = new QuadNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY));
+			}
+			if (3 != oldQuadrant) {
+				ch[3] = new QuadNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY));
+			}
+			newRoot.children = ch;
+			root = newRoot;
+		}
+	}
+
 	@Override
 	public void insert(final IAgent agent) {
 		if (agent == null) return;
+		final IEnvelope env = agent.getEnvelope();
+		ensureBoundsCover(env);
 		if (agent.isPoint()) {
 			root.add(agent.getLocation(), agent);
 		} else {
-			root.add(agent.getEnvelope(), agent);
+			root.add(env, agent);
 		}
 	}
 

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -214,7 +214,7 @@ public class GamaQuadTree implements ISpatialIndex {
 		return root.bounds.covers(env);
 	}
 
-	private void ensureBoundsCover(final IEnvelope env) {
+	private synchronized void ensureBoundsCover(final IEnvelope env) {
 		if (isCovered(env)) return;
 		while (!root.bounds.covers(env)) {
 			if (!expandRootStep(env)) break;
@@ -247,17 +247,27 @@ public class GamaQuadTree implements ISpatialIndex {
 		final double maxY = Math.max(b.getMaxY(), env.getMaxY());
 		final QuadNode newRoot = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
 
-		oldRoot.objects.forEach((a, e) -> {
+		migrateSubtree(oldRoot, newRoot);
+		root = newRoot;
+	}
+
+	private void migrateSubtree(final QuadNode node, final QuadNode target) {
+		if (node == null) return;
+		node.objects.forEach((a, e) -> {
 			if (a != null && !a.dead() && e != null) {
 				if (e instanceof IPoint) {
-					newRoot.add((IPoint) e, a);
+					target.add((IPoint) e, a);
 				} else {
-					newRoot.add((IEnvelope) e, a);
+					target.add((IEnvelope) e, a);
 				}
 			}
 		});
-		oldRoot.objects.clear();
-		root = newRoot;
+		final QuadNode[] ch = node.children;
+		if (ch != null) {
+			for (final QuadNode child : ch) {
+				migrateSubtree(child, target);
+			}
+		}
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h) {

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -208,49 +208,51 @@ public class GamaQuadTree implements ISpatialIndex {
 		root.dispose();
 	}
 
+	private boolean isCovered(final IEnvelope env) {
+		if (env == null) return true;
+		if (env.isNull()) return true;
+		return root.bounds.covers(env);
+	}
+
 	private void ensureBoundsCover(final IEnvelope env) {
-		if (env == null || env.isNull() || root.bounds.covers(env)) return;
+		if (isCovered(env)) return;
 		while (!root.bounds.covers(env)) {
 			if (!expandRootStep(env)) break;
 		}
 	}
 
 	private boolean expandRootStep(final IEnvelope env) {
-		final double minX = root.bounds.getMinX();
-		final double maxX = root.bounds.getMaxX();
-		final double minY = root.bounds.getMinY();
-		final double maxY = root.bounds.getMaxY();
-		final double w = maxX - minX;
-		final double h = maxY - minY;
+		final IEnvelope b = root.bounds;
+		final double w = b.getWidth();
+		final double h = b.getHeight();
 
 		if (w <= 0 || h <= 0) {
-			recreateDegenerateRoot(env, minX, maxX, minY, maxY);
+			recreateDegenerateRoot(env, b);
 			return false;
 		}
 
-		expandRootBounds(env, minX, maxX, minY, maxY, w, h);
+		expandRootBounds(env, b, w, h);
 		return true;
 	}
 
-	private void recreateDegenerateRoot(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY) {
+	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
 		root = new QuadNode(GamaEnvelopeFactory.of(
-				Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
-				Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY())));
+				Math.min(b.getMinX(), env.getMinX()), Math.max(b.getMaxX(), env.getMaxX()),
+				Math.min(b.getMinY(), env.getMinY()), Math.max(b.getMaxY(), env.getMaxY())));
 	}
 
-	private void expandRootBounds(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double w, final double h) {
-		final boolean expandWest = env.getMinX() < minX;
-		final boolean expandNorth = env.getMinY() < minY;
-		final double newMinX = expandWest ? minX - w : minX;
-		final double newMaxX = expandWest ? maxX : maxX + w;
-		final double newMinY = expandNorth ? minY - h : minY;
-		final double newMaxY = expandNorth ? maxY : maxY + h;
+	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h) {
+		final boolean expandWest = env.getMinX() < b.getMinX();
+		final boolean expandNorth = env.getMinY() < b.getMinY();
+		final double minX = expandWest ? b.getMinX() - w : b.getMinX();
+		final double maxX = expandWest ? b.getMaxX() : b.getMaxX() + w;
+		final double minY = expandNorth ? b.getMinY() - h : b.getMinY();
+		final double maxY = expandNorth ? b.getMaxY() : b.getMaxY() + h;
 
-		final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY);
-		final QuadNode newRoot = new QuadNode(newBounds);
+		final QuadNode newRoot = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
 		final int oldQuadrant = (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
 
-		newRoot.children = createExpandedChildren(newRoot, oldQuadrant, newMinX, newMaxX, newMinY, newMaxY);
+		newRoot.children = createExpandedChildren(newRoot, oldQuadrant, minX, maxX, minY, maxY);
 		root = newRoot;
 	}
 

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -211,52 +211,60 @@ public class GamaQuadTree implements ISpatialIndex {
 	private void ensureBoundsCover(final IEnvelope env) {
 		if (env == null || env.isNull() || root.bounds.covers(env)) return;
 		while (!root.bounds.covers(env)) {
-			final double minX = root.bounds.getMinX();
-			final double maxX = root.bounds.getMaxX();
-			final double minY = root.bounds.getMinY();
-			final double maxY = root.bounds.getMaxY();
-			double w = maxX - minX;
-			double h = maxY - minY;
-			if (w <= 0 || h <= 0) {
-				w = Math.max(1.0, env.getWidth());
-				h = Math.max(1.0, env.getHeight());
-				root = new QuadNode(GamaEnvelopeFactory.of(
-						Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
-						Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY())));
-				break;
-			}
-			final boolean expandWest = env.getMinX() < minX;
-			final boolean expandNorth = env.getMinY() < minY;
-			final double newMinX = expandWest ? minX - w : minX;
-			final double newMaxX = expandWest ? maxX : maxX + w;
-			final double newMinY = expandNorth ? minY - h : minY;
-			final double newMaxY = expandNorth ? maxY : maxY + h;
-
-			final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY);
-			final QuadNode newRoot = new QuadNode(newBounds);
-			final QuadNode[] ch = new QuadNode[4];
-
-			final int oldQuadrant = (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
-			ch[oldQuadrant] = root;
-
-			final double halfx = newRoot.halfx;
-			final double halfy = newRoot.halfy;
-
-			if (0 != oldQuadrant) {
-				ch[0] = new QuadNode(GamaEnvelopeFactory.of(newMinX, halfx, newMinY, halfy));
-			}
-			if (1 != oldQuadrant) {
-				ch[1] = new QuadNode(GamaEnvelopeFactory.of(halfx, newMaxX, newMinY, halfy));
-			}
-			if (2 != oldQuadrant) {
-				ch[2] = new QuadNode(GamaEnvelopeFactory.of(newMinX, halfx, halfy, newMaxY));
-			}
-			if (3 != oldQuadrant) {
-				ch[3] = new QuadNode(GamaEnvelopeFactory.of(halfx, newMaxX, halfy, newMaxY));
-			}
-			newRoot.children = ch;
-			root = newRoot;
+			if (!expandRootStep(env)) break;
 		}
+	}
+
+	private boolean expandRootStep(final IEnvelope env) {
+		final double minX = root.bounds.getMinX();
+		final double maxX = root.bounds.getMaxX();
+		final double minY = root.bounds.getMinY();
+		final double maxY = root.bounds.getMaxY();
+		final double w = maxX - minX;
+		final double h = maxY - minY;
+
+		if (w <= 0 || h <= 0) {
+			recreateDegenerateRoot(env, minX, maxX, minY, maxY);
+			return false;
+		}
+
+		expandRootBounds(env, minX, maxX, minY, maxY, w, h);
+		return true;
+	}
+
+	private void recreateDegenerateRoot(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY) {
+		root = new QuadNode(GamaEnvelopeFactory.of(
+				Math.min(minX, env.getMinX()), Math.max(maxX, env.getMaxX()),
+				Math.min(minY, env.getMinY()), Math.max(maxY, env.getMaxY())));
+	}
+
+	private void expandRootBounds(final IEnvelope env, final double minX, final double maxX, final double minY, final double maxY, final double w, final double h) {
+		final boolean expandWest = env.getMinX() < minX;
+		final boolean expandNorth = env.getMinY() < minY;
+		final double newMinX = expandWest ? minX - w : minX;
+		final double newMaxX = expandWest ? maxX : maxX + w;
+		final double newMinY = expandNorth ? minY - h : minY;
+		final double newMaxY = expandNorth ? maxY : maxY + h;
+
+		final IEnvelope newBounds = GamaEnvelopeFactory.of(newMinX, newMaxX, newMinY, newMaxY);
+		final QuadNode newRoot = new QuadNode(newBounds);
+		final int oldQuadrant = (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
+
+		newRoot.children = createExpandedChildren(newRoot, oldQuadrant, newMinX, newMaxX, newMinY, newMaxY);
+		root = newRoot;
+	}
+
+	private QuadNode[] createExpandedChildren(final QuadNode newRoot, final int oldQuadrant, final double minX, final double maxX, final double minY, final double maxY) {
+		final QuadNode[] ch = new QuadNode[4];
+		ch[oldQuadrant] = root;
+		final double hx = newRoot.halfx;
+		final double hy = newRoot.halfy;
+
+		if (oldQuadrant != 0) ch[0] = new QuadNode(GamaEnvelopeFactory.of(minX, hx, minY, hy));
+		if (oldQuadrant != 1) ch[1] = new QuadNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy));
+		if (oldQuadrant != 2) ch[2] = new QuadNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY));
+		if (oldQuadrant != 3) ch[3] = new QuadNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY));
+		return ch;
 	}
 
 	@Override

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -226,7 +226,11 @@ public class GamaQuadTree implements ISpatialIndex {
 		final double w = b.getWidth();
 		final double h = b.getHeight();
 
-		if (w <= 0 || h <= 0) {
+		if (w <= 0) {
+			recreateDegenerateRoot(env, b);
+			return false;
+		}
+		if (h <= 0) {
 			recreateDegenerateRoot(env, b);
 			return false;
 		}
@@ -236,36 +240,58 @@ public class GamaQuadTree implements ISpatialIndex {
 	}
 
 	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
-		root = new QuadNode(GamaEnvelopeFactory.of(
-				Math.min(b.getMinX(), env.getMinX()), Math.max(b.getMaxX(), env.getMaxX()),
-				Math.min(b.getMinY(), env.getMinY()), Math.max(b.getMaxY(), env.getMaxY())));
+		final double minX = Math.min(b.getMinX(), env.getMinX());
+		final double maxX = Math.max(b.getMaxX(), env.getMaxX());
+		final double minY = Math.min(b.getMinY(), env.getMinY());
+		final double maxY = Math.max(b.getMaxY(), env.getMaxY());
+		root = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h) {
-		final boolean expandWest = env.getMinX() < b.getMinX();
-		final boolean expandNorth = env.getMinY() < b.getMinY();
-		final double minX = expandWest ? b.getMinX() - w : b.getMinX();
-		final double maxX = expandWest ? b.getMaxX() : b.getMaxX() + w;
-		final double minY = expandNorth ? b.getMinY() - h : b.getMinY();
-		final double maxY = expandNorth ? b.getMaxY() : b.getMaxY() + h;
+		final IEnvelope newEnv = computeExpandedEnvelope2D(env, b, w, h);
+		final int oldQuadrant = computeOldQuadrant(env, b);
+		final QuadNode newRoot = new QuadNode(newEnv);
 
-		final QuadNode newRoot = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
-		final int oldQuadrant = (expandNorth ? 2 : 0) | (expandWest ? 1 : 0);
-
-		newRoot.children = createExpandedChildren(newRoot, oldQuadrant, minX, maxX, minY, maxY);
+		newRoot.children = createExpandedChildren(newRoot, oldQuadrant);
 		root = newRoot;
 	}
 
-	private QuadNode[] createExpandedChildren(final QuadNode newRoot, final int oldQuadrant, final double minX, final double maxX, final double minY, final double maxY) {
-		final QuadNode[] ch = new QuadNode[4];
-		ch[oldQuadrant] = root;
+	private IEnvelope computeExpandedEnvelope2D(final IEnvelope env, final IEnvelope b, final double w, final double h) {
+		double minX = b.getMinX();
+		double maxX = b.getMaxX();
+		double minY = b.getMinY();
+		double maxY = b.getMaxY();
+
+		if (env.getMinX() < b.getMinX()) minX -= w; else maxX += w;
+		if (env.getMinY() < b.getMinY()) minY -= h; else maxY += h;
+
+		return GamaEnvelopeFactory.of(minX, maxX, minY, maxY);
+	}
+
+	private int computeOldQuadrant(final IEnvelope env, final IEnvelope b) {
+		int quad = 0;
+		if (env.getMinY() < b.getMinY()) quad |= 2;
+		if (env.getMinX() < b.getMinX()) quad |= 1;
+		return quad;
+	}
+
+	private QuadNode[] createExpandedChildren(final QuadNode newRoot, final int oldQuadrant) {
+		final IEnvelope env = newRoot.bounds;
+		final double minX = env.getMinX();
+		final double maxX = env.getMaxX();
+		final double minY = env.getMinY();
+		final double maxY = env.getMaxY();
 		final double hx = newRoot.halfx;
 		final double hy = newRoot.halfy;
+
+		final QuadNode[] ch = new QuadNode[4];
+		ch[oldQuadrant] = root;
 
 		if (oldQuadrant != 0) ch[0] = new QuadNode(GamaEnvelopeFactory.of(minX, hx, minY, hy));
 		if (oldQuadrant != 1) ch[1] = new QuadNode(GamaEnvelopeFactory.of(hx, maxX, minY, hy));
 		if (oldQuadrant != 2) ch[2] = new QuadNode(GamaEnvelopeFactory.of(minX, hx, hy, maxY));
 		if (oldQuadrant != 3) ch[3] = new QuadNode(GamaEnvelopeFactory.of(hx, maxX, hy, maxY));
+
 		return ch;
 	}
 

--- a/gama.core/src/gama/core/topology/GamaQuadTree.java
+++ b/gama.core/src/gama/core/topology/GamaQuadTree.java
@@ -73,7 +73,7 @@ public class GamaQuadTree implements ISpatialIndex {
 	private static final int NW = 0, NE = 1, SW = 2, SE = 3;
 
 	/** The root. */
-	final QuadNode root;
+	volatile QuadNode root;
 
 	/** The Constant maxCapacity. */
 	final static int maxCapacity = 100;
@@ -240,11 +240,24 @@ public class GamaQuadTree implements ISpatialIndex {
 	}
 
 	private void recreateDegenerateRoot(final IEnvelope env, final IEnvelope b) {
+		final QuadNode oldRoot = root;
 		final double minX = Math.min(b.getMinX(), env.getMinX());
 		final double maxX = Math.max(b.getMaxX(), env.getMaxX());
 		final double minY = Math.min(b.getMinY(), env.getMinY());
 		final double maxY = Math.max(b.getMaxY(), env.getMaxY());
-		root = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
+		final QuadNode newRoot = new QuadNode(GamaEnvelopeFactory.of(minX, maxX, minY, maxY));
+
+		oldRoot.objects.forEach((a, e) -> {
+			if (a != null && !a.dead() && e != null) {
+				if (e instanceof IPoint) {
+					newRoot.add((IPoint) e, a);
+				} else {
+					newRoot.add((IEnvelope) e, a);
+				}
+			}
+		});
+		oldRoot.objects.clear();
+		root = newRoot;
 	}
 
 	private void expandRootBounds(final IEnvelope env, final IEnvelope b, final double w, final double h) {

--- a/gama.core/tests/Spatial Tests/models/Query.experiment
+++ b/gama.core/tests/Spatial Tests/models/Query.experiment
@@ -170,6 +170,20 @@ experiment QueryTests type: test {
 		}
 		assert agents_overlapping = [dummy(8)];
 	}
+
+	test "overlapping_outside_world" {
+		dummy out_dummy;
+		create dummy returns: created_ag {
+			location <- {-20, -20};
+		}
+		out_dummy <- created_ag[0];
+
+		list<dummy> agents_overlapping;
+		using topology(world) {
+			agents_overlapping <- dummy overlapping (circle(5) at_location {-20, -20});
+		}
+		assert agents_overlapping contains out_dummy;
+	}
 	
 } 
 


### PR DESCRIPTION
Fixes GAMA issue #1174 where the overlapping operator and other spatial queries failed when checking collisions outside of the world shape.

Key changes:
1. In `AbstractTopology.java`, replaced envelope intersection clipping against `environment.getEnvelope()` with `GamaEnvelopeFactory.of(source.getEnvelope())`, allowing search queries to evaluate geometries outside the world.
2. In `GamaQuadTree.java` and `GamaOctTree.java`, added `ensureBoundsCover(IEnvelope env)` to dynamically expand root bounds when inserting agents located outside the initial world envelope.
3. Added a test case `overlapping_outside_world` to `Query.experiment`.

This "obvious" solution to the problem exposed in the issue needs however to be carefully tested because I'm a bit uncomfortable with the idea of returning agents "outside the world boundaries" with a topological request. 