### PR TITLE
Fix Synchronize button state on experiment reload (#506)

### DIFF
--- a/gama.api/src/gama/api/GAMA.java
+++ b/gama.api/src/gama/api/GAMA.java
@@ -1071,6 +1071,7 @@ public class GAMA {
 	 */
 	public static void desynchronizeFrontmostExperiment() {
 		isSynchronized = false;
+		getGui().updateSynchronizedState();
 	}
 
 	/**
@@ -1085,6 +1086,7 @@ public class GAMA {
 	 */
 	public static void synchronizeFrontmostExperiment() {
 		isSynchronized = true;
+		getGui().updateSynchronizedState();
 	}
 
 	// ==================================================================================

--- a/gama.api/src/gama/api/ui/IGui.java
+++ b/gama.api/src/gama/api/ui/IGui.java
@@ -696,6 +696,11 @@ public interface IGui {
 	default void updateParameters(final boolean refreshValues) {}
 
 	/**
+	 * Updates the synchronized experiment state in UI.
+	 */
+	default void updateSynchronizedState() {}
+
+	/**
 	 * Gets the server commands.
 	 *
 	 * @author Alexis Drogoul (alexis.drogoul@ird.fr)

--- a/gama.ui.shared/src/gama/ui/shared/utils/SwtGui.java
+++ b/gama.ui.shared/src/gama/ui/shared/utils/SwtGui.java
@@ -508,10 +508,7 @@ public class SwtGui implements IGui {
 		pendingArrange = () -> {
 			WorkbenchHelper.getWindow().updateActionBars();
 			// To solve issue #3697
-			ICommandService hs = WorkbenchHelper.getService(ICommandService.class);
-			if (hs != null) {
-				hs.refreshElements("gama.application.commands.SynchronizeExperiment", null);
-			}
+			updateSynchronizedState();
 			WorkbenchHelper.getPage().setEditorAreaVisible(showEditors);
 			getConsole().toggleConsoleViews(exp.getAgent(), showConsoles == null || showConsoles);
 			if (showNavigator != null && !showNavigator) { hideView(IGui.NAVIGATOR_VIEW_ID); }

--- a/gama.ui.shared/src/gama/ui/shared/utils/SwtGui.java
+++ b/gama.ui.shared/src/gama/ui/shared/utils/SwtGui.java
@@ -399,6 +399,16 @@ public class SwtGui implements IGui {
 	@Override
 	public IModelsManager getModelsManager() { return WorkbenchHelper.getService(IModelsManager.class); }
 
+	@Override
+	public void updateSynchronizedState() {
+		WorkbenchHelper.asyncRun(() -> {
+			ICommandService hs = WorkbenchHelper.getService(ICommandService.class);
+			if (hs != null) {
+				hs.refreshElements("gama.application.commands.SynchronizeExperiment", null);
+			}
+		});
+	}
+
 	/**
 	 * Update parameters.
 	 *
@@ -499,7 +509,9 @@ public class SwtGui implements IGui {
 			WorkbenchHelper.getWindow().updateActionBars();
 			// To solve issue #3697
 			ICommandService hs = WorkbenchHelper.getService(ICommandService.class);
-			hs.refreshElements("gama.ui.application.commands.SynchronizeExperiment", null);
+			if (hs != null) {
+				hs.refreshElements("gama.application.commands.SynchronizeExperiment", null);
+			}
 			WorkbenchHelper.getPage().setEditorAreaVisible(showEditors);
 			getConsole().toggleConsoleViews(exp.getAgent(), showConsoles == null || showConsoles);
 			if (showNavigator != null && !showNavigator) { hideView(IGui.NAVIGATOR_VIEW_ID); }


### PR DESCRIPTION
Fixes issue #506 where the Synchronize button in the control bar displayed an incorrect state after reloading an experiment. This was caused by a typo in the command ID string ('gama.ui.application.commands.SynchronizeExperiment' instead of 'gama.application.commands.SynchronizeExperiment') and a lack of UI updates when synchronization state is changed programmatically via GAMA.synchronizeFrontmostExperiment() or GAMA.desynchronizeFrontmostExperiment().

