### PR TITLE
Document that agents cannot be copied with copy operator

### DIFF
--- a/gama.core/src/gama/core/agent/MinimalAgent.java
+++ b/gama.core/src/gama/core/agent/MinimalAgent.java
@@ -764,7 +764,8 @@ public class MinimalAgent implements IAgent, Comparable<IAgent> {
 	}
 
 	/**
-	 * Copy.
+	 * Copy. Agents cannot be copied; calling copy on an agent returns the agent itself. To duplicate an agent, use the
+	 * {@code create} statement instead (e.g. {@code create species_of(agent) from: agent;}).
 	 *
 	 * @author Alexis Drogoul (alexis.drogoul@ird.fr)
 	 * @param scope

--- a/gama.core/src/gama/gaml/operators/System.java
+++ b/gama.core/src/gama/gaml/operators/System.java
@@ -580,7 +580,7 @@ public class System {
 			value = "returns a copy of the operand.",
 			returns = "a deep copy of the operand.",
 			special_cases = { "copy(nil) returns nil.",
-					"The copy is independent of the original; modifying one does not affect the other.",
+					"The copy is independent of the original for all operand types except agents; modifying one does not affect the other.",
 					"Agents cannot be copied: copy(agent) returns the agent itself. To duplicate an agent, use the create statement instead (e.g. create species_of(agent) from: agent;)." })
 	@no_test
 	public static Object opCopy(final IScope scope, final Object o) throws GamaRuntimeException {

--- a/gama.core/src/gama/gaml/operators/System.java
+++ b/gama.core/src/gama/gaml/operators/System.java
@@ -580,7 +580,8 @@ public class System {
 			value = "returns a copy of the operand.",
 			returns = "a deep copy of the operand.",
 			special_cases = { "copy(nil) returns nil.",
-					"The copy is independent of the original; modifying one does not affect the other." })
+					"The copy is independent of the original; modifying one does not affect the other.",
+					"Agents cannot be copied: copy(agent) returns the agent itself. To duplicate an agent, use the create statement instead (e.g. create species_of(agent) from: agent;)." })
 	@no_test
 	public static Object opCopy(final IScope scope, final Object o) throws GamaRuntimeException {
 		if (o instanceof IValue) return ((IValue) o).copy(scope);


### PR DESCRIPTION
Documented that agents cannot be copied with the GAML `copy` operator in `System.java` and `MinimalAgent.java`, explaining that `copy(agent)` returns the agent itself and referencing the `create` statement as the way to duplicate an agent.

Fixes #1151 