### PR TITLE
Add CHART_PERSPECTIVE preference to refresh charts when not visible (#511)

### DIFF
--- a/gama.api/src/gama/api/ui/IOutput.java
+++ b/gama.api/src/gama/api/ui/IOutput.java
@@ -90,6 +90,13 @@ import gama.api.ui.layers.ILayerStatement;
 public interface IOutput extends ISymbol, IStepable, IScoped {
 
 	/**
+	 * Checks if this output contains any chart layers.
+	 *
+	 * @return true if at least one layer is a chart layer
+	 */
+	default boolean containsChart() { return false; }
+
+	/**
 	 * The Interface Display.
 	 */
 	interface Display extends IOutput {

--- a/gama.api/src/gama/api/utils/prefs/GamaPreferences.java
+++ b/gama.api/src/gama/api/utils/prefs/GamaPreferences.java
@@ -813,6 +813,14 @@ public class GamaPreferences {
 						IType.BOOL, true).in(NAME, PRESENTATION);
 
 		/**
+		 * Whether chart displays should continue to refresh even while the Modeling perspective is active (i.e., not
+		 * the simulation perspective).
+		 */
+		public static final Pref<Boolean> CHART_PERSPECTIVE =
+				create("pref_chart_continue_drawing", "Continue to draw charts when in Modeling perspective", true,
+						IType.BOOL, true).in(NAME, PRESENTATION);
+
+		/**
 		 * Whether to use a faster but potentially incomplete snapshot mechanism. Fast snapshots may be incorrect if the
 		 * display is obscured by other windows.
 		 */

--- a/gama.core/src/gama/core/outputs/LayeredDisplayOutput.java
+++ b/gama.core/src/gama/core/outputs/LayeredDisplayOutput.java
@@ -57,6 +57,7 @@ import gama.api.utils.prefs.GamaPreferences;
 import gama.core.outputs.LayeredDisplayOutput.DisplaySerializer;
 import gama.core.outputs.LayeredDisplayOutput.DisplayValidator;
 import gama.core.outputs.layers.AbstractLayerStatement;
+import gama.core.outputs.layers.charts.ChartLayerStatement;
 import gama.core.outputs.layers.properties.CameraStatement;
 import gama.core.outputs.layers.properties.LightStatement;
 import gama.core.outputs.layers.properties.RotationStatement;
@@ -664,6 +665,14 @@ public class LayeredDisplayOutput extends AbstractOutput implements IOutput.Disp
 
 	@Override
 	public IGamaView.Display getView() { return (IGamaView.Display) super.getView(); }
+
+	@Override
+	public boolean containsChart() {
+		for (final ILayerStatement layer : getLayers()) {
+			if (layer instanceof ChartLayerStatement) return true;
+		}
+		return false;
+	}
 
 	/**
 	 * Release view.

--- a/gama.ui.experiment/src/gama/ui/experiment/views/displays/LayeredDisplayPerspectiveListener.java
+++ b/gama.ui.experiment/src/gama/ui/experiment/views/displays/LayeredDisplayPerspectiveListener.java
@@ -9,6 +9,7 @@ import org.eclipse.ui.IWorkbenchPage;
 
 import gama.api.runtime.SystemInfo;
 import gama.api.ui.displays.IDisplaySurface;
+import gama.api.ui.IOutput;
 import gama.api.utils.prefs.GamaPreferences;
 import gama.ui.application.workbench.PerspectiveHelper;
 import gama.ui.shared.utils.WorkbenchHelper;
@@ -39,12 +40,15 @@ final class LayeredDisplayPerspectiveListener implements IPerspectiveListener {
 
 	@Override
 	public void perspectiveActivated(final IWorkbenchPage page, final IPerspectiveDescriptor perspective) {
+		final IOutput output = decorator.view.getOutput();
+		final boolean continueDrawing = output != null && (output.containsChart()
+				? GamaPreferences.Displays.CHART_PERSPECTIVE.getValue()
+				: GamaPreferences.Displays.CORE_DISPLAY_PERSPECTIVE.getValue());
 
 		if (PerspectiveHelper.PERSPECTIVE_MODELING_ID.equals(perspective.getId())) {
-			if (decorator.view.getOutput() != null && decorator.view.getDisplaySurface() != null
-					&& !GamaPreferences.Displays.CORE_DISPLAY_PERSPECTIVE.getValue()) {
-				previousState = decorator.view.getOutput().isPaused();
-				decorator.view.getOutput().setPaused(true);
+			if (output != null && decorator.view.getDisplaySurface() != null && !continueDrawing) {
+				previousState = output.isPaused();
+				output.setPaused(true);
 			}
 			// Seems necessary in addition to the IPartListener
 			WorkbenchHelper.asyncRun(() -> {
@@ -57,9 +61,8 @@ final class LayeredDisplayPerspectiveListener implements IPerspectiveListener {
 				final IDisplaySurface ds = decorator.view.getDisplaySurface();
 				if (ds != null) { ds.updateDisplay(true); }
 			}
-			if (!GamaPreferences.Displays.CORE_DISPLAY_PERSPECTIVE.getValue() && decorator.view.getOutput() != null
-					&& decorator.view.getDisplaySurface() != null) {
-				decorator.view.getOutput().setPaused(previousState);
+			if (!continueDrawing && output != null && decorator.view.getDisplaySurface() != null) {
+				output.setPaused(previousState);
 			}
 			// Necessary in addition to the IPartListener as there is no way to distinguish between the wrong
 			// "hidden" event and the good one when there are no tabs.


### PR DESCRIPTION
Add specific preference CHART_PERSPECTIVE (pref_chart_continue_drawing) set to true by default to allow charts to continue refreshing when not visible or when in Modeling perspective.

Fixes #511 